### PR TITLE
test: assert retained capacity LastUpdated in TestCephStatus

### DIFF
--- a/pkg/operator/ceph/cluster/cephstatus_test.go
+++ b/pkg/operator/ceph/cluster/cephstatus_test.go
@@ -119,7 +119,9 @@ func TestCephStatus(t *testing.T) {
 
 	// Test for storage capacity of the ceph cluster when initially there is a disk of size
 	// 1024 bytes attached and then the disk is removed or newStatus.PgMap.TotalBytes is 0.
+	lastCapacityUpdate := formatTime(time.Now().Add(-time.Minute).UTC())
 	currentStatus.CephStatus.Capacity.TotalBytes = 1024
+	currentStatus.CephStatus.Capacity.LastUpdated = lastCapacityUpdate
 	newStatus = &cephclient.CephStatus{
 		PgMap: cephclient.PgMap{TotalBytes: 0},
 	}
@@ -127,7 +129,7 @@ func TestCephStatus(t *testing.T) {
 	aggregateStatus = toCustomResourceStatus(currentStatus, newStatus)
 	// nolint:gosec // G115 no overflow expected in the test
 	assert.Equal(t, 1024, int(aggregateStatus.Capacity.TotalBytes))
-	assert.Equal(t, formatTime(time.Now().Add(-time.Minute).UTC()), formatTime(time.Now().Add(-time.Minute).UTC()))
+	assert.Equal(t, lastCapacityUpdate, aggregateStatus.Capacity.LastUpdated)
 }
 
 func TestNewCephStatusChecker(t *testing.T) {


### PR DESCRIPTION
The capacity-retention case in `TestCephStatus` asserted
`formatTime(time.Now().Add(-time.Minute).UTC())` against the identical
expression — a value compared to itself, which can never fail and never looks at
the function under test. So the branch in `toCustomResourceStatus` that retains
the previous capacity when `newStatus.PgMap.TotalBytes == 0` was effectively
untested for its `LastUpdated` field.

This seeds a known `LastUpdated` on the current status alongside the existing
`TotalBytes = 1024`, then asserts the aggregated status carries that timestamp
through — verifying that when total bytes drop to 0 the prior capacity, including
`LastUpdated`, is retained. The two sibling cases in the same test already assert
`Capacity.LastUpdated` this way. Test-only; no product code change.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

---

Description rewritten by a maintainer to replace unedited PR-template scaffolding
(the original left the AI-disclosure section as a "phrase in your own voice"
draft). The original report and fix are by @anxkhn and the commit is unchanged.

AI assistance: the original change was submitted as AI-assisted (per the author's
checklist); this description was rewritten by a maintainer with AI assistance.
The code change itself is unmodified.
