### PR TITLE
docs: fix mirror Placement comments naming rgw pods

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -1362,7 +1362,7 @@ Placement
 </td>
 <td>
 <em>(Optional)</em>
-<p>The affinity to place the rgw pods (default is to place on any available node)</p>
+<p>The affinity to place the cephfs-mirror pods (default is to place on any available node)</p>
 </td>
 </tr>
 <tr>
@@ -2605,7 +2605,7 @@ Placement
 </td>
 <td>
 <em>(Optional)</em>
-<p>The affinity to place the rgw pods (default is to place on any available node)</p>
+<p>The affinity to place the rbd mirror pods (default is to place on any available node)</p>
 </td>
 </tr>
 <tr>
@@ -7547,7 +7547,7 @@ Placement
 </td>
 <td>
 <em>(Optional)</em>
-<p>The affinity to place the rgw pods (default is to place on any available node)</p>
+<p>The affinity to place the cephfs-mirror pods (default is to place on any available node)</p>
 </td>
 </tr>
 <tr>
@@ -14133,7 +14133,7 @@ Placement
 </td>
 <td>
 <em>(Optional)</em>
-<p>The affinity to place the rgw pods (default is to place on any available node)</p>
+<p>The affinity to place the rbd mirror pods (default is to place on any available node)</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -3584,7 +3584,7 @@ type RBDMirroringSpec struct {
 	// +optional
 	Peers MirroringPeerSpec `json:"peers,omitempty"`
 
-	// The affinity to place the rgw pods (default is to place on any available node)
+	// The affinity to place the rbd mirror pods (default is to place on any available node)
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +nullable
 	// +optional
@@ -3654,7 +3654,7 @@ type CephFilesystemMirrorList struct {
 
 // FilesystemMirroringSpec is the filesystem mirroring specification
 type FilesystemMirroringSpec struct {
-	// The affinity to place the rgw pods (default is to place on any available node)
+	// The affinity to place the cephfs-mirror pods (default is to place on any available node)
 	// +nullable
 	// +optional
 	Placement Placement `json:"placement,omitempty"`


### PR DESCRIPTION
The `Placement` field comments on `RBDMirroringSpec` and `FilesystemMirroringSpec` both read "The affinity to place the rgw pods". That wording was copy-pasted from `GatewaySpec` (the RGW gateway spec) and never updated. Neither mirror spec manages RGW pods: `RBDMirroringSpec` configures the rbd mirror daemon (`rook-ceph-rbd-mirror`) and `FilesystemMirroringSpec` configures the cephfs-mirror daemon.

These `// +optional` field comments are rendered verbatim into the generated CRD API reference, so the CephRBDMirror and CephFilesystemMirror `placement` docs currently tell readers the field places RGW pods.

This change:

- `pkg/apis/ceph.rook.io/v1/types.go`: fixes the two comments to name the correct daemon (`rbd mirror pods` for `RBDMirroringSpec`, `cephfs-mirror pods` for `FilesystemMirroringSpec`), matching the wording already used by the sibling `Resources` and `PriorityClassName` fields in each of those structs.
- `Documentation/CRDs/specification.md`: regenerated so the published CRD reference matches the corrected comments.

The legitimate "rgw pods" comment on `GatewaySpec` is left untouched. No CRD YAML change is needed: the CRD manifest build strips all placement descriptions from `crds.yaml`/`resources.yaml`, so the comment never reaches those files. This is a documentation-only change with no functional behavior change.

_AI assistance disclosure: I used an AI coding assistant to help find the mislabeled comments, cross-check the correct daemon names against the code, and regenerate the CRD reference. I reviewed and verified the change myself._

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
