### PR TITLE
test: assert cephfs CSI directory removal in cleanCSIDirs test

### DIFF
--- a/pkg/daemon/ceph/cleanup/hostpath_test.go
+++ b/pkg/daemon/ceph/cleanup/hostpath_test.go
@@ -41,7 +41,7 @@ func Test_cleanCSIDirs(t *testing.T) {
 	_, err = os.Stat(rbdDriverDir)
 	assert.True(t, os.IsNotExist(err))
 
-	_, err = os.Stat(rbdDriverDir)
+	_, err = os.Stat(cephFSDriverDir)
 	assert.True(t, os.IsNotExist(err))
 }
 


### PR DESCRIPTION
`Test_cleanCSIDirs` creates two CSI driver directories under the temp dir —
`rbd.csi.ceph.com` and `cephfs.csi.ceph.com` — and `cleanCSIDirs` removes every
directory whose name ends in `.csi.ceph.com`. After the call the test asserted
that the rbd directory was gone, but the second `os.Stat` re-checked
`rbdDriverDir` instead of `cephFSDriverDir`, so removal of the cephfs directory
was never actually verified even though the test created it for that purpose.

This points the second assertion at `cephFSDriverDir` so both directories that
`cleanCSIDirs` is expected to remove are checked. Test-only; no product code
change.

The assertion is meaningful rather than a tautology: narrowing the suffix check
in `cleanCSIDirs` to match only `rbd.csi.ceph.com` (leaving cephfs behind) makes
the updated test fail on the new cephfs assertion, and restoring the suffix
makes it pass again.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request).
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release. — N/A: test-only, no user-facing or breaking change.
- [ ] Documentation has been updated, if necessary. — N/A: no behavior or API change.
- [x] Unit tests have been added, if necessary. — this PR is itself a unit-test correctness fix.
- [ ] Integration tests have been added, if necessary. — N/A.

---

Description rewritten by a maintainer for accuracy and to remove unfilled
PR-template text from the original; the original report and fix are by @anxkhn
and the commit is unchanged.

AI assistance: the original change was submitted as AI-assisted (per the
author's checklist); this description was rewritten by a maintainer with AI
assistance. The code change itself is unmodified.
