### PR TITLE
test: assert preferred anti-affinity count in testPodSpecPlacement

### DIFF
--- a/pkg/operator/k8sutil/pod_test.go
+++ b/pkg/operator/k8sutil/pod_test.go
@@ -190,10 +190,13 @@ func testPodSpecPlacement(t *testing.T, requiredDuringScheduling bool, req, pref
 	placement.ApplyToPodSpec(&spec)
 	SetNodeAntiAffinityForPod(&spec, requiredDuringScheduling, v1.LabelHostname, map[string]string{"app": "mon"}, nil)
 
-	// should have a required anti-affinity and no preferred anti-affinity
+	// should have the expected number of required and preferred anti-affinity terms
 	assert.Equal(t,
 		req,
 		len(spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution))
+	assert.Equal(t,
+		pref,
+		len(spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution))
 }
 
 func makePlacement() cephv1.Placement {
@@ -220,7 +223,6 @@ func TestPodSpecPlacement(t *testing.T) {
 	p := cephv1.Placement{}
 	testPodSpecPlacement(t, true, 1, 0, &p)
 	testPodSpecPlacement(t, false, 0, 1, &p)
-	testPodSpecPlacement(t, false, 0, 0, &p)
 
 	// crd has other preferred and required anti-affinity setting
 	p = makePlacement()


### PR DESCRIPTION
`testPodSpecPlacement` takes a `pref` argument for the expected number of
preferred anti-affinity terms, but the helper only asserted the *required*
count. `pref` was unused, so the preferred branch of `SetNodeAntiAffinityForPod`
(the weighted term it appends when `requiredDuringScheduling == false`) went
unchecked even though several cases pass a non-zero preferred count. The dropped
assertion dates to `b91f4211c9`, which collapsed the two-boolean signature into
one and removed the preferred-count check while keeping the parameter.

This adds the missing `assert.Equal` on the preferred term count so the helper
validates both counts. With `pref` now asserted, the third empty-placement case
`testPodSpecPlacement(t, false, 0, 0, &p)` is a stale duplicate of the second
(`false, 0, 1`) — an empty placement with `required == false` yields one
preferred term, not zero — so it is removed. Test-only; no product code change.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

---

Description rewritten by a maintainer to replace verbatim PR-template scaffolding
(the original opened with a "do NOT paste this verbatim" preamble and left the
AI-disclosure as an unfilled `<Anas to write>` placeholder). The original report
and fix are by @anxkhn and the commit is unchanged.

AI assistance: the original change was submitted as AI-assisted (per the author's
checklist); this description was rewritten by a maintainer with AI assistance.
The code change itself is unmodified.
