### PR TITLE
mgr: use dashboard port 1024 as requested

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/config.go
+++ b/pkg/operator/ceph/cluster/mgr/config.go
@@ -55,7 +55,7 @@ type mgrConfig struct {
 // the desired port in the cluster CR.
 func (c *Cluster) dashboardInternalPort() int {
 	port := c.dashboardPublicPort()
-	if port <= minPortWithoutPrivileges {
+	if port < minPortWithoutPrivileges {
 		// If the port is less than the allowed range, set it back to the default
 		return c.dashboardDefaultPort()
 	}

--- a/pkg/operator/ceph/cluster/mgr/dashboard_test.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard_test.go
@@ -175,6 +175,18 @@ func TestStartSecureDashboard(t *testing.T) {
 	assert.Equal(t, 1025, int(svc.Spec.Ports[0].Port))
 	assert.Equal(t, 1025, int(svc.Spec.Ports[0].TargetPort.IntVal))
 
+	// Set the port to exactly 1024 (the lowest non-privileged port) and confirm the port and targetPort are the same
+	c.spec.Dashboard.Enabled = true
+	c.spec.Dashboard.Port = 1024
+	err = c.configureDashboardService()
+	assert.Nil(t, err)
+
+	svc, err = c.context.Clientset.CoreV1().Services(clusterInfo.Namespace).Get(ctx, "rook-ceph-mgr-dashboard", metav1.GetOptions{})
+	assert.Nil(t, err)
+	assert.NotNil(t, svc)
+	assert.Equal(t, 1024, int(svc.Spec.Ports[0].Port))
+	assert.Equal(t, 1024, int(svc.Spec.Ports[0].TargetPort.IntVal))
+
 	// Fall back to the default port
 	c.spec.Dashboard.Enabled = true
 	c.spec.Dashboard.Port = 0


### PR DESCRIPTION

> The template's "Resolves #" section is intentionally omitted: there is no
> existing tracking issue for this. If you open one first, add it back.

**What**

`dashboardInternalPort()` decides the mgr container/targetPort for the Ceph
dashboard. Its guard used `<=`:

```go
if port <= minPortWithoutPrivileges { // minPortWithoutPrivileges = 1024
    return c.dashboardDefaultPort()
}
```

Linux privileged ports are 0-1023, so 1024 is the lowest *non*-privileged port and
should be honored as-is like any port >= 1024. With `<=`, a requested
`Dashboard.Port: 1024` fell into the "privileged" branch and the container/targetPort
was reset to the default (7000 HTTP / 8443 HTTPS). The Service `Port` stayed 1024
while its `targetPort` became the default, a silent mismatch that contradicts both
the constant's own comment ("Ports below 1024 require extra privileges") and the
adjacent `Port: 1025` case, which is honored correctly.

**Fix**

Change the comparison to `<` so only ports strictly below 1024 revert to the default.
Behavior for every other input is unchanged: `< 1024` still reverts, `> 1024` still
used as-is; only the exact 1024 boundary now behaves like 1025.

**Test**

Adds a `Port: 1024` boundary case to `TestStartSecureDashboard` (mirrors the existing
`Port: 1025` case), asserting the Service `Port` and `targetPort` are both 1024. It is
red before the fix (targetPort would be 8443) and green after.

**AI assistance disclosure**

AI tooling assisted with investigating and drafting this change. I reviewed,
tested, and take ownership of it.

**Checklist**

- [x] **Commit Message Formatting**: follows the developer guide (`mgr:` scope,
  subject 41 chars, body wrapped, blank lines around body and trailer).
- [x] Reviewed the developer guide on Submitting a Pull Request.
- [x] Reviewed AI guidelines (AI assisted with the PR).
- [ ] Pending release notes: not needed (small boundary bug fix, not a breaking or
  notable user-facing change).
- [ ] Documentation: not needed.
- [x] Unit tests have been added.
- [ ] Integration tests: not needed (covered by the unit test; no cluster behavior
  path added).

---

## Verification summary (from implement + independent verify)

Go 1.26.4, all run by the loop:

- `gofmt -l` on both changed files: clean.
- `go vet ./pkg/operator/ceph/cluster/mgr/`: clean.
- `go test ./pkg/operator/ceph/cluster/mgr/ -run TestStartSecureDashboard -count=1`: ok.
- `go test ./pkg/operator/ceph/cluster/mgr/ -count=1` (full package): ok.
- Red/green: reverting `<` to `<=` fails the new case at `dashboard_test.go:188`
  (expected 1024, got 8443); restoring `<` is green.

Downstream confirmation (why it is not cosmetic): `dashboardInternalPort()` feeds the
Service `TargetPort` (spec.go:342), the container `ContainerPort` (spec.go:198), and
the ceph mgr `server_port`/`ssl_server_port` (dashboard.go:183). In the red run the
log showed `mgr/dashboard/server_port 8443` for a requested 1024.

## Duplicate / competing-PR gate (re-checked at draft time)

- `origin/master` still has `if port <= minPortWithoutPrivileges` at config.go:58
  (fetched now): unfixed upstream, not a duplicate.
- No open PR references `dashboardInternalPort` or `minPortWithoutPrivileges`, and no
  open PR has "dashboard port" in its title (`gh search`/`gh pr list` all empty).
