### PR TITLE
rbdmirror: fix swapped log args on snapshot schedule removal

### DIFF
--- a/pkg/daemon/ceph/client/mirror.go
+++ b/pkg/daemon/ceph/client/mirror.go
@@ -318,7 +318,7 @@ func removeSnapshotSchedule(context *clusterd.Context, clusterInfo *ClusterInfo,
 		return errors.Wrapf(err, "failed to remove snapshot schedule on pool %q. %s", poolName, string(buf))
 	}
 
-	logger.Infof("successfully removed snapshot schedule %q for pool %q", poolName, snapScheduleResponse.Interval)
+	logger.Infof("successfully removed snapshot schedule %q for pool %q", snapScheduleResponse.Interval, poolName)
 	return nil
 }
 


### PR DESCRIPTION

The success log in `removeSnapshotSchedule` passes its arguments in the wrong
order for its format string:

```go
logger.Infof("successfully removed snapshot schedule %q for pool %q", poolName, snapScheduleResponse.Interval)
```

The first verb (`schedule %q`) is meant for the schedule interval and the second
(`for pool %q`) for the pool, but the arguments are supplied as `poolName` then
`snapScheduleResponse.Interval`. As a result the log prints the pool name in the
schedule slot and the interval in the pool slot, for example
`successfully removed snapshot schedule "replicapool" for pool "1d"` instead of
`successfully removed snapshot schedule "1d" for pool "replicapool"`.

`go vet` does not catch it because both arguments are strings and the format is
`%q %q`, so it is a semantic swap rather than a type mismatch.

This swaps the two arguments so the interval prints in the schedule slot and the
pool name in the pool slot. The corrected order is consistent with the sibling
success log in `enableSnapshotSchedule`
(`"successfully enabled snapshot schedule for pool %q every %q", poolName, snapSpec.Interval`)
and with the order used to build the remove command itself
(`--pool poolName ... snapScheduleResponse.Interval`).

This is a log-message-only change; there is no behavior change.

AI assistance: an AI tool helped locate the transposed arguments and draft this
change. The fix, testing, and this description were reviewed and are owned by me.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the developer guide.
- [x] Reviewed the developer guide on Submitting a Pull Request.
- [x] Reviewed AI guidelines, if AI assisted with the PR.
- [ ] Pending release notes updated with breaking and/or notable changes for the next minor release. (Not applicable: log-text-only, no breaking or notable change.)
- [ ] Documentation has been updated, if necessary. (Not applicable.)
- [ ] Unit tests have been added, if necessary. (See note below.)
- [ ] Integration tests have been added, if necessary. (Not applicable.)

(The "Resolves #" section is intentionally removed: there is no tracking issue,
which the template says to remove in that case.)
