### PR TITLE
core: fix grammar and spelling in API comments

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -1059,7 +1059,7 @@ LogCollectorSpec
 </td>
 <td>
 <em>(Optional)</em>
-<p>Logging represents loggings settings</p>
+<p>Logging represents logging settings</p>
 </td>
 </tr>
 <tr>
@@ -2686,7 +2686,7 @@ RBDMirrorStatus
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.TopicEndpointSpec">TopicEndpointSpec</a>)
 </p>
 <div>
-<p>AMQPEndpointSpec represent the spec of an AMQP endpoint of a Bucket Topic</p>
+<p>AMQPEndpointSpec represents the spec of an AMQP endpoint of a Bucket Topic</p>
 </div>
 <table>
 <thead>
@@ -2941,7 +2941,7 @@ KeystoneSpec
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.BucketNotificationSpec">BucketNotificationSpec</a>)
 </p>
 <div>
-<p>BucketNotificationEvent represent the event type of the bucket notification
+<p>BucketNotificationEvent represents the event type of the bucket notification
 See: <a href="https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types">https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types</a></p>
 </div>
 <h3 id="ceph.rook.io/v1.BucketNotificationSpec">BucketNotificationSpec
@@ -2950,7 +2950,7 @@ See: <a href="https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibil
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephBucketNotification">CephBucketNotification</a>)
 </p>
 <div>
-<p>BucketNotificationSpec represent the spec of a Bucket Notification</p>
+<p>BucketNotificationSpec represents the spec of a Bucket Notification</p>
 </div>
 <table>
 <thead>
@@ -3007,7 +3007,7 @@ NotificationFilterSpec
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephBucketTopic">CephBucketTopic</a>)
 </p>
 <div>
-<p>BucketTopicSpec represent the spec of a Bucket Topic</p>
+<p>BucketTopicSpec represents the spec of a Bucket Topic</p>
 </div>
 <table>
 <thead>
@@ -3898,7 +3898,7 @@ CephxStatus
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.ClusterSpec">ClusterSpec</a>)
 </p>
 <div>
-<p>CephClusterHealthCheckSpec represent the healthcheck for Ceph daemons</p>
+<p>CephClusterHealthCheckSpec represents the healthcheck for Ceph daemons</p>
 </div>
 <table>
 <thead>
@@ -3972,7 +3972,7 @@ map[string]github.com/rook/rook/pkg/apis/ceph.rook.io/v1.MuteHealthWarningSpec
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephStatus">CephStatus</a>)
 </p>
 <div>
-<p>CephDaemonsVersions show the current ceph version for different ceph daemons</p>
+<p>CephDaemonsVersions shows the current ceph version for different ceph daemons</p>
 </div>
 <table>
 <thead>
@@ -6046,7 +6046,7 @@ LogCollectorSpec
 </td>
 <td>
 <em>(Optional)</em>
-<p>Logging represents loggings settings</p>
+<p>Logging represents logging settings</p>
 </td>
 </tr>
 <tr>
@@ -6481,7 +6481,7 @@ deletion.</p>
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephBlockPoolRadosNamespaceStatus">CephBlockPoolRadosNamespaceStatus</a>, <a href="#ceph.rook.io/v1.CephBlockPoolStatus">CephBlockPoolStatus</a>, <a href="#ceph.rook.io/v1.CephClientStatus">CephClientStatus</a>, <a href="#ceph.rook.io/v1.CephFilesystemStatus">CephFilesystemStatus</a>, <a href="#ceph.rook.io/v1.CephFilesystemSubVolumeGroupStatus">CephFilesystemSubVolumeGroupStatus</a>, <a href="#ceph.rook.io/v1.ClusterStatus">ClusterStatus</a>, <a href="#ceph.rook.io/v1.Condition">Condition</a>, <a href="#ceph.rook.io/v1.ObjectStoreStatus">ObjectStoreStatus</a>)
 </p>
 <div>
-<p>ConditionType represent a resource&rsquo;s status</p>
+<p>ConditionType represents a resource&rsquo;s status</p>
 </div>
 <table>
 <thead>
@@ -7389,7 +7389,7 @@ PeerRemoteSpec
 </td>
 <td>
 <em>(Optional)</em>
-<p>Remote are the remote cluster information</p>
+<p>Remote is the remote cluster information</p>
 </td>
 </tr>
 <tr>
@@ -7403,7 +7403,7 @@ PeerStatSpec
 </td>
 <td>
 <em>(Optional)</em>
-<p>Stats are the stat a peer mirror</p>
+<p>Stats are the stat of a peer mirror</p>
 </td>
 </tr>
 </tbody>
@@ -8253,7 +8253,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>LogLevel set logging level</p>
+<p>LogLevel sets logging level</p>
 </td>
 </tr>
 <tr>
@@ -8632,7 +8632,7 @@ Note: Only supported from Ceph Tentacle (v20)</p>
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.TopicEndpointSpec">TopicEndpointSpec</a>)
 </p>
 <div>
-<p>HTTPEndpointSpec represent the spec of an HTTP endpoint of a Bucket Topic</p>
+<p>HTTPEndpointSpec represents the spec of an HTTP endpoint of a Bucket Topic</p>
 </div>
 <table>
 <thead>
@@ -8828,7 +8828,7 @@ string
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.TopicEndpointSpec">TopicEndpointSpec</a>)
 </p>
 <div>
-<p>KafkaEndpointSpec represent the spec of a Kafka endpoint of a Bucket Topic</p>
+<p>KafkaEndpointSpec represents the spec of a Kafka endpoint of a Bucket Topic</p>
 </div>
 <table>
 <thead>
@@ -9092,7 +9092,7 @@ securely add the file via annotations on the CephNFS spec (passed to the NFS ser
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.ClusterSecuritySpec">ClusterSecuritySpec</a>, <a href="#ceph.rook.io/v1.ObjectStoreSecuritySpec">ObjectStoreSecuritySpec</a>, <a href="#ceph.rook.io/v1.SecuritySpec">SecuritySpec</a>)
 </p>
 <div>
-<p>KeyManagementServiceSpec represent various details of the KMS server</p>
+<p>KeyManagementServiceSpec represents various details of the KMS server</p>
 </div>
 <table>
 <thead>
@@ -11413,7 +11413,7 @@ Selection
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.NotificationFilterSpec">NotificationFilterSpec</a>)
 </p>
 <div>
-<p>NotificationFilterRule represent a single rule in the Notification Filter spec</p>
+<p>NotificationFilterRule represents a single rule in the Notification Filter spec</p>
 </div>
 <table>
 <thead>
@@ -11453,7 +11453,7 @@ string
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.BucketNotificationSpec">BucketNotificationSpec</a>)
 </p>
 <div>
-<p>NotificationFilterSpec represent the spec of a Bucket Notification filter</p>
+<p>NotificationFilterSpec represents the spec of a Bucket Notification filter</p>
 </div>
 <table>
 <thead>
@@ -11513,7 +11513,7 @@ string
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.NotificationFilterSpec">NotificationFilterSpec</a>)
 </p>
 <div>
-<p>NotificationKeyFilterRule represent a single key rule in the Notification Filter spec</p>
+<p>NotificationKeyFilterRule represents a single key rule in the Notification Filter spec</p>
 </div>
 <table>
 <thead>
@@ -11774,7 +11774,7 @@ ProbeSpec
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephObjectRealm">CephObjectRealm</a>)
 </p>
 <div>
-<p>ObjectRealmSpec represent the spec of an ObjectRealm</p>
+<p>ObjectRealmSpec represents the spec of an ObjectRealm</p>
 </div>
 <table>
 <thead>
@@ -11899,7 +11899,7 @@ If spec.sharedPools are also empty, then RGW pools (spec.dataPool and spec.metad
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephObjectStoreAccount">CephObjectStoreAccount</a>)
 </p>
 <div>
-<p>ObjectStoreAccountSpec represent the spec of a RGW Account</p>
+<p>ObjectStoreAccountSpec represents the spec of an RGW Account</p>
 </div>
 <table>
 <thead>
@@ -12193,7 +12193,7 @@ See <a href="https://docs.openssl.org/master/man3/SSL_CTX_set1_curves/#descripti
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephObjectStore">CephObjectStore</a>)
 </p>
 <div>
-<p>ObjectStoreSpec represent the spec of a pool</p>
+<p>ObjectStoreSpec represents the spec of a pool</p>
 </div>
 <table>
 <thead>
@@ -12550,7 +12550,7 @@ string
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephObjectStoreUser">CephObjectStoreUser</a>)
 </p>
 <div>
-<p>ObjectStoreUserSpec represent the spec of an Objectstoreuser</p>
+<p>ObjectStoreUserSpec represents the spec of an Objectstoreuser</p>
 </div>
 <table>
 <thead>
@@ -12993,7 +12993,7 @@ Kubernetes core/v1.SecretKeySelector
 <h3 id="ceph.rook.io/v1.ObjectUserOpMask">ObjectUserOpMask
 (<code>string</code> alias)</h3>
 <div>
-<p>Internally, RGW labels &ldquo;operations&rdquo; on persistent state as <code>RGW_OP_TYPE_READ</code> (<code>read</code>), <code>RGW_OP_TYPE_WRITE</code> (<code>write</code>), or <code>RGW_OP_TYPE_DELETE</code> (<code>delete</code>). All RGW users have an &ldquo;operation mask&rdquo;, which does not function as mask or filter as is typically implied by the word &ldquo;mask&rdquo;, but as a set of allowed or permissible &ldquo;operation&rdquo; types the user is able to perform. The &ldquo;operation mask&rdquo; is applied regardless of the bucket or IAM policy. For example, in order for an RGW user to be able to read an object from a bucket, that user must have <strong>both</strong> the <code>read</code> &ldquo;op mask&rdquo; bit and an IAM/bucket policy that allows <code>s3:GetObject</code>. The default operations allowed are <code>read</code>, <code>write</code>, and <code>delete</code>. Setting the value to <code>[]</code> (an empty YAML sequence) causes all &ldquo;operations&rdquo; in the mask to be removed, meaning that the user will not be able to perform any operations. These operation masks are supported: <code>read</code>, <code>write</code>, <code>delete</code></p>
+<p>Internally, RGW labels &ldquo;operations&rdquo; on persistent state as <code>RGW_OP_TYPE_READ</code> (<code>read</code>), <code>RGW_OP_TYPE_WRITE</code> (<code>write</code>), or <code>RGW_OP_TYPE_DELETE</code> (<code>delete</code>). All RGW users have an &ldquo;operation mask&rdquo;, which does not function as a mask or filter as is typically implied by the word &ldquo;mask&rdquo;, but as a set of allowed or permissible &ldquo;operation&rdquo; types the user is able to perform. The &ldquo;operation mask&rdquo; is applied regardless of the bucket or IAM policy. For example, in order for an RGW user to be able to read an object from a bucket, that user must have <strong>both</strong> the <code>read</code> &ldquo;op mask&rdquo; bit and an IAM/bucket policy that allows <code>s3:GetObject</code>. The default operations allowed are <code>read</code>, <code>write</code>, and <code>delete</code>. Setting the value to <code>[]</code> (an empty YAML sequence) causes all &ldquo;operations&rdquo; in the mask to be removed, meaning that the user will not be able to perform any operations. These operation masks are supported: <code>read</code>, <code>write</code>, <code>delete</code></p>
 </div>
 <h3 id="ceph.rook.io/v1.ObjectUserQuotaSpec">ObjectUserQuotaSpec
 </h3>
@@ -13056,7 +13056,7 @@ int64
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephObjectZoneGroup">CephObjectZoneGroup</a>)
 </p>
 <div>
-<p>ObjectZoneGroupSpec represent the spec of an ObjectZoneGroup</p>
+<p>ObjectZoneGroupSpec represents the spec of an ObjectZoneGroup</p>
 </div>
 <table>
 <thead>
@@ -13085,7 +13085,7 @@ string
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephObjectZone">CephObjectZone</a>)
 </p>
 <div>
-<p>ObjectZoneSpec represent the spec of an ObjectZone</p>
+<p>ObjectZoneSpec represents the spec of an ObjectZone</p>
 </div>
 <table>
 <thead>
@@ -13273,7 +13273,7 @@ string
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.FilesystemMirrorInfoPeerSpec">FilesystemMirrorInfoPeerSpec</a>)
 </p>
 <div>
-<p>PeerStatSpec are the mirror stat with a given peer</p>
+<p>PeerStatSpec is the mirror stat with a given peer</p>
 </div>
 <table>
 <thead>
@@ -14198,7 +14198,7 @@ string
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.GatewaySpec">GatewaySpec</a>)
 </p>
 <div>
-<p>RGWServiceSpec represent the spec for RGW service</p>
+<p>RGWServiceSpec represents the spec for RGW service</p>
 </div>
 <table>
 <thead>
@@ -15098,7 +15098,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Interval represent the periodicity of the snapshot.</p>
+<p>Interval represents the periodicity of the snapshot.</p>
 </td>
 </tr>
 <tr>
@@ -15372,7 +15372,7 @@ bool
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.MirroringStatusSummarySpec">MirroringStatusSummarySpec</a>)
 </p>
 <div>
-<p>StatesSpec are rbd images mirroring state</p>
+<p>StatesSpec is rbd images mirroring state</p>
 </div>
 <table>
 <thead>

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -1059,7 +1059,7 @@ LogCollectorSpec
 </td>
 <td>
 <em>(Optional)</em>
-<p>Logging represents loggings settings</p>
+<p>LogCollector represents logging settings</p>
 </td>
 </tr>
 <tr>
@@ -2686,7 +2686,7 @@ RBDMirrorStatus
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.TopicEndpointSpec">TopicEndpointSpec</a>)
 </p>
 <div>
-<p>AMQPEndpointSpec represent the spec of an AMQP endpoint of a Bucket Topic</p>
+<p>AMQPEndpointSpec represents the spec of an AMQP endpoint of a Bucket Topic</p>
 </div>
 <table>
 <thead>
@@ -2943,7 +2943,7 @@ KeystoneSpec
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.BucketNotificationSpec">BucketNotificationSpec</a>)
 </p>
 <div>
-<p>BucketNotificationEvent represent the event type of the bucket notification
+<p>BucketNotificationEvent represents the event type of the bucket notification
 See: <a href="https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types">https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types</a></p>
 </div>
 <h3 id="ceph.rook.io/v1.BucketNotificationSpec">BucketNotificationSpec
@@ -2952,7 +2952,7 @@ See: <a href="https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibil
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephBucketNotification">CephBucketNotification</a>)
 </p>
 <div>
-<p>BucketNotificationSpec represent the spec of a Bucket Notification</p>
+<p>BucketNotificationSpec represents the spec of a Bucket Notification</p>
 </div>
 <table>
 <thead>
@@ -3009,7 +3009,7 @@ NotificationFilterSpec
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephBucketTopic">CephBucketTopic</a>)
 </p>
 <div>
-<p>BucketTopicSpec represent the spec of a Bucket Topic</p>
+<p>BucketTopicSpec represents the spec of a Bucket Topic</p>
 </div>
 <table>
 <thead>
@@ -3900,7 +3900,7 @@ CephxStatus
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.ClusterSpec">ClusterSpec</a>)
 </p>
 <div>
-<p>CephClusterHealthCheckSpec represent the healthcheck for Ceph daemons</p>
+<p>CephClusterHealthCheckSpec represents the healthcheck for Ceph daemons</p>
 </div>
 <table>
 <thead>
@@ -3974,7 +3974,7 @@ map[string]github.com/rook/rook/pkg/apis/ceph.rook.io/v1.MuteHealthWarningSpec
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephStatus">CephStatus</a>)
 </p>
 <div>
-<p>CephDaemonsVersions show the current ceph version for different ceph daemons</p>
+<p>CephDaemonsVersions shows the current ceph version for different ceph daemons</p>
 </div>
 <table>
 <thead>
@@ -4757,7 +4757,7 @@ Allow any string so that over-specified legacy clusters do not break on CRD upda
 <h3 id="ceph.rook.io/v1.CephObjectStoreAccount">CephObjectStoreAccount
 </h3>
 <div>
-<p>CephObjectStoreAccount represent the RGW user account</p>
+<p>CephObjectStoreAccount represents the RGW user account</p>
 </div>
 <table>
 <thead>
@@ -6117,7 +6117,7 @@ LogCollectorSpec
 </td>
 <td>
 <em>(Optional)</em>
-<p>Logging represents loggings settings</p>
+<p>LogCollector represents logging settings</p>
 </td>
 </tr>
 <tr>
@@ -6552,7 +6552,7 @@ deletion.</p>
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephBlockPoolRadosNamespaceStatus">CephBlockPoolRadosNamespaceStatus</a>, <a href="#ceph.rook.io/v1.CephBlockPoolStatus">CephBlockPoolStatus</a>, <a href="#ceph.rook.io/v1.CephClientStatus">CephClientStatus</a>, <a href="#ceph.rook.io/v1.CephFilesystemStatus">CephFilesystemStatus</a>, <a href="#ceph.rook.io/v1.CephFilesystemSubVolumeGroupStatus">CephFilesystemSubVolumeGroupStatus</a>, <a href="#ceph.rook.io/v1.ClusterStatus">ClusterStatus</a>, <a href="#ceph.rook.io/v1.Condition">Condition</a>, <a href="#ceph.rook.io/v1.ObjectStoreStatus">ObjectStoreStatus</a>)
 </p>
 <div>
-<p>ConditionType represent a resource&rsquo;s status</p>
+<p>ConditionType represents a resource&rsquo;s status</p>
 </div>
 <table>
 <thead>
@@ -7488,7 +7488,7 @@ PeerRemoteSpec
 </td>
 <td>
 <em>(Optional)</em>
-<p>Remote are the remote cluster information</p>
+<p>Remote is the remote cluster information</p>
 </td>
 </tr>
 <tr>
@@ -7502,7 +7502,7 @@ PeerStatSpec
 </td>
 <td>
 <em>(Optional)</em>
-<p>Stats are the stat a peer mirror</p>
+<p>Stats is the mirror stat for a given peer</p>
 </td>
 </tr>
 </tbody>
@@ -8352,7 +8352,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>LogLevel set logging level</p>
+<p>LogLevel sets logging level</p>
 </td>
 </tr>
 <tr>
@@ -8744,7 +8744,7 @@ Note: Only supported from Ceph Tentacle (v20)</p>
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.TopicEndpointSpec">TopicEndpointSpec</a>)
 </p>
 <div>
-<p>HTTPEndpointSpec represent the spec of an HTTP endpoint of a Bucket Topic</p>
+<p>HTTPEndpointSpec represents the spec of an HTTP endpoint of a Bucket Topic</p>
 </div>
 <table>
 <thead>
@@ -8940,7 +8940,7 @@ string
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.TopicEndpointSpec">TopicEndpointSpec</a>)
 </p>
 <div>
-<p>KafkaEndpointSpec represent the spec of a Kafka endpoint of a Bucket Topic</p>
+<p>KafkaEndpointSpec represents the spec of a Kafka endpoint of a Bucket Topic</p>
 </div>
 <table>
 <thead>
@@ -9204,7 +9204,7 @@ securely add the file via annotations on the CephNFS spec (passed to the NFS ser
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.ClusterSecuritySpec">ClusterSecuritySpec</a>, <a href="#ceph.rook.io/v1.ObjectStoreSecuritySpec">ObjectStoreSecuritySpec</a>, <a href="#ceph.rook.io/v1.SecuritySpec">SecuritySpec</a>)
 </p>
 <div>
-<p>KeyManagementServiceSpec represent various details of the KMS server</p>
+<p>KeyManagementServiceSpec represents various details of the KMS server</p>
 </div>
 <table>
 <thead>
@@ -9421,7 +9421,7 @@ int
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.FilesystemMirroringSpec">FilesystemMirroringSpec</a>, <a href="#ceph.rook.io/v1.GaneshaServerSpec">GaneshaServerSpec</a>, <a href="#ceph.rook.io/v1.GatewaySpec">GatewaySpec</a>, <a href="#ceph.rook.io/v1.MetadataServerSpec">MetadataServerSpec</a>, <a href="#ceph.rook.io/v1.NVMeOFGatewaySpec">NVMeOFGatewaySpec</a>, <a href="#ceph.rook.io/v1.RBDMirroringSpec">RBDMirroringSpec</a>, <a href="#ceph.rook.io/v1.RGWServiceSpec">RGWServiceSpec</a>)
 </p>
 <div>
-<p>Labels are label for a given daemons</p>
+<p>Labels are the labels for a given daemon</p>
 </div>
 <h3 id="ceph.rook.io/v1.LabelsSpec">LabelsSpec
 (<code>map[github.com/rook/rook/pkg/apis/ceph.rook.io/v1.KeyType]github.com/rook/rook/pkg/apis/ceph.rook.io/v1.Labels</code> alias)</h3>
@@ -11514,7 +11514,7 @@ Selection
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.NotificationFilterSpec">NotificationFilterSpec</a>)
 </p>
 <div>
-<p>NotificationFilterRule represent a single rule in the Notification Filter spec</p>
+<p>NotificationFilterRule represents a single rule in the Notification Filter spec</p>
 </div>
 <table>
 <thead>
@@ -11554,7 +11554,7 @@ string
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.BucketNotificationSpec">BucketNotificationSpec</a>)
 </p>
 <div>
-<p>NotificationFilterSpec represent the spec of a Bucket Notification filter</p>
+<p>NotificationFilterSpec represents the spec of a Bucket Notification filter</p>
 </div>
 <table>
 <thead>
@@ -11614,7 +11614,7 @@ string
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.NotificationFilterSpec">NotificationFilterSpec</a>)
 </p>
 <div>
-<p>NotificationKeyFilterRule represent a single key rule in the Notification Filter spec</p>
+<p>NotificationKeyFilterRule represents a single key rule in the Notification Filter spec</p>
 </div>
 <table>
 <thead>
@@ -11875,7 +11875,7 @@ ProbeSpec
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephObjectRealm">CephObjectRealm</a>)
 </p>
 <div>
-<p>ObjectRealmSpec represent the spec of an ObjectRealm</p>
+<p>ObjectRealmSpec represents the spec of a CephObjectRealm</p>
 </div>
 <table>
 <thead>
@@ -12000,7 +12000,7 @@ If spec.sharedPools are also empty, then RGW pools (spec.dataPool and spec.metad
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephObjectStoreAccount">CephObjectStoreAccount</a>)
 </p>
 <div>
-<p>ObjectStoreAccountSpec represent the spec of a RGW Account</p>
+<p>ObjectStoreAccountSpec represents the spec of an RGW Account</p>
 </div>
 <table>
 <thead>
@@ -12294,7 +12294,7 @@ See <a href="https://docs.openssl.org/master/man3/SSL_CTX_set1_curves/#descripti
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephObjectStore">CephObjectStore</a>)
 </p>
 <div>
-<p>ObjectStoreSpec represent the spec of a pool</p>
+<p>ObjectStoreSpec represents the spec of a CephObjectStore</p>
 </div>
 <table>
 <thead>
@@ -12651,7 +12651,7 @@ string
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephObjectStoreUser">CephObjectStoreUser</a>)
 </p>
 <div>
-<p>ObjectStoreUserSpec represent the spec of an Objectstoreuser</p>
+<p>ObjectStoreUserSpec represents the spec of a CephObjectStoreUser</p>
 </div>
 <table>
 <thead>
@@ -13120,7 +13120,7 @@ Kubernetes core/v1.SecretKeySelector
 <h3 id="ceph.rook.io/v1.ObjectUserOpMask">ObjectUserOpMask
 (<code>string</code> alias)</h3>
 <div>
-<p>Internally, RGW labels &ldquo;operations&rdquo; on persistent state as <code>RGW_OP_TYPE_READ</code> (<code>read</code>), <code>RGW_OP_TYPE_WRITE</code> (<code>write</code>), or <code>RGW_OP_TYPE_DELETE</code> (<code>delete</code>). All RGW users have an &ldquo;operation mask&rdquo;, which does not function as mask or filter as is typically implied by the word &ldquo;mask&rdquo;, but as a set of allowed or permissible &ldquo;operation&rdquo; types the user is able to perform. The &ldquo;operation mask&rdquo; is applied regardless of the bucket or IAM policy. For example, in order for an RGW user to be able to read an object from a bucket, that user must have <strong>both</strong> the <code>read</code> &ldquo;op mask&rdquo; bit and an IAM/bucket policy that allows <code>s3:GetObject</code>. The default operations allowed are <code>read</code>, <code>write</code>, and <code>delete</code>. Setting the value to <code>[]</code> (an empty YAML sequence) causes all &ldquo;operations&rdquo; in the mask to be removed, meaning that the user will not be able to perform any operations. These operation masks are supported: <code>read</code>, <code>write</code>, <code>delete</code></p>
+<p>Internally, RGW labels &ldquo;operations&rdquo; on persistent state as <code>RGW_OP_TYPE_READ</code> (<code>read</code>), <code>RGW_OP_TYPE_WRITE</code> (<code>write</code>), or <code>RGW_OP_TYPE_DELETE</code> (<code>delete</code>). All RGW users have an &ldquo;operation mask&rdquo;, which does not function as a mask or filter as is typically implied by the word &ldquo;mask&rdquo;, but as a set of allowed or permissible &ldquo;operation&rdquo; types the user is able to perform. The &ldquo;operation mask&rdquo; is applied regardless of the bucket or IAM policy. For example, in order for an RGW user to be able to read an object from a bucket, that user must have <strong>both</strong> the <code>read</code> &ldquo;op mask&rdquo; bit and an IAM/bucket policy that allows <code>s3:GetObject</code>. The default operations allowed are <code>read</code>, <code>write</code>, and <code>delete</code>. Setting the value to <code>[]</code> (an empty YAML sequence) causes all &ldquo;operations&rdquo; in the mask to be removed, meaning that the user will not be able to perform any operations. These operation masks are supported: <code>read</code>, <code>write</code>, <code>delete</code></p>
 </div>
 <h3 id="ceph.rook.io/v1.ObjectUserQuotaSpec">ObjectUserQuotaSpec
 </h3>
@@ -13183,7 +13183,7 @@ int64
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephObjectZoneGroup">CephObjectZoneGroup</a>)
 </p>
 <div>
-<p>ObjectZoneGroupSpec represent the spec of an ObjectZoneGroup</p>
+<p>ObjectZoneGroupSpec represents the spec of a CephObjectZoneGroup</p>
 </div>
 <table>
 <thead>
@@ -13212,7 +13212,7 @@ string
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.CephObjectZone">CephObjectZone</a>)
 </p>
 <div>
-<p>ObjectZoneSpec represent the spec of an ObjectZone</p>
+<p>ObjectZoneSpec represents the spec of a CephObjectZone</p>
 </div>
 <table>
 <thead>
@@ -13400,7 +13400,7 @@ string
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.FilesystemMirrorInfoPeerSpec">FilesystemMirrorInfoPeerSpec</a>)
 </p>
 <div>
-<p>PeerStatSpec are the mirror stat with a given peer</p>
+<p>PeerStatSpec is the mirror stat with a given peer</p>
 </div>
 <table>
 <thead>
@@ -14325,7 +14325,7 @@ string
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.GatewaySpec">GatewaySpec</a>)
 </p>
 <div>
-<p>RGWServiceSpec represent the spec for RGW service</p>
+<p>RGWServiceSpec represents the spec for RGW service</p>
 </div>
 <table>
 <thead>
@@ -15225,7 +15225,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Interval represent the periodicity of the snapshot.</p>
+<p>Interval represents the periodicity of the snapshot.</p>
 </td>
 </tr>
 <tr>
@@ -15499,7 +15499,7 @@ bool
 (<em>Appears on:</em><a href="#ceph.rook.io/v1.MirroringStatusSummarySpec">MirroringStatusSummarySpec</a>)
 </p>
 <div>
-<p>StatesSpec are rbd images mirroring state</p>
+<p>StatesSpec is rbd images mirroring state</p>
 </div>
 <table>
 <thead>
@@ -15860,7 +15860,7 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>Whether to always schedule OSDs on a node even if the node is not currently scheduleable or ready</p>
+<p>Whether to always schedule OSDs on a node even if the node is not currently schedulable or ready</p>
 </td>
 </tr>
 <tr>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -94,7 +94,7 @@ spec:
                         description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                         properties:
                           interval:
-                            description: Interval represent the periodicity of the snapshot.
+                            description: Interval represents the periodicity of the snapshot.
                             type: string
                           path:
                             description: Path is the path to snapshot, only valid for CephFS
@@ -137,7 +137,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -293,7 +293,7 @@ spec:
                       type: object
                   type: object
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 snapshotScheduleStatus:
                   description: SnapshotScheduleStatusSpec is the status of the snapshot schedule
@@ -526,7 +526,7 @@ spec:
                         description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                         properties:
                           interval:
-                            description: Interval represent the periodicity of the snapshot.
+                            description: Interval represents the periodicity of the snapshot.
                             type: string
                           path:
                             description: Path is the path to snapshot, only valid for CephFS
@@ -675,7 +675,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -835,7 +835,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 poolID:
                   description: optional
@@ -942,13 +942,13 @@ spec:
             metadata:
               type: object
             spec:
-              description: BucketNotificationSpec represent the spec of a Bucket Notification
+              description: BucketNotificationSpec represents the spec of a Bucket Notification
               properties:
                 events:
                   description: List of events that should trigger the notification
                   items:
                     description: |-
-                      BucketNotificationEvent represent the event type of the bucket notification
+                      BucketNotificationEvent represents the event type of the bucket notification
                       See: https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types
                     enum:
                       - s3:ObjectCreated:*
@@ -989,7 +989,7 @@ spec:
                     keyFilters:
                       description: Filters based on the object's key
                       items:
-                        description: NotificationKeyFilterRule represent a single key rule in the Notification Filter spec
+                        description: NotificationKeyFilterRule represents a single key rule in the Notification Filter spec
                         properties:
                           name:
                             description: Name of the filter - prefix/suffix/regex
@@ -1009,7 +1009,7 @@ spec:
                     metadataFilters:
                       description: Filters based on the object's metadata
                       items:
-                        description: NotificationFilterRule represent a single rule in the Notification Filter spec
+                        description: NotificationFilterRule represents a single rule in the Notification Filter spec
                         properties:
                           name:
                             description: Name of the metadata or tag
@@ -1026,7 +1026,7 @@ spec:
                     tagFilters:
                       description: Filters based on the object's tags
                       items:
-                        description: NotificationFilterRule represent a single rule in the Notification Filter spec
+                        description: NotificationFilterRule represents a single rule in the Notification Filter spec
                         properties:
                           name:
                             description: Name of the metadata or tag
@@ -1069,7 +1069,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -1138,7 +1138,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: BucketTopicSpec represent the spec of a Bucket Topic
+              description: BucketTopicSpec represents the spec of a Bucket Topic
               properties:
                 endpoint:
                   description: Contains the endpoint spec of the topic
@@ -1465,7 +1465,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
               type: object
               x-kubernetes-preserve-unknown-fields: true
@@ -2155,7 +2155,7 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 logCollector:
-                  description: Logging represents loggings settings
+                  description: Logging represents logging settings
                   nullable: true
                   properties:
                     enabled:
@@ -6036,7 +6036,7 @@ spec:
                     previousHealth:
                       type: string
                     versions:
-                      description: CephDaemonsVersions show the current ceph version for different ceph daemons
+                      description: CephDaemonsVersions shows the current ceph version for different ceph daemons
                       properties:
                         cephfs-mirror:
                           additionalProperties:
@@ -6281,7 +6281,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -6292,7 +6292,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 state:
                   description: ClusterState represents the state of a Ceph Cluster
@@ -7663,7 +7663,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -7848,7 +7848,7 @@ spec:
                               description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                               properties:
                                 interval:
-                                  description: Interval represent the periodicity of the snapshot.
+                                  description: Interval represents the periodicity of the snapshot.
                                   type: string
                                 path:
                                   description: Path is the path to snapshot, only valid for CephFS
@@ -8058,7 +8058,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -9107,7 +9107,7 @@ spec:
                         description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                         properties:
                           interval:
-                            description: Interval represent the periodicity of the snapshot.
+                            description: Interval represents the periodicity of the snapshot.
                             type: string
                           path:
                             description: Path is the path to snapshot, only valid for CephFS
@@ -9195,7 +9195,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -9236,7 +9236,7 @@ spec:
                                     description: FilesystemMirrorInfoPeerSpec is the specification of a filesystem peer mirror
                                     properties:
                                       remote:
-                                        description: Remote are the remote cluster information
+                                        description: Remote is the remote cluster information
                                         properties:
                                           client_name:
                                             description: ClientName is cephx name
@@ -9249,7 +9249,7 @@ spec:
                                             type: string
                                         type: object
                                       stats:
-                                        description: Stats are the stat a peer mirror
+                                        description: Stats are the stat of a peer mirror
                                         properties:
                                           failure_count:
                                             description: FailureCount is the number of mirroring failure
@@ -9283,7 +9283,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 snapshotScheduleStatus:
                   description: FilesystemSnapshotScheduleStatusSpec is the status of the snapshot schedule
@@ -9509,7 +9509,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
               type: object
               x-kubernetes-preserve-unknown-fields: true
@@ -11001,7 +11001,7 @@ spec:
                           type: object
                       type: object
                     logLevel:
-                      description: LogLevel set logging level
+                      description: LogLevel sets logging level
                       type: string
                     placement:
                       nullable: true
@@ -11630,7 +11630,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -12547,7 +12547,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -12615,7 +12615,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectRealmSpec represent the spec of an ObjectRealm
+              description: ObjectRealmSpec represents the spec of an ObjectRealm
               nullable: true
               properties:
                 defaultRealm:
@@ -12650,7 +12650,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -12716,7 +12716,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectStoreAccountSpec represent the spec of a RGW Account
+              description: ObjectStoreAccountSpec represents the spec of an RGW Account
               properties:
                 accountID:
                   description: |-
@@ -12846,7 +12846,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectStoreSpec represent the spec of a pool
+              description: ObjectStoreSpec represents the spec of a pool
               properties:
                 allowUsersInNamespaces:
                   description: |-
@@ -13004,7 +13004,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -14661,7 +14661,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -15077,7 +15077,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -15106,7 +15106,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 replicas:
                   format: int32
@@ -15178,7 +15178,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectStoreUserSpec represent the spec of an Objectstoreuser
+              description: ObjectStoreUserSpec represents the spec of an Objectstoreuser
               properties:
                 accountRef:
                   description: |-
@@ -15396,7 +15396,7 @@ spec:
                 opMask:
                   description: The op-mask of the user.
                   items:
-                    description: 'Internally, RGW labels "operations" on persistent state as `RGW_OP_TYPE_READ` (`read`), `RGW_OP_TYPE_WRITE` (`write`), or `RGW_OP_TYPE_DELETE` (`delete`). All RGW users have an "operation mask", which does not function as mask or filter as is typically implied by the word "mask", but as a set of allowed or permissible "operation" types the user is able to perform. The "operation mask" is applied regardless of the bucket or IAM policy. For example, in order for an RGW user to be able to read an object from a bucket, that user must have **both** the `read` "op mask" bit and an IAM/bucket policy that allows `s3:GetObject`. The default operations allowed are `read`, `write`, and `delete`. Setting the value to `[]` (an empty YAML sequence) causes all "operations" in the mask to be removed, meaning that the user will not be able to perform any operations. These operation masks are supported: `read`, `write`, `delete`'
+                    description: 'Internally, RGW labels "operations" on persistent state as `RGW_OP_TYPE_READ` (`read`), `RGW_OP_TYPE_WRITE` (`write`), or `RGW_OP_TYPE_DELETE` (`delete`). All RGW users have an "operation mask", which does not function as a mask or filter as is typically implied by the word "mask", but as a set of allowed or permissible "operation" types the user is able to perform. The "operation mask" is applied regardless of the bucket or IAM policy. For example, in order for an RGW user to be able to read an object from a bucket, that user must have **both** the `read` "op mask" bit and an IAM/bucket policy that allows `s3:GetObject`. The default operations allowed are `read`, `write`, and `delete`. Setting the value to `[]` (an empty YAML sequence) causes all "operations" in the mask to be removed, meaning that the user will not be able to perform any operations. These operation masks are supported: `read`, `write`, `delete`'
                     enum:
                       - read
                       - write
@@ -15528,7 +15528,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectZoneGroupSpec represent the spec of an ObjectZoneGroup
+              description: ObjectZoneGroupSpec represents the spec of an ObjectZoneGroup
               properties:
                 realm:
                   description: The name of the realm the zone group is a member of.
@@ -15557,7 +15557,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -15626,7 +15626,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectZoneSpec represent the spec of an ObjectZone
+              description: ObjectZoneSpec represents the spec of an ObjectZone
               properties:
                 customEndpoints:
                   description: |-
@@ -15754,7 +15754,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -15959,7 +15959,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -16181,7 +16181,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -16904,7 +16904,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -94,7 +94,7 @@ spec:
                         description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                         properties:
                           interval:
-                            description: Interval represent the periodicity of the snapshot.
+                            description: Interval represents the periodicity of the snapshot.
                             type: string
                           path:
                             description: Path is the path to snapshot, only valid for CephFS
@@ -137,7 +137,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -293,7 +293,7 @@ spec:
                       type: object
                   type: object
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 snapshotScheduleStatus:
                   description: SnapshotScheduleStatusSpec is the status of the snapshot schedule
@@ -545,7 +545,7 @@ spec:
                         description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                         properties:
                           interval:
-                            description: Interval represent the periodicity of the snapshot.
+                            description: Interval represents the periodicity of the snapshot.
                             type: string
                           path:
                             description: Path is the path to snapshot, only valid for CephFS
@@ -702,7 +702,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -862,7 +862,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 poolID:
                   description: optional
@@ -969,13 +969,13 @@ spec:
             metadata:
               type: object
             spec:
-              description: BucketNotificationSpec represent the spec of a Bucket Notification
+              description: BucketNotificationSpec represents the spec of a Bucket Notification
               properties:
                 events:
                   description: List of events that should trigger the notification
                   items:
                     description: |-
-                      BucketNotificationEvent represent the event type of the bucket notification
+                      BucketNotificationEvent represents the event type of the bucket notification
                       See: https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types
                     enum:
                       - s3:ObjectCreated:*
@@ -1016,7 +1016,7 @@ spec:
                     keyFilters:
                       description: Filters based on the object's key
                       items:
-                        description: NotificationKeyFilterRule represent a single key rule in the Notification Filter spec
+                        description: NotificationKeyFilterRule represents a single key rule in the Notification Filter spec
                         properties:
                           name:
                             description: Name of the filter - prefix/suffix/regex
@@ -1036,7 +1036,7 @@ spec:
                     metadataFilters:
                       description: Filters based on the object's metadata
                       items:
-                        description: NotificationFilterRule represent a single rule in the Notification Filter spec
+                        description: NotificationFilterRule represents a single rule in the Notification Filter spec
                         properties:
                           name:
                             description: Name of the metadata or tag
@@ -1053,7 +1053,7 @@ spec:
                     tagFilters:
                       description: Filters based on the object's tags
                       items:
-                        description: NotificationFilterRule represent a single rule in the Notification Filter spec
+                        description: NotificationFilterRule represents a single rule in the Notification Filter spec
                         properties:
                           name:
                             description: Name of the metadata or tag
@@ -1096,7 +1096,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -1165,7 +1165,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: BucketTopicSpec represent the spec of a Bucket Topic
+              description: BucketTopicSpec represents the spec of a Bucket Topic
               properties:
                 endpoint:
                   description: Contains the endpoint spec of the topic
@@ -1520,7 +1520,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
               type: object
               x-kubernetes-preserve-unknown-fields: true
@@ -2203,14 +2203,14 @@ spec:
                   additionalProperties:
                     additionalProperties:
                       type: string
-                    description: Labels are label for a given daemons
+                    description: Labels are the labels for a given daemon
                     type: object
                   description: The labels-related configuration to add/set on each Pod related object.
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 logCollector:
-                  description: Logging represents loggings settings
+                  description: LogCollector represents logging settings
                   nullable: true
                   properties:
                     enabled:
@@ -4509,7 +4509,7 @@ spec:
                       minimum: 1
                       type: integer
                     scheduleAlways:
-                      description: Whether to always schedule OSDs on a node even if the node is not currently scheduleable or ready
+                      description: Whether to always schedule OSDs on a node even if the node is not currently schedulable or ready
                       type: boolean
                     storageClassDeviceSets:
                       items:
@@ -6163,7 +6163,7 @@ spec:
                     previousHealth:
                       type: string
                     versions:
-                      description: CephDaemonsVersions show the current ceph version for different ceph daemons
+                      description: CephDaemonsVersions shows the current ceph version for different ceph daemons
                       properties:
                         cephfs-mirror:
                           additionalProperties:
@@ -6464,7 +6464,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -6475,7 +6475,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 state:
                   description: ClusterState represents the state of a Ceph Cluster
@@ -7853,7 +7853,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -8057,7 +8057,7 @@ spec:
                               description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                               properties:
                                 interval:
-                                  description: Interval represent the periodicity of the snapshot.
+                                  description: Interval represents the periodicity of the snapshot.
                                   type: string
                                 path:
                                   description: Path is the path to snapshot, only valid for CephFS
@@ -8286,7 +8286,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -9335,7 +9335,7 @@ spec:
                         description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                         properties:
                           interval:
-                            description: Interval represent the periodicity of the snapshot.
+                            description: Interval represents the periodicity of the snapshot.
                             type: string
                           path:
                             description: Path is the path to snapshot, only valid for CephFS
@@ -9430,7 +9430,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -9471,7 +9471,7 @@ spec:
                                     description: FilesystemMirrorInfoPeerSpec is the specification of a filesystem peer mirror
                                     properties:
                                       remote:
-                                        description: Remote are the remote cluster information
+                                        description: Remote is the remote cluster information
                                         properties:
                                           client_name:
                                             description: ClientName is cephx name
@@ -9484,7 +9484,7 @@ spec:
                                             type: string
                                         type: object
                                       stats:
-                                        description: Stats are the stat a peer mirror
+                                        description: Stats is the mirror stat for a given peer
                                         properties:
                                           failure_count:
                                             description: FailureCount is the number of mirroring failure
@@ -9518,7 +9518,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 snapshotScheduleStatus:
                   description: FilesystemSnapshotScheduleStatusSpec is the status of the snapshot schedule
@@ -9744,7 +9744,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
               type: object
               x-kubernetes-preserve-unknown-fields: true
@@ -11236,7 +11236,7 @@ spec:
                           type: object
                       type: object
                     logLevel:
-                      description: LogLevel set logging level
+                      description: LogLevel sets logging level
                       type: string
                     placement:
                       nullable: true
@@ -11880,7 +11880,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -12799,7 +12799,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -12867,7 +12867,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectRealmSpec represent the spec of an ObjectRealm
+              description: ObjectRealmSpec represents the spec of a CephObjectRealm
               nullable: true
               properties:
                 defaultRealm:
@@ -12902,7 +12902,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -12948,7 +12948,7 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephObjectStoreAccount represent the RGW user account
+          description: CephObjectStoreAccount represents the RGW user account
           properties:
             apiVersion:
               description: |-
@@ -12968,7 +12968,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectStoreAccountSpec represent the spec of a RGW Account
+              description: ObjectStoreAccountSpec represents the spec of an RGW Account
               properties:
                 accountID:
                   description: |-
@@ -13098,7 +13098,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectStoreSpec represent the spec of a pool
+              description: ObjectStoreSpec represents the spec of a CephObjectStore
               properties:
                 allowUsersInNamespaces:
                   description: |-
@@ -13275,7 +13275,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -14951,7 +14951,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -15374,7 +15374,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -15403,7 +15403,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 replicas:
                   format: int32
@@ -15475,7 +15475,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectStoreUserSpec represent the spec of an Objectstoreuser
+              description: ObjectStoreUserSpec represents the spec of a CephObjectStoreUser
               properties:
                 accountRef:
                   description: |-
@@ -15713,7 +15713,7 @@ spec:
                 opMask:
                   description: The op-mask of the user.
                   items:
-                    description: 'Internally, RGW labels "operations" on persistent state as `RGW_OP_TYPE_READ` (`read`), `RGW_OP_TYPE_WRITE` (`write`), or `RGW_OP_TYPE_DELETE` (`delete`). All RGW users have an "operation mask", which does not function as mask or filter as is typically implied by the word "mask", but as a set of allowed or permissible "operation" types the user is able to perform. The "operation mask" is applied regardless of the bucket or IAM policy. For example, in order for an RGW user to be able to read an object from a bucket, that user must have **both** the `read` "op mask" bit and an IAM/bucket policy that allows `s3:GetObject`. The default operations allowed are `read`, `write`, and `delete`. Setting the value to `[]` (an empty YAML sequence) causes all "operations" in the mask to be removed, meaning that the user will not be able to perform any operations. These operation masks are supported: `read`, `write`, `delete`'
+                    description: 'Internally, RGW labels "operations" on persistent state as `RGW_OP_TYPE_READ` (`read`), `RGW_OP_TYPE_WRITE` (`write`), or `RGW_OP_TYPE_DELETE` (`delete`). All RGW users have an "operation mask", which does not function as a mask or filter as is typically implied by the word "mask", but as a set of allowed or permissible "operation" types the user is able to perform. The "operation mask" is applied regardless of the bucket or IAM policy. For example, in order for an RGW user to be able to read an object from a bucket, that user must have **both** the `read` "op mask" bit and an IAM/bucket policy that allows `s3:GetObject`. The default operations allowed are `read`, `write`, and `delete`. Setting the value to `[]` (an empty YAML sequence) causes all "operations" in the mask to be removed, meaning that the user will not be able to perform any operations. These operation masks are supported: `read`, `write`, `delete`'
                     enum:
                       - read
                       - write
@@ -15845,7 +15845,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectZoneGroupSpec represent the spec of an ObjectZoneGroup
+              description: ObjectZoneGroupSpec represents the spec of a CephObjectZoneGroup
               properties:
                 realm:
                   description: The name of the realm the zone group is a member of.
@@ -15874,7 +15874,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -15943,7 +15943,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectZoneSpec represent the spec of an ObjectZone
+              description: ObjectZoneSpec represents the spec of a CephObjectZone
               properties:
                 customEndpoints:
                   description: |-
@@ -16090,7 +16090,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -16314,7 +16314,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -16536,7 +16536,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -17266,7 +17266,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -97,7 +97,7 @@ spec:
                         description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                         properties:
                           interval:
-                            description: Interval represent the periodicity of the snapshot.
+                            description: Interval represents the periodicity of the snapshot.
                             type: string
                           path:
                             description: Path is the path to snapshot, only valid for CephFS
@@ -140,7 +140,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -296,7 +296,7 @@ spec:
                       type: object
                   type: object
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 snapshotScheduleStatus:
                   description: SnapshotScheduleStatusSpec is the status of the snapshot schedule
@@ -528,7 +528,7 @@ spec:
                         description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                         properties:
                           interval:
-                            description: Interval represent the periodicity of the snapshot.
+                            description: Interval represents the periodicity of the snapshot.
                             type: string
                           path:
                             description: Path is the path to snapshot, only valid for CephFS
@@ -677,7 +677,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -837,7 +837,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 poolID:
                   description: optional
@@ -943,13 +943,13 @@ spec:
             metadata:
               type: object
             spec:
-              description: BucketNotificationSpec represent the spec of a Bucket Notification
+              description: BucketNotificationSpec represents the spec of a Bucket Notification
               properties:
                 events:
                   description: List of events that should trigger the notification
                   items:
                     description: |-
-                      BucketNotificationEvent represent the event type of the bucket notification
+                      BucketNotificationEvent represents the event type of the bucket notification
                       See: https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types
                     enum:
                       - s3:ObjectCreated:*
@@ -990,7 +990,7 @@ spec:
                     keyFilters:
                       description: Filters based on the object's key
                       items:
-                        description: NotificationKeyFilterRule represent a single key rule in the Notification Filter spec
+                        description: NotificationKeyFilterRule represents a single key rule in the Notification Filter spec
                         properties:
                           name:
                             description: Name of the filter - prefix/suffix/regex
@@ -1010,7 +1010,7 @@ spec:
                     metadataFilters:
                       description: Filters based on the object's metadata
                       items:
-                        description: NotificationFilterRule represent a single rule in the Notification Filter spec
+                        description: NotificationFilterRule represents a single rule in the Notification Filter spec
                         properties:
                           name:
                             description: Name of the metadata or tag
@@ -1027,7 +1027,7 @@ spec:
                     tagFilters:
                       description: Filters based on the object's tags
                       items:
-                        description: NotificationFilterRule represent a single rule in the Notification Filter spec
+                        description: NotificationFilterRule represents a single rule in the Notification Filter spec
                         properties:
                           name:
                             description: Name of the metadata or tag
@@ -1070,7 +1070,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -1138,7 +1138,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: BucketTopicSpec represent the spec of a Bucket Topic
+              description: BucketTopicSpec represents the spec of a Bucket Topic
               properties:
                 endpoint:
                   description: Contains the endpoint spec of the topic
@@ -1464,7 +1464,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
               type: object
               x-kubernetes-preserve-unknown-fields: true
@@ -2153,7 +2153,7 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 logCollector:
-                  description: Logging represents loggings settings
+                  description: Logging represents logging settings
                   nullable: true
                   properties:
                     enabled:
@@ -6034,7 +6034,7 @@ spec:
                     previousHealth:
                       type: string
                     versions:
-                      description: CephDaemonsVersions show the current ceph version for different ceph daemons
+                      description: CephDaemonsVersions shows the current ceph version for different ceph daemons
                       properties:
                         cephfs-mirror:
                           additionalProperties:
@@ -6279,7 +6279,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -6290,7 +6290,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 state:
                   description: ClusterState represents the state of a Ceph Cluster
@@ -7659,7 +7659,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -7843,7 +7843,7 @@ spec:
                               description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                               properties:
                                 interval:
-                                  description: Interval represent the periodicity of the snapshot.
+                                  description: Interval represents the periodicity of the snapshot.
                                   type: string
                                 path:
                                   description: Path is the path to snapshot, only valid for CephFS
@@ -8053,7 +8053,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -9102,7 +9102,7 @@ spec:
                         description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                         properties:
                           interval:
-                            description: Interval represent the periodicity of the snapshot.
+                            description: Interval represents the periodicity of the snapshot.
                             type: string
                           path:
                             description: Path is the path to snapshot, only valid for CephFS
@@ -9190,7 +9190,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -9231,7 +9231,7 @@ spec:
                                     description: FilesystemMirrorInfoPeerSpec is the specification of a filesystem peer mirror
                                     properties:
                                       remote:
-                                        description: Remote are the remote cluster information
+                                        description: Remote is the remote cluster information
                                         properties:
                                           client_name:
                                             description: ClientName is cephx name
@@ -9244,7 +9244,7 @@ spec:
                                             type: string
                                         type: object
                                       stats:
-                                        description: Stats are the stat a peer mirror
+                                        description: Stats are the stat of a peer mirror
                                         properties:
                                           failure_count:
                                             description: FailureCount is the number of mirroring failure
@@ -9278,7 +9278,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 snapshotScheduleStatus:
                   description: FilesystemSnapshotScheduleStatusSpec is the status of the snapshot schedule
@@ -9503,7 +9503,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
               type: object
               x-kubernetes-preserve-unknown-fields: true
@@ -10994,7 +10994,7 @@ spec:
                           type: object
                       type: object
                     logLevel:
-                      description: LogLevel set logging level
+                      description: LogLevel sets logging level
                       type: string
                     placement:
                       nullable: true
@@ -11623,7 +11623,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -12539,7 +12539,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -12606,7 +12606,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectRealmSpec represent the spec of an ObjectRealm
+              description: ObjectRealmSpec represents the spec of an ObjectRealm
               nullable: true
               properties:
                 defaultRealm:
@@ -12641,7 +12641,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -12706,7 +12706,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectStoreAccountSpec represent the spec of a RGW Account
+              description: ObjectStoreAccountSpec represents the spec of an RGW Account
               properties:
                 accountID:
                   description: |-
@@ -12835,7 +12835,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectStoreSpec represent the spec of a pool
+              description: ObjectStoreSpec represents the spec of a pool
               properties:
                 allowUsersInNamespaces:
                   description: |-
@@ -12993,7 +12993,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -14650,7 +14650,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -15066,7 +15066,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -15095,7 +15095,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 replicas:
                   format: int32
@@ -15166,7 +15166,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectStoreUserSpec represent the spec of an Objectstoreuser
+              description: ObjectStoreUserSpec represents the spec of an Objectstoreuser
               properties:
                 accountRef:
                   description: |-
@@ -15384,7 +15384,7 @@ spec:
                 opMask:
                   description: The op-mask of the user.
                   items:
-                    description: 'Internally, RGW labels "operations" on persistent state as `RGW_OP_TYPE_READ` (`read`), `RGW_OP_TYPE_WRITE` (`write`), or `RGW_OP_TYPE_DELETE` (`delete`). All RGW users have an "operation mask", which does not function as mask or filter as is typically implied by the word "mask", but as a set of allowed or permissible "operation" types the user is able to perform. The "operation mask" is applied regardless of the bucket or IAM policy. For example, in order for an RGW user to be able to read an object from a bucket, that user must have **both** the `read` "op mask" bit and an IAM/bucket policy that allows `s3:GetObject`. The default operations allowed are `read`, `write`, and `delete`. Setting the value to `[]` (an empty YAML sequence) causes all "operations" in the mask to be removed, meaning that the user will not be able to perform any operations. These operation masks are supported: `read`, `write`, `delete`'
+                    description: 'Internally, RGW labels "operations" on persistent state as `RGW_OP_TYPE_READ` (`read`), `RGW_OP_TYPE_WRITE` (`write`), or `RGW_OP_TYPE_DELETE` (`delete`). All RGW users have an "operation mask", which does not function as a mask or filter as is typically implied by the word "mask", but as a set of allowed or permissible "operation" types the user is able to perform. The "operation mask" is applied regardless of the bucket or IAM policy. For example, in order for an RGW user to be able to read an object from a bucket, that user must have **both** the `read` "op mask" bit and an IAM/bucket policy that allows `s3:GetObject`. The default operations allowed are `read`, `write`, and `delete`. Setting the value to `[]` (an empty YAML sequence) causes all "operations" in the mask to be removed, meaning that the user will not be able to perform any operations. These operation masks are supported: `read`, `write`, `delete`'
                     enum:
                       - read
                       - write
@@ -15515,7 +15515,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectZoneGroupSpec represent the spec of an ObjectZoneGroup
+              description: ObjectZoneGroupSpec represents the spec of an ObjectZoneGroup
               properties:
                 realm:
                   description: The name of the realm the zone group is a member of.
@@ -15544,7 +15544,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -15612,7 +15612,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectZoneSpec represent the spec of an ObjectZone
+              description: ObjectZoneSpec represents the spec of an ObjectZone
               properties:
                 customEndpoints:
                   description: |-
@@ -15740,7 +15740,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -15945,7 +15945,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -16167,7 +16167,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -16889,7 +16889,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -97,7 +97,7 @@ spec:
                         description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                         properties:
                           interval:
-                            description: Interval represent the periodicity of the snapshot.
+                            description: Interval represents the periodicity of the snapshot.
                             type: string
                           path:
                             description: Path is the path to snapshot, only valid for CephFS
@@ -140,7 +140,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -296,7 +296,7 @@ spec:
                       type: object
                   type: object
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 snapshotScheduleStatus:
                   description: SnapshotScheduleStatusSpec is the status of the snapshot schedule
@@ -547,7 +547,7 @@ spec:
                         description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                         properties:
                           interval:
-                            description: Interval represent the periodicity of the snapshot.
+                            description: Interval represents the periodicity of the snapshot.
                             type: string
                           path:
                             description: Path is the path to snapshot, only valid for CephFS
@@ -704,7 +704,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -864,7 +864,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 poolID:
                   description: optional
@@ -970,13 +970,13 @@ spec:
             metadata:
               type: object
             spec:
-              description: BucketNotificationSpec represent the spec of a Bucket Notification
+              description: BucketNotificationSpec represents the spec of a Bucket Notification
               properties:
                 events:
                   description: List of events that should trigger the notification
                   items:
                     description: |-
-                      BucketNotificationEvent represent the event type of the bucket notification
+                      BucketNotificationEvent represents the event type of the bucket notification
                       See: https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types
                     enum:
                       - s3:ObjectCreated:*
@@ -1017,7 +1017,7 @@ spec:
                     keyFilters:
                       description: Filters based on the object's key
                       items:
-                        description: NotificationKeyFilterRule represent a single key rule in the Notification Filter spec
+                        description: NotificationKeyFilterRule represents a single key rule in the Notification Filter spec
                         properties:
                           name:
                             description: Name of the filter - prefix/suffix/regex
@@ -1037,7 +1037,7 @@ spec:
                     metadataFilters:
                       description: Filters based on the object's metadata
                       items:
-                        description: NotificationFilterRule represent a single rule in the Notification Filter spec
+                        description: NotificationFilterRule represents a single rule in the Notification Filter spec
                         properties:
                           name:
                             description: Name of the metadata or tag
@@ -1054,7 +1054,7 @@ spec:
                     tagFilters:
                       description: Filters based on the object's tags
                       items:
-                        description: NotificationFilterRule represent a single rule in the Notification Filter spec
+                        description: NotificationFilterRule represents a single rule in the Notification Filter spec
                         properties:
                           name:
                             description: Name of the metadata or tag
@@ -1097,7 +1097,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -1165,7 +1165,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: BucketTopicSpec represent the spec of a Bucket Topic
+              description: BucketTopicSpec represents the spec of a Bucket Topic
               properties:
                 endpoint:
                   description: Contains the endpoint spec of the topic
@@ -1519,7 +1519,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
               type: object
               x-kubernetes-preserve-unknown-fields: true
@@ -2201,14 +2201,14 @@ spec:
                   additionalProperties:
                     additionalProperties:
                       type: string
-                    description: Labels are label for a given daemons
+                    description: Labels are the labels for a given daemon
                     type: object
                   description: The labels-related configuration to add/set on each Pod related object.
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 logCollector:
-                  description: Logging represents loggings settings
+                  description: LogCollector represents logging settings
                   nullable: true
                   properties:
                     enabled:
@@ -4507,7 +4507,7 @@ spec:
                       minimum: 1
                       type: integer
                     scheduleAlways:
-                      description: Whether to always schedule OSDs on a node even if the node is not currently scheduleable or ready
+                      description: Whether to always schedule OSDs on a node even if the node is not currently schedulable or ready
                       type: boolean
                     storageClassDeviceSets:
                       items:
@@ -6161,7 +6161,7 @@ spec:
                     previousHealth:
                       type: string
                     versions:
-                      description: CephDaemonsVersions show the current ceph version for different ceph daemons
+                      description: CephDaemonsVersions shows the current ceph version for different ceph daemons
                       properties:
                         cephfs-mirror:
                           additionalProperties:
@@ -6462,7 +6462,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -6473,7 +6473,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 state:
                   description: ClusterState represents the state of a Ceph Cluster
@@ -7849,7 +7849,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -8052,7 +8052,7 @@ spec:
                               description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                               properties:
                                 interval:
-                                  description: Interval represent the periodicity of the snapshot.
+                                  description: Interval represents the periodicity of the snapshot.
                                   type: string
                                 path:
                                   description: Path is the path to snapshot, only valid for CephFS
@@ -8281,7 +8281,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -9330,7 +9330,7 @@ spec:
                         description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                         properties:
                           interval:
-                            description: Interval represent the periodicity of the snapshot.
+                            description: Interval represents the periodicity of the snapshot.
                             type: string
                           path:
                             description: Path is the path to snapshot, only valid for CephFS
@@ -9425,7 +9425,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -9466,7 +9466,7 @@ spec:
                                     description: FilesystemMirrorInfoPeerSpec is the specification of a filesystem peer mirror
                                     properties:
                                       remote:
-                                        description: Remote are the remote cluster information
+                                        description: Remote is the remote cluster information
                                         properties:
                                           client_name:
                                             description: ClientName is cephx name
@@ -9479,7 +9479,7 @@ spec:
                                             type: string
                                         type: object
                                       stats:
-                                        description: Stats are the stat a peer mirror
+                                        description: Stats is the mirror stat for a given peer
                                         properties:
                                           failure_count:
                                             description: FailureCount is the number of mirroring failure
@@ -9513,7 +9513,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 snapshotScheduleStatus:
                   description: FilesystemSnapshotScheduleStatusSpec is the status of the snapshot schedule
@@ -9738,7 +9738,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
               type: object
               x-kubernetes-preserve-unknown-fields: true
@@ -11229,7 +11229,7 @@ spec:
                           type: object
                       type: object
                     logLevel:
-                      description: LogLevel set logging level
+                      description: LogLevel sets logging level
                       type: string
                     placement:
                       nullable: true
@@ -11873,7 +11873,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -12791,7 +12791,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -12858,7 +12858,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectRealmSpec represent the spec of an ObjectRealm
+              description: ObjectRealmSpec represents the spec of a CephObjectRealm
               nullable: true
               properties:
                 defaultRealm:
@@ -12893,7 +12893,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -12938,7 +12938,7 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: CephObjectStoreAccount represent the RGW user account
+          description: CephObjectStoreAccount represents the RGW user account
           properties:
             apiVersion:
               description: |-
@@ -12958,7 +12958,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectStoreAccountSpec represent the spec of a RGW Account
+              description: ObjectStoreAccountSpec represents the spec of an RGW Account
               properties:
                 accountID:
                   description: |-
@@ -13087,7 +13087,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectStoreSpec represent the spec of a pool
+              description: ObjectStoreSpec represents the spec of a CephObjectStore
               properties:
                 allowUsersInNamespaces:
                   description: |-
@@ -13264,7 +13264,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -14940,7 +14940,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -15363,7 +15363,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -15392,7 +15392,7 @@ spec:
                   format: int64
                   type: integer
                 phase:
-                  description: ConditionType represent a resource's status
+                  description: ConditionType represents a resource's status
                   type: string
                 replicas:
                   format: int32
@@ -15463,7 +15463,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectStoreUserSpec represent the spec of an Objectstoreuser
+              description: ObjectStoreUserSpec represents the spec of a CephObjectStoreUser
               properties:
                 accountRef:
                   description: |-
@@ -15701,7 +15701,7 @@ spec:
                 opMask:
                   description: The op-mask of the user.
                   items:
-                    description: 'Internally, RGW labels "operations" on persistent state as `RGW_OP_TYPE_READ` (`read`), `RGW_OP_TYPE_WRITE` (`write`), or `RGW_OP_TYPE_DELETE` (`delete`). All RGW users have an "operation mask", which does not function as mask or filter as is typically implied by the word "mask", but as a set of allowed or permissible "operation" types the user is able to perform. The "operation mask" is applied regardless of the bucket or IAM policy. For example, in order for an RGW user to be able to read an object from a bucket, that user must have **both** the `read` "op mask" bit and an IAM/bucket policy that allows `s3:GetObject`. The default operations allowed are `read`, `write`, and `delete`. Setting the value to `[]` (an empty YAML sequence) causes all "operations" in the mask to be removed, meaning that the user will not be able to perform any operations. These operation masks are supported: `read`, `write`, `delete`'
+                    description: 'Internally, RGW labels "operations" on persistent state as `RGW_OP_TYPE_READ` (`read`), `RGW_OP_TYPE_WRITE` (`write`), or `RGW_OP_TYPE_DELETE` (`delete`). All RGW users have an "operation mask", which does not function as a mask or filter as is typically implied by the word "mask", but as a set of allowed or permissible "operation" types the user is able to perform. The "operation mask" is applied regardless of the bucket or IAM policy. For example, in order for an RGW user to be able to read an object from a bucket, that user must have **both** the `read` "op mask" bit and an IAM/bucket policy that allows `s3:GetObject`. The default operations allowed are `read`, `write`, and `delete`. Setting the value to `[]` (an empty YAML sequence) causes all "operations" in the mask to be removed, meaning that the user will not be able to perform any operations. These operation masks are supported: `read`, `write`, `delete`'
                     enum:
                       - read
                       - write
@@ -15832,7 +15832,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectZoneGroupSpec represent the spec of an ObjectZoneGroup
+              description: ObjectZoneGroupSpec represents the spec of a CephObjectZoneGroup
               properties:
                 realm:
                   description: The name of the realm the zone group is a member of.
@@ -15861,7 +15861,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -15929,7 +15929,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ObjectZoneSpec represent the spec of an ObjectZone
+              description: ObjectZoneSpec represents the spec of a CephObjectZone
               properties:
                 customEndpoints:
                   description: |-
@@ -16076,7 +16076,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -16300,7 +16300,7 @@ spec:
                             description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
                             properties:
                               interval:
-                                description: Interval represent the periodicity of the snapshot.
+                                description: Interval represents the periodicity of the snapshot.
                                 type: string
                               path:
                                 description: Path is the path to snapshot, only valid for CephFS
@@ -16522,7 +16522,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array
@@ -17251,7 +17251,7 @@ spec:
                       status:
                         type: string
                       type:
-                        description: ConditionType represent a resource's status
+                        description: ConditionType represents a resource's status
                         type: string
                     type: object
                   type: array

--- a/pkg/apis/ceph.rook.io/v1/cluster.go
+++ b/pkg/apis/ceph.rook.io/v1/cluster.go
@@ -33,7 +33,7 @@ func (c *ClusterSpec) RequireMsgr2() bool {
 	return false
 }
 
-// RequireMsgr2 checks if the network settings require the msgr2 protocol
+// NetworkEncryptionEnabled returns whether Ceph network encryption is enabled
 func (c *ClusterSpec) NetworkEncryptionEnabled() bool {
 	if c.Network.Connections == nil {
 		return false

--- a/pkg/apis/ceph.rook.io/v1/labels.go
+++ b/pkg/apis/ceph.rook.io/v1/labels.go
@@ -150,7 +150,7 @@ func (a Labels) Merge(with Labels) Labels {
 //   - Multiple resultant dashes in a row are compressed to a single dash.
 //   - If the starting character is a number, a 'd' is prepended to preserve the number.
 //   - Any non-alphanumeric starting or ending characters are removed.
-//   - If the resultant string is longer than the maximum-allowed 63 characters], characters are
+//   - If the resultant string is longer than the maximum-allowed 63 characters, characters are
 //     removed from the middle and replaced with a double dash ('--') to reduce the string to 63
 //     characters.
 func ToValidDNSLabel(input string) string {

--- a/pkg/apis/ceph.rook.io/v1/labels.go
+++ b/pkg/apis/ceph.rook.io/v1/labels.go
@@ -53,7 +53,7 @@ type LabelsSpec map[KeyType]Labels
 // KeyType type safety
 type KeyType string
 
-// Labels are label for a given daemons
+// Labels are the labels for a given daemon
 type Labels map[string]string
 
 func (a LabelsSpec) All() Labels {
@@ -169,7 +169,7 @@ func (a Labels) Merge(with Labels) Labels {
 //   - Multiple resultant dashes in a row are compressed to a single dash.
 //   - If the starting character is a number, a 'd' is prepended to preserve the number.
 //   - Any non-alphanumeric starting or ending characters are removed.
-//   - If the resultant string is longer than the maximum-allowed 63 characters], characters are
+//   - If the resultant string is longer than the maximum-allowed 63 characters, characters are
 //     removed from the middle and replaced with a double dash ('--') to reduce the string to 63
 //     characters.
 func ToValidDNSLabel(input string) string {

--- a/pkg/apis/ceph.rook.io/v1/network.go
+++ b/pkg/apis/ceph.rook.io/v1/network.go
@@ -32,7 +32,7 @@ import (
 // This can be used, for example, to run Rook in k8s clusters with no CNI where host networking is required
 var enforceHostNetwork bool = false
 
-// IsMultus get whether to use multus network provider
+// IsMultus gets whether to use multus network provider
 func (n *NetworkSpec) IsMultus() bool {
 	return n.Provider == NetworkProviderMultus
 }

--- a/pkg/apis/ceph.rook.io/v1/network.go
+++ b/pkg/apis/ceph.rook.io/v1/network.go
@@ -32,7 +32,7 @@ import (
 // This can be used, for example, to run Rook in k8s clusters with no CNI where host networking is required
 var enforceHostNetwork bool = false
 
-// IsMultus get whether to use multus network provider
+// IsMultus returns whether the multus network provider is configured
 func (n *NetworkSpec) IsMultus() bool {
 	return n.Provider == NetworkProviderMultus
 }

--- a/pkg/apis/ceph.rook.io/v1/network_test.go
+++ b/pkg/apis/ceph.rook.io/v1/network_test.go
@@ -244,7 +244,7 @@ func TestAddressRangesSpec_Validate(t *testing.T) {
 	}
 }
 
-// these two functions are should almost always used together and can be unit tested together more
+// these two functions are almost always used together and can be unit tested together more
 // easily than apart
 func TestNetworkSpec_GetNetworkSelection_NetworkSelectionsToAnnotationValue(t *testing.T) {
 	// inputs are the same definition expressed in json format or non-json format

--- a/pkg/apis/ceph.rook.io/v1/object.go
+++ b/pkg/apis/ceph.rook.io/v1/object.go
@@ -29,7 +29,7 @@ const ServiceServingCertKey = "service.beta.openshift.io/serving-cert-secret-nam
 
 // 38 is the max length of a ceph store name as total length of the resource name cannot be more than 63 characters limit
 // and there is a configmap which is formed by appending `rook-ceph-rgw-<STORE-NAME>-mime-types`
-// so over all it brings up to (63-14-11 = 38) characters for the store name
+// so overall it brings up to (63-14-11 = 38) characters for the store name
 const objectStoreNameMaxLen = 38
 
 func (s *ObjectStoreSpec) IsMultisite() bool {
@@ -68,7 +68,7 @@ func (s *ObjectRealmSpec) IsPullRealm() bool {
 	return s.Pull.Endpoint != ""
 }
 
-// ValidateObjectSpec validate the object store arguments
+// ValidateObjectSpec validates the object store arguments
 func ValidateObjectSpec(gs *CephObjectStore) error {
 	if gs.Name == "" {
 		return errors.New("missing name")
@@ -78,7 +78,7 @@ func ValidateObjectSpec(gs *CephObjectStore) error {
 	}
 
 	// validate the object store name only if it is not an external cluster
-	// as external cluster won't create the rgw daemon and it's other resources
+	// as external cluster won't create the rgw daemon and its other resources
 	// and there is some legacy external cluster which has more length of objectstore
 	// so to run them successfully we are not validating the objectstore name
 	if !gs.Spec.IsExternal() {
@@ -146,7 +146,7 @@ func validateObjectStoreSecurity(spec *ObjectStoreSpec) error {
 	return nil
 }
 
-// isTLSv1_2orBelowEnabled check if TLS v1.2 or below is enabled
+// isTLSv1_2orBelowEnabled checks if TLS v1.2 or below is enabled
 func isTLSv1_2orBelowEnabled(opts *SslOptionsSpec) bool {
 	if opts == nil {
 		return true
@@ -193,7 +193,7 @@ func (c *CephObjectStore) GetAdvertiseEndpoint() (string, int32, bool, error) {
 		address = c.Spec.Gateway.ExternalRgwEndpoints[0].String()
 	}
 
-	// if users override the advertise endpoint themselves, these value take priority
+	// if users override the advertise endpoint themselves, these values take priority
 	if c.AdvertiseEndpointIsSet() {
 		address = c.Spec.Hosting.AdvertiseEndpoint.DnsName
 		port = c.Spec.Hosting.AdvertiseEndpoint.Port

--- a/pkg/apis/ceph.rook.io/v1/object_test.go
+++ b/pkg/apis/ceph.rook.io/v1/object_test.go
@@ -39,7 +39,7 @@ func TestValidateObjectStoreSpec(t *testing.T) {
 	err := ValidateObjectSpec(o)
 	assert.NoError(t, err)
 
-	// when both port and securePort are o
+	// when both port and securePort are 0
 	o.Spec.Gateway.Port = 0
 	err = ValidateObjectSpec(o)
 	assert.Error(t, err)
@@ -202,7 +202,7 @@ func TestIsTLSEnabled(t *testing.T) {
 	IsTLS = objStore.Spec.IsTLSEnabled()
 	assert.True(t, IsTLS)
 
-	// when cert are set but securePort unset
+	// when certs are set but securePort unset
 	objStore.Spec.Gateway.SecurePort = 0
 	IsTLS = objStore.Spec.IsTLSEnabled()
 	assert.False(t, IsTLS)

--- a/pkg/apis/ceph.rook.io/v1/pool.go
+++ b/pkg/apis/ceph.rook.io/v1/pool.go
@@ -49,7 +49,7 @@ func validatePoolSpec(ps NamedPoolSpec) error {
 	if ps.ErasureCoded.CodingChunks <= 0 && ps.ErasureCoded.DataChunks <= 0 && ps.Replicated.TargetSizeRatio <= 0 && ps.Replicated.Size <= 0 {
 		return errors.New("invalid pool spec: either of erasurecoded or replicated fields should be set")
 	}
-	// Check if any of the ErasureCoded fields are populated. Then check if replicated is populated. Both can't be populated at same time.
+	// Check if any of the ErasureCoded fields are populated. Then check if replicated is populated. Both can't be populated at the same time.
 	if ps.ErasureCoded.CodingChunks > 0 || ps.ErasureCoded.DataChunks > 0 || ps.ErasureCoded.Algorithm != "" {
 		if ps.Replicated.Size > 0 || ps.Replicated.TargetSizeRatio > 0 {
 			return errors.New("invalid pool spec: both erasurecoded and replicated fields cannot be set at the same time")

--- a/pkg/apis/ceph.rook.io/v1/security.go
+++ b/pkg/apis/ceph.rook.io/v1/security.go
@@ -26,27 +26,27 @@ import (
 
 var VaultTLSConnectionDetails = []string{api.EnvVaultCACert, api.EnvVaultClientCert, api.EnvVaultClientKey}
 
-// IsEnabled return whether a KMS is configured
+// IsEnabled returns whether a KMS is configured
 func (kms *KeyManagementServiceSpec) IsEnabled() bool {
 	return len(kms.ConnectionDetails) != 0
 }
 
-// IsTokenAuthEnabled return whether KMS token auth is enabled
+// IsTokenAuthEnabled returns whether KMS token auth is enabled
 func (kms *KeyManagementServiceSpec) IsTokenAuthEnabled() bool {
 	return kms.TokenSecretName != ""
 }
 
-// IsK8sAuthEnabled return whether KMS Kubernetes auth is enabled
+// IsK8sAuthEnabled returns whether KMS Kubernetes auth is enabled
 func (kms *KeyManagementServiceSpec) IsK8sAuthEnabled() bool {
 	return getParam(kms.ConnectionDetails, vault.AuthMethod) == vault.AuthMethodKubernetes && kms.TokenSecretName == ""
 }
 
-// IsAgentAuthEnabled return whether Vault Agent auth is enabled
+// IsAgentAuthEnabled returns whether Vault Agent auth is enabled
 func (kms *KeyManagementServiceSpec) IsAgentAuthEnabled() bool {
 	return getParam(kms.ConnectionDetails, vault.AuthMethod) == "agent" && kms.TokenSecretName == ""
 }
 
-// IsVaultKMS return whether Vault KMS is configured
+// IsVaultKMS returns whether Vault KMS is configured
 func (kms *KeyManagementServiceSpec) IsVaultKMS() bool {
 	return getParam(kms.ConnectionDetails, "KMS_PROVIDER") == secrets.TypeVault
 }
@@ -55,17 +55,17 @@ func (kms *KeyManagementServiceSpec) IsAzureMS() bool {
 	return getParam(kms.ConnectionDetails, "KMS_PROVIDER") == secrets.TypeAzure
 }
 
-// IsIBMKeyProtectKMS return whether IBM Key Protect KMS is configured
+// IsIBMKeyProtectKMS returns whether IBM Key Protect KMS is configured
 func (kms *KeyManagementServiceSpec) IsIBMKeyProtectKMS() bool {
 	return getParam(kms.ConnectionDetails, "KMS_PROVIDER") == "ibmkeyprotect"
 }
 
-// IsKMIPKMS return whether KMIP KMS is configured
+// IsKMIPKMS returns whether KMIP KMS is configured
 func (kms *KeyManagementServiceSpec) IsKMIPKMS() bool {
 	return getParam(kms.ConnectionDetails, "KMS_PROVIDER") == "kmip"
 }
 
-// IsTLSEnabled return KMS TLS details are configured
+// IsTLSEnabled returns whether KMS TLS details are configured
 func (kms *KeyManagementServiceSpec) IsTLSEnabled() bool {
 	for _, tlsOption := range VaultTLSConnectionDetails {
 		tlsSecretName := getParam(kms.ConnectionDetails, tlsOption)

--- a/pkg/apis/ceph.rook.io/v1/storage.go
+++ b/pkg/apis/ceph.rook.io/v1/storage.go
@@ -136,7 +136,7 @@ func (s *StorageScopeSpec) NodeWithNameExists(name string) bool {
 	return false
 }
 
-// GetUseAllDevices return if all devices should be used.
+// GetUseAllDevices returns whether all devices should be used.
 func (s *Selection) GetUseAllDevices() bool {
 	return s.UseAllDevices != nil && *(s.UseAllDevices)
 }

--- a/pkg/apis/ceph.rook.io/v1/topic.go
+++ b/pkg/apis/ceph.rook.io/v1/topic.go
@@ -49,7 +49,7 @@ func ValidateKafkaSpec(s *KafkaEndpointSpec) error {
 	return validateURI(s.URI, []string{"kafka"})
 }
 
-// ValidateTopicSpec validate the bucket notification topic arguments
+// ValidateTopicSpec validates the bucket notification topic arguments
 func (t *CephBucketTopic) ValidateTopicSpec() error {
 	hasEndpoint := false
 	if t.Spec.Endpoint.HTTP != nil {

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -57,7 +57,7 @@ type CephCluster struct {
 	Status ClusterStatus `json:"status,omitempty"`
 }
 
-// CephClusterHealthCheckSpec represent the healthcheck for Ceph daemons
+// CephClusterHealthCheckSpec represents the healthcheck for Ceph daemons
 type CephClusterHealthCheckSpec struct {
 	// DaemonHealth is the health check for a given daemon
 	// +optional
@@ -242,7 +242,7 @@ type ClusterSpec struct {
 	// +nullable
 	Security ClusterSecuritySpec `json:"security,omitempty"`
 
-	// Logging represents loggings settings
+	// Logging represents logging settings
 	// +optional
 	// +nullable
 	LogCollector LogCollectorSpec `json:"logCollector,omitempty"`
@@ -476,7 +476,7 @@ type SslOptionsSpec struct {
 	SingleDiffieHellmanUse *bool `json:"singleDiffieHellmanUse,omitempty"`
 }
 
-// KeyManagementServiceSpec represent various details of the KMS server
+// KeyManagementServiceSpec represents various details of the KMS server
 type KeyManagementServiceSpec struct {
 	// ConnectionDetails contains the KMS connection details (address, port etc)
 	// +optional
@@ -615,7 +615,7 @@ type ClusterStatus struct {
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
-// CephDaemonsVersions show the current ceph version for different ceph daemons
+// CephDaemonsVersions shows the current ceph version for different ceph daemons
 type CephDaemonsVersions struct {
 	// Mon shows Mon Ceph version
 	// +optional
@@ -755,7 +755,7 @@ const (
 	RadosNamespaceEmptyReason ConditionReason = "RadosNamespaceEmpty"
 )
 
-// ConditionType represent a resource's status
+// ConditionType represents a resource's status
 type ConditionType string
 
 const (
@@ -1214,7 +1214,7 @@ type MirroringStatusSummarySpec struct {
 	GroupStates StatesSpec `json:"group_states,omitempty"`
 }
 
-// StatesSpec are rbd images mirroring state
+// StatesSpec is rbd images mirroring state
 type StatesSpec struct {
 	// StartingReplay is when the replay of the mirroring journal starts
 	// +optional
@@ -1407,7 +1407,7 @@ type SnapshotScheduleSpec struct {
 	// +optional
 	Path string `json:"path,omitempty"`
 
-	// Interval represent the periodicity of the snapshot.
+	// Interval represents the periodicity of the snapshot.
 	// +optional
 	Interval string `json:"interval,omitempty"`
 
@@ -1749,10 +1749,10 @@ type FilesystemMirrorInfoPeerSpec struct {
 	// UUID is the peer unique identifier
 	// +optional
 	UUID string `json:"uuid,omitempty"`
-	// Remote are the remote cluster information
+	// Remote is the remote cluster information
 	// +optional
 	Remote *PeerRemoteSpec `json:"remote,omitempty"`
-	// Stats are the stat a peer mirror
+	// Stats are the stat of a peer mirror
 	// +optional
 	Stats *PeerStatSpec `json:"stats,omitempty"`
 }
@@ -1769,7 +1769,7 @@ type PeerRemoteSpec struct {
 	FsName string `json:"fs_name,omitempty"`
 }
 
-// PeerStatSpec are the mirror stat with a given peer
+// PeerStatSpec is the mirror stat with a given peer
 type PeerStatSpec struct {
 	// FailureCount is the number of mirroring failure
 	// +optional
@@ -1808,7 +1808,7 @@ type CephObjectStoreList struct {
 	Items           []CephObjectStore `json:"items"`
 }
 
-// ObjectStoreSpec represent the spec of a pool
+// ObjectStoreSpec represents the spec of a pool
 // +kubebuilder:validation:XValidation:rule="!(has(self.defaultRealm) && self.defaultRealm == true && has(self.zone) && size(self.zone.name) > 0)",message="defaultRealm must not be true when zone.name is set (multisite configuration)"
 type ObjectStoreSpec struct {
 	// The metadata pool settings
@@ -2367,7 +2367,7 @@ type CephObjectStoreUserList struct {
 	Items           []CephObjectStoreUser `json:"items"`
 }
 
-// ObjectStoreUserSpec represent the spec of an Objectstoreuser
+// ObjectStoreUserSpec represents the spec of an Objectstoreuser
 type ObjectStoreUserSpec struct {
 	// The store the user will be created in
 	// +optional
@@ -2413,7 +2413,7 @@ type ObjectStoreUserAccountRef struct {
 	Name string `json:"name,omitempty"`
 }
 
-// Internally, RGW labels "operations" on persistent state as `RGW_OP_TYPE_READ` (`read`), `RGW_OP_TYPE_WRITE` (`write`), or `RGW_OP_TYPE_DELETE` (`delete`). All RGW users have an "operation mask", which does not function as mask or filter as is typically implied by the word "mask", but as a set of allowed or permissible "operation" types the user is able to perform. The "operation mask" is applied regardless of the bucket or IAM policy. For example, in order for an RGW user to be able to read an object from a bucket, that user must have **both** the `read` "op mask" bit and an IAM/bucket policy that allows `s3:GetObject`. The default operations allowed are `read`, `write`, and `delete`. Setting the value to `[]` (an empty YAML sequence) causes all "operations" in the mask to be removed, meaning that the user will not be able to perform any operations. These operation masks are supported: `read`, `write`, `delete`
+// Internally, RGW labels "operations" on persistent state as `RGW_OP_TYPE_READ` (`read`), `RGW_OP_TYPE_WRITE` (`write`), or `RGW_OP_TYPE_DELETE` (`delete`). All RGW users have an "operation mask", which does not function as a mask or filter as is typically implied by the word "mask", but as a set of allowed or permissible "operation" types the user is able to perform. The "operation mask" is applied regardless of the bucket or IAM policy. For example, in order for an RGW user to be able to read an object from a bucket, that user must have **both** the `read` "op mask" bit and an IAM/bucket policy that allows `s3:GetObject`. The default operations allowed are `read`, `write`, and `delete`. Setting the value to `[]` (an empty YAML sequence) causes all "operations" in the mask to be removed, meaning that the user will not be able to perform any operations. These operation masks are supported: `read`, `write`, `delete`
 // +enum
 // +kubebuilder:validation:Enum=read;write;delete
 type ObjectUserOpMask string
@@ -2540,7 +2540,7 @@ type CephObjectRealmList struct {
 	Items           []CephObjectRealm `json:"items"`
 }
 
-// ObjectRealmSpec represent the spec of an ObjectRealm
+// ObjectRealmSpec represents the spec of an ObjectRealm
 type ObjectRealmSpec struct {
 	Pull PullSpec `json:"pull,omitempty"`
 
@@ -2581,7 +2581,7 @@ type CephObjectZoneGroupList struct {
 	Items           []CephObjectZoneGroup `json:"items"`
 }
 
-// ObjectZoneGroupSpec represent the spec of an ObjectZoneGroup
+// ObjectZoneGroupSpec represents the spec of an ObjectZoneGroup
 type ObjectZoneGroupSpec struct {
 	// The name of the realm the zone group is a member of.
 	Realm string `json:"realm"`
@@ -2613,7 +2613,7 @@ type CephObjectZoneList struct {
 	Items           []CephObjectZone `json:"items"`
 }
 
-// ObjectZoneSpec represent the spec of an ObjectZone
+// ObjectZoneSpec represents the spec of an ObjectZone
 type ObjectZoneSpec struct {
 	// The name of the zone group the zone is a member of.
 	ZoneGroup string `json:"zoneGroup"`
@@ -2694,7 +2694,7 @@ type CephBucketTopicList struct {
 	Items           []CephBucketTopic `json:"items"`
 }
 
-// BucketTopicSpec represent the spec of a Bucket Topic
+// BucketTopicSpec represents the spec of a Bucket Topic
 type BucketTopicSpec struct {
 	// The name of the object store on which to define the topic
 	// +kubebuilder:validation:MinLength=1
@@ -2725,7 +2725,7 @@ type TopicEndpointSpec struct {
 	Kafka *KafkaEndpointSpec `json:"kafka,omitempty"`
 }
 
-// HTTPEndpointSpec represent the spec of an HTTP endpoint of a Bucket Topic
+// HTTPEndpointSpec represents the spec of an HTTP endpoint of a Bucket Topic
 type HTTPEndpointSpec struct {
 	// The URI of the HTTP endpoint to push notification to
 	// +kubebuilder:validation:MinLength=1
@@ -2738,7 +2738,7 @@ type HTTPEndpointSpec struct {
 	SendCloudEvents bool `json:"sendCloudEvents,omitempty"`
 }
 
-// AMQPEndpointSpec represent the spec of an AMQP endpoint of a Bucket Topic
+// AMQPEndpointSpec represents the spec of an AMQP endpoint of a Bucket Topic
 type AMQPEndpointSpec struct {
 	// The URI of the AMQP endpoint to push notification to
 	// +kubebuilder:validation:MinLength=1
@@ -2756,7 +2756,7 @@ type AMQPEndpointSpec struct {
 	AckLevel string `json:"ackLevel,omitempty"`
 }
 
-// KafkaEndpointSpec represent the spec of a Kafka endpoint of a Bucket Topic
+// KafkaEndpointSpec represents the spec of a Kafka endpoint of a Bucket Topic
 type KafkaEndpointSpec struct {
 	// The URI of the Kafka endpoint to push notification to
 	// +kubebuilder:validation:MinLength=1
@@ -2811,12 +2811,12 @@ type CephBucketNotificationList struct {
 	Items           []CephBucketNotification `json:"items"`
 }
 
-// BucketNotificationEvent represent the event type of the bucket notification
+// BucketNotificationEvent represents the event type of the bucket notification
 // See: https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types
 // +kubebuilder:validation:Enum="s3:ObjectCreated:*";"s3:ObjectCreated:Put";"s3:ObjectCreated:Post";"s3:ObjectCreated:Copy";"s3:ObjectCreated:CompleteMultipartUpload";"s3:ObjectRemoved:*";"s3:ObjectRemoved:Delete";"s3:ObjectRemoved:DeleteMarkerCreated";"s3:ObjectLifecycle:Expiration:Current";"s3:ObjectLifecycle:Expiration:NonCurrent";"s3:ObjectLifecycle:Expiration:DeleteMarker";"s3:ObjectLifecycle:Expiration:AbortMultipartUpload";"s3:ObjectLifecycle:Transition:Current";"s3:ObjectLifecycle:Transition:NonCurrent";"s3:LifecycleExpiration:*";"s3:LifecycleExpiration:Delete";"s3:LifecycleExpiration:DeleteMarkerCreated";"s3:LifecycleTransition";"s3:ObjectSynced:*";"s3:ObjectSynced:Create";"s3:ObjectSynced:Delete";"s3:ObjectSynced:DeletionMarkerCreated";"s3:Replication:*";"s3:Replication:Create";"s3:Replication:Delete";"s3:Replication:DeletionMarkerCreated";"s3:ObjectRestore:*";"s3:ObjectRestore:Post";"s3:ObjectRestore:Completed";"s3:ObjectRestore:Delete"
 type BucketNotificationEvent string
 
-// BucketNotificationSpec represent the spec of a Bucket Notification
+// BucketNotificationSpec represents the spec of a Bucket Notification
 type BucketNotificationSpec struct {
 	// The name of the topic associated with this notification
 	// +kubebuilder:validation:MinLength=1
@@ -2829,7 +2829,7 @@ type BucketNotificationSpec struct {
 	Filter *NotificationFilterSpec `json:"filter,omitempty"`
 }
 
-// NotificationFilterRule represent a single rule in the Notification Filter spec
+// NotificationFilterRule represents a single rule in the Notification Filter spec
 type NotificationFilterRule struct {
 	// Name of the metadata or tag
 	// +kubebuilder:validation:MinLength=1
@@ -2838,7 +2838,7 @@ type NotificationFilterRule struct {
 	Value string `json:"value"`
 }
 
-// NotificationKeyFilterRule represent a single key rule in the Notification Filter spec
+// NotificationKeyFilterRule represents a single key rule in the Notification Filter spec
 type NotificationKeyFilterRule struct {
 	// Name of the filter - prefix/suffix/regex
 	// +kubebuilder:validation:Enum=prefix;suffix;regex
@@ -2847,7 +2847,7 @@ type NotificationKeyFilterRule struct {
 	Value string `json:"value"`
 }
 
-// NotificationFilterSpec represent the spec of a Bucket Notification filter
+// NotificationFilterSpec represents the spec of a Bucket Notification filter
 type NotificationFilterSpec struct {
 	// Filters based on the object's key
 	// +optional
@@ -2860,7 +2860,7 @@ type NotificationFilterSpec struct {
 	TagFilters []NotificationFilterRule `json:"tagFilters,omitempty"`
 }
 
-// RGWServiceSpec represent the spec for RGW service
+// RGWServiceSpec represents the spec for RGW service
 type RGWServiceSpec struct {
 	// The annotations-related configuration to add/set on each rgw service.
 	// nullable
@@ -2888,7 +2888,7 @@ type CephObjectStoreAccount struct {
 	Status *ObjectStoreAccountStatus `json:"status,omitzero"` //nolint:kubeapilinter // MinProperties cannot be applied to a struct pointer field
 }
 
-// ObjectStoreAccountSpec represent the spec of a RGW Account
+// ObjectStoreAccountSpec represents the spec of an RGW Account
 type ObjectStoreAccountSpec struct {
 	// Store is the CephObjectStore the account will be associated with
 	// +required
@@ -3051,7 +3051,7 @@ type GaneshaServerSpec struct {
 	// +optional
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 
-	// LogLevel set logging level
+	// LogLevel sets logging level
 	// +optional
 	LogLevel string `json:"logLevel,omitempty"`
 

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -57,7 +57,7 @@ type CephCluster struct {
 	Status ClusterStatus `json:"status,omitempty"`
 }
 
-// CephClusterHealthCheckSpec represent the healthcheck for Ceph daemons
+// CephClusterHealthCheckSpec represents the healthcheck for Ceph daemons
 type CephClusterHealthCheckSpec struct {
 	// DaemonHealth is the health check for a given daemon
 	// +optional
@@ -242,7 +242,7 @@ type ClusterSpec struct {
 	// +nullable
 	Security ClusterSecuritySpec `json:"security,omitempty"`
 
-	// Logging represents loggings settings
+	// LogCollector represents logging settings
 	// +optional
 	// +nullable
 	LogCollector LogCollectorSpec `json:"logCollector,omitempty"`
@@ -515,7 +515,7 @@ type SslOptionsSpec struct {
 	SingleDiffieHellmanUse *bool `json:"singleDiffieHellmanUse,omitempty"`
 }
 
-// KeyManagementServiceSpec represent various details of the KMS server
+// KeyManagementServiceSpec represents various details of the KMS server
 type KeyManagementServiceSpec struct {
 	// ConnectionDetails contains the KMS connection details (address, port etc)
 	// +optional
@@ -654,7 +654,7 @@ type ClusterStatus struct {
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
-// CephDaemonsVersions show the current ceph version for different ceph daemons
+// CephDaemonsVersions shows the current ceph version for different ceph daemons
 type CephDaemonsVersions struct {
 	// Mon shows Mon Ceph version
 	// +optional
@@ -794,7 +794,7 @@ const (
 	RadosNamespaceEmptyReason ConditionReason = "RadosNamespaceEmpty"
 )
 
-// ConditionType represent a resource's status
+// ConditionType represents a resource's status
 type ConditionType string
 
 const (
@@ -1258,7 +1258,7 @@ type MirroringStatusSummarySpec struct {
 	GroupStates StatesSpec `json:"group_states,omitempty"`
 }
 
-// StatesSpec are rbd images mirroring state
+// StatesSpec is rbd images mirroring state
 type StatesSpec struct {
 	// StartingReplay is when the replay of the mirroring journal starts
 	// +optional
@@ -1451,7 +1451,7 @@ type SnapshotScheduleSpec struct {
 	// +optional
 	Path string `json:"path,omitempty"`
 
-	// Interval represent the periodicity of the snapshot.
+	// Interval represents the periodicity of the snapshot.
 	// +optional
 	Interval string `json:"interval,omitempty"`
 
@@ -1808,10 +1808,10 @@ type FilesystemMirrorInfoPeerSpec struct {
 	// UUID is the peer unique identifier
 	// +optional
 	UUID string `json:"uuid,omitempty"`
-	// Remote are the remote cluster information
+	// Remote is the remote cluster information
 	// +optional
 	Remote *PeerRemoteSpec `json:"remote,omitempty"`
-	// Stats are the stat a peer mirror
+	// Stats is the mirror stat for a given peer
 	// +optional
 	Stats *PeerStatSpec `json:"stats,omitempty"`
 }
@@ -1828,7 +1828,7 @@ type PeerRemoteSpec struct {
 	FsName string `json:"fs_name,omitempty"`
 }
 
-// PeerStatSpec are the mirror stat with a given peer
+// PeerStatSpec is the mirror stat with a given peer
 type PeerStatSpec struct {
 	// FailureCount is the number of mirroring failure
 	// +optional
@@ -1867,7 +1867,7 @@ type CephObjectStoreList struct {
 	Items           []CephObjectStore `json:"items"`
 }
 
-// ObjectStoreSpec represent the spec of a pool
+// ObjectStoreSpec represents the spec of a CephObjectStore
 // +kubebuilder:validation:XValidation:rule="!(has(self.defaultRealm) && self.defaultRealm == true && has(self.zone) && size(self.zone.name) > 0)",message="defaultRealm must not be true when zone.name is set (multisite configuration)"
 type ObjectStoreSpec struct {
 	// The metadata pool settings
@@ -2426,7 +2426,7 @@ type CephObjectStoreUserList struct {
 	Items           []CephObjectStoreUser `json:"items"`
 }
 
-// ObjectStoreUserSpec represent the spec of an Objectstoreuser
+// ObjectStoreUserSpec represents the spec of a CephObjectStoreUser
 type ObjectStoreUserSpec struct {
 	// The store the user will be created in
 	// +optional
@@ -2472,7 +2472,7 @@ type ObjectStoreUserAccountRef struct {
 	Name string `json:"name,omitempty"`
 }
 
-// Internally, RGW labels "operations" on persistent state as `RGW_OP_TYPE_READ` (`read`), `RGW_OP_TYPE_WRITE` (`write`), or `RGW_OP_TYPE_DELETE` (`delete`). All RGW users have an "operation mask", which does not function as mask or filter as is typically implied by the word "mask", but as a set of allowed or permissible "operation" types the user is able to perform. The "operation mask" is applied regardless of the bucket or IAM policy. For example, in order for an RGW user to be able to read an object from a bucket, that user must have **both** the `read` "op mask" bit and an IAM/bucket policy that allows `s3:GetObject`. The default operations allowed are `read`, `write`, and `delete`. Setting the value to `[]` (an empty YAML sequence) causes all "operations" in the mask to be removed, meaning that the user will not be able to perform any operations. These operation masks are supported: `read`, `write`, `delete`
+// Internally, RGW labels "operations" on persistent state as `RGW_OP_TYPE_READ` (`read`), `RGW_OP_TYPE_WRITE` (`write`), or `RGW_OP_TYPE_DELETE` (`delete`). All RGW users have an "operation mask", which does not function as a mask or filter as is typically implied by the word "mask", but as a set of allowed or permissible "operation" types the user is able to perform. The "operation mask" is applied regardless of the bucket or IAM policy. For example, in order for an RGW user to be able to read an object from a bucket, that user must have **both** the `read` "op mask" bit and an IAM/bucket policy that allows `s3:GetObject`. The default operations allowed are `read`, `write`, and `delete`. Setting the value to `[]` (an empty YAML sequence) causes all "operations" in the mask to be removed, meaning that the user will not be able to perform any operations. These operation masks are supported: `read`, `write`, `delete`
 // +enum
 // +kubebuilder:validation:Enum=read;write;delete
 type ObjectUserOpMask string
@@ -2609,7 +2609,7 @@ type CephObjectRealmList struct {
 	Items           []CephObjectRealm `json:"items"`
 }
 
-// ObjectRealmSpec represent the spec of an ObjectRealm
+// ObjectRealmSpec represents the spec of a CephObjectRealm
 type ObjectRealmSpec struct {
 	Pull PullSpec `json:"pull,omitempty"`
 
@@ -2650,7 +2650,7 @@ type CephObjectZoneGroupList struct {
 	Items           []CephObjectZoneGroup `json:"items"`
 }
 
-// ObjectZoneGroupSpec represent the spec of an ObjectZoneGroup
+// ObjectZoneGroupSpec represents the spec of a CephObjectZoneGroup
 type ObjectZoneGroupSpec struct {
 	// The name of the realm the zone group is a member of.
 	Realm string `json:"realm"`
@@ -2682,7 +2682,7 @@ type CephObjectZoneList struct {
 	Items           []CephObjectZone `json:"items"`
 }
 
-// ObjectZoneSpec represent the spec of an ObjectZone
+// ObjectZoneSpec represents the spec of a CephObjectZone
 type ObjectZoneSpec struct {
 	// The name of the zone group the zone is a member of.
 	ZoneGroup string `json:"zoneGroup"`
@@ -2763,7 +2763,7 @@ type CephBucketTopicList struct {
 	Items           []CephBucketTopic `json:"items"`
 }
 
-// BucketTopicSpec represent the spec of a Bucket Topic
+// BucketTopicSpec represents the spec of a Bucket Topic
 type BucketTopicSpec struct {
 	// The name of the object store on which to define the topic
 	// +kubebuilder:validation:MinLength=1
@@ -2794,7 +2794,7 @@ type TopicEndpointSpec struct {
 	Kafka *KafkaEndpointSpec `json:"kafka,omitempty"`
 }
 
-// HTTPEndpointSpec represent the spec of an HTTP endpoint of a Bucket Topic
+// HTTPEndpointSpec represents the spec of an HTTP endpoint of a Bucket Topic
 type HTTPEndpointSpec struct {
 	// The URI of the HTTP endpoint to push notification to
 	// +kubebuilder:validation:MinLength=1
@@ -2807,7 +2807,7 @@ type HTTPEndpointSpec struct {
 	SendCloudEvents bool `json:"sendCloudEvents,omitempty"`
 }
 
-// AMQPEndpointSpec represent the spec of an AMQP endpoint of a Bucket Topic
+// AMQPEndpointSpec represents the spec of an AMQP endpoint of a Bucket Topic
 type AMQPEndpointSpec struct {
 	// The URI of the AMQP endpoint to push notification to
 	// +kubebuilder:validation:MinLength=1
@@ -2827,7 +2827,7 @@ type AMQPEndpointSpec struct {
 	AckLevel string `json:"ackLevel,omitempty"`
 }
 
-// KafkaEndpointSpec represent the spec of a Kafka endpoint of a Bucket Topic
+// KafkaEndpointSpec represents the spec of a Kafka endpoint of a Bucket Topic
 type KafkaEndpointSpec struct {
 	// The URI of the Kafka endpoint to push notification to
 	// +kubebuilder:validation:MinLength=1
@@ -2882,12 +2882,12 @@ type CephBucketNotificationList struct {
 	Items           []CephBucketNotification `json:"items"`
 }
 
-// BucketNotificationEvent represent the event type of the bucket notification
+// BucketNotificationEvent represents the event type of the bucket notification
 // See: https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types
 // +kubebuilder:validation:Enum="s3:ObjectCreated:*";"s3:ObjectCreated:Put";"s3:ObjectCreated:Post";"s3:ObjectCreated:Copy";"s3:ObjectCreated:CompleteMultipartUpload";"s3:ObjectRemoved:*";"s3:ObjectRemoved:Delete";"s3:ObjectRemoved:DeleteMarkerCreated";"s3:ObjectLifecycle:Expiration:Current";"s3:ObjectLifecycle:Expiration:NonCurrent";"s3:ObjectLifecycle:Expiration:DeleteMarker";"s3:ObjectLifecycle:Expiration:AbortMultipartUpload";"s3:ObjectLifecycle:Transition:Current";"s3:ObjectLifecycle:Transition:NonCurrent";"s3:LifecycleExpiration:*";"s3:LifecycleExpiration:Delete";"s3:LifecycleExpiration:DeleteMarkerCreated";"s3:LifecycleTransition";"s3:ObjectSynced:*";"s3:ObjectSynced:Create";"s3:ObjectSynced:Delete";"s3:ObjectSynced:DeletionMarkerCreated";"s3:Replication:*";"s3:Replication:Create";"s3:Replication:Delete";"s3:Replication:DeletionMarkerCreated";"s3:ObjectRestore:*";"s3:ObjectRestore:Post";"s3:ObjectRestore:Completed";"s3:ObjectRestore:Delete"
 type BucketNotificationEvent string
 
-// BucketNotificationSpec represent the spec of a Bucket Notification
+// BucketNotificationSpec represents the spec of a Bucket Notification
 type BucketNotificationSpec struct {
 	// The name of the topic associated with this notification
 	// +kubebuilder:validation:MinLength=1
@@ -2900,7 +2900,7 @@ type BucketNotificationSpec struct {
 	Filter *NotificationFilterSpec `json:"filter,omitempty"`
 }
 
-// NotificationFilterRule represent a single rule in the Notification Filter spec
+// NotificationFilterRule represents a single rule in the Notification Filter spec
 type NotificationFilterRule struct {
 	// Name of the metadata or tag
 	// +kubebuilder:validation:MinLength=1
@@ -2909,7 +2909,7 @@ type NotificationFilterRule struct {
 	Value string `json:"value"`
 }
 
-// NotificationKeyFilterRule represent a single key rule in the Notification Filter spec
+// NotificationKeyFilterRule represents a single key rule in the Notification Filter spec
 type NotificationKeyFilterRule struct {
 	// Name of the filter - prefix/suffix/regex
 	// +kubebuilder:validation:Enum=prefix;suffix;regex
@@ -2918,7 +2918,7 @@ type NotificationKeyFilterRule struct {
 	Value string `json:"value"`
 }
 
-// NotificationFilterSpec represent the spec of a Bucket Notification filter
+// NotificationFilterSpec represents the spec of a Bucket Notification filter
 type NotificationFilterSpec struct {
 	// Filters based on the object's key
 	// +optional
@@ -2931,7 +2931,7 @@ type NotificationFilterSpec struct {
 	TagFilters []NotificationFilterRule `json:"tagFilters,omitempty"`
 }
 
-// RGWServiceSpec represent the spec for RGW service
+// RGWServiceSpec represents the spec for RGW service
 type RGWServiceSpec struct {
 	// The annotations-related configuration to add/set on each rgw service.
 	// nullable
@@ -2948,7 +2948,7 @@ type RGWServiceSpec struct {
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:subresource:status
-// CephObjectStoreAccount represent the RGW user account
+// CephObjectStoreAccount represents the RGW user account
 type CephObjectStoreAccount struct {
 	metav1.TypeMeta `json:",inline"`
 	// +required
@@ -2959,7 +2959,7 @@ type CephObjectStoreAccount struct {
 	Status *ObjectStoreAccountStatus `json:"status,omitzero"` //nolint:kubeapilinter // MinProperties cannot be applied to a struct pointer field
 }
 
-// ObjectStoreAccountSpec represent the spec of a RGW Account
+// ObjectStoreAccountSpec represents the spec of an RGW Account
 type ObjectStoreAccountSpec struct {
 	// Store is the CephObjectStore the account will be associated with
 	// +required
@@ -3122,7 +3122,7 @@ type GaneshaServerSpec struct {
 	// +optional
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 
-	// LogLevel set logging level
+	// LogLevel sets logging level
 	// +optional
 	LogLevel string `json:"logLevel,omitempty"`
 
@@ -3774,7 +3774,7 @@ type StorageScopeSpec struct {
 	// +optional
 	UseAllNodes bool `json:"useAllNodes,omitempty"`
 	// +optional
-	// Whether to always schedule OSDs on a node even if the node is not currently scheduleable or ready
+	// Whether to always schedule OSDs on a node even if the node is not currently schedulable or ready
 	ScheduleAlways bool `json:"scheduleAlways,omitempty"`
 	// +optional
 	OnlyApplyOSDPlacement bool `json:"onlyApplyOSDPlacement,omitempty"`


### PR DESCRIPTION
`pkg/apis/ceph.rook.io/v1` comments are emitted verbatim into the generated CRD `description` fields, so errors surface to users in `crds.yaml`, the helm `resources.yaml`, and `Documentation/CRDs/specification.md`.

This corrects them. The largest class is a verb disagreeing with its subject — `// IsEnabled return whether ...` instead of `returns`. Also fixed: a stray bracket, `it's` for the possessive `its`, wrong plurals, and several comments that were wrong, not just ungrammatical — `ObjectStoreSpec` called itself the spec of a pool; `NetworkEncryptionEnabled` carried `RequireMsgr2`'s comment. Comment text only: no types, fields, kubebuilder markers, or behavior change.

Comments outside `pkg/apis` were handled in #17951, now merged.

**AI assistance:** AI was used to sweep the Go sources for candidate comment errors, to adjudicate each candidate against the surrounding code, and to draft the corrections and this description.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
