### PR TITLE
csi: fix compareJSON to compare actual output

### DIFF
--- a/pkg/operator/ceph/csi/cluster_config_test.go
+++ b/pkg/operator/ceph/csi/cluster_config_test.go
@@ -54,7 +54,7 @@ func compareJSON(t *testing.T, exceptedJSON, actualJSON string) {
 	if err != nil {
 		t.Error(err)
 	}
-	actual, err = unmarshal(exceptedJSON)
+	actual, err = unmarshal(actualJSON)
 	if err != nil {
 		t.Error(err)
 	}
@@ -436,7 +436,7 @@ func TestUpdateCsiClusterConfig(t *testing.T) {
 		clusterInfo.Namespace = "rook-ceph-1"
 		s, err = updateCsiClusterConfig("[]", "rook-ceph-1", clusterInfo, &csiClusterConfigEntryMultus)
 		assert.NoError(t, err)
-		compareJSON(t, `[{"clusterID":"rook-ceph-1","monitors":["1.2.3.4:5000"],"rbd":{"netNamespaceFilePath":"/var/run/netns/rook-ceph-1","radosNamespace":"rook-ceph-1"},"namespace":"rook-ceph-1"}]`, s)
+		compareJSON(t, `[{"clusterID":"rook-ceph-1","monitors":["1.2.3.4:5000"],"rbd":{"radosNamespace":"rook-ceph-1"},"namespace":"rook-ceph-1"}]`, s)
 	})
 
 	t.Run("test crush location labels are set", func(t *testing.T) {


### PR DESCRIPTION
`compareJSON` is a test helper that compares two JSON strings by unmarshalling
each into a structure. Its second `unmarshal` call read `exceptedJSON` — the
*expected* argument — into the `actual` local instead of `actualJSON`, so the
helper compared the expected value against itself. Every `compareJSON` call in
`cluster_config_test.go`, including those feeding the real output of
`updateCsiClusterConfig`, therefore asserted nothing about the value under test.

Pointing the second `unmarshal` at `actualJSON` makes the helper compare the
function's real output. That surfaces one stale expectation in the `test multus
cluster` subtest: the expected literal still listed `rbd.netNamespaceFilePath`,
which `updateNetNamespaceFilePath` deliberately clears for entries in the
cluster namespace (holder pods are no longer used with the ceph-csi-operator).
The expected literal is corrected to match the real, current output. Test-only;
no product code change and no product bug was masked.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

---

Description rewritten by a maintainer to supply the PR-template checklist (the
original had none) and correct an inaccurate mechanism claim (it attributed the
matching literal to `omitempty`; the helper compares unmarshalled structs). The
original fix is by @anxkhn and the commit is unchanged.

AI assistance: the original change was submitted as part of an AI-assisted
contribution; this description was rewritten by a maintainer with AI assistance.
The code change itself is unmodified.
