### PR TITLE
core: fix data race reading exec output on timeout

### DIFF
--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -127,6 +127,11 @@ func executeCommandWithTimeout(timeout time.Duration, command string, stdin *str
 					logger.Errorf("Failed to kill process %s: %v", command, err)
 					e = fmt.Errorf("%s the command %s to return after interrupt signal was sent. Tried to kill the process but that failed: %v", TimeoutWaitingForMessage, command, err)
 				} else {
+					// Wait for cmd.Wait() to return before reading the output buffer.
+					// Kill() only signals the process; it does not wait for the internal
+					// goroutines that copy the command's output into b to finish. Reading b
+					// before Wait() returns would race with those writers.
+					<-done
 					e = fmt.Errorf("%s the command %s to return", TimeoutWaitingForMessage, command)
 				}
 				return strings.TrimSpace(b.String()), e

--- a/pkg/util/exec/exec_test.go
+++ b/pkg/util/exec/exec_test.go
@@ -202,3 +202,21 @@ func TestExecuteCommandWithTimeout(t *testing.T) {
 		})
 	}
 }
+
+// TestExecuteCommandWithTimeoutKillPath exercises the timeout branch where the
+// command ignores the interrupt signal and must be killed, while it keeps
+// writing to stdout. The output buffer must only be read after cmd.Wait()
+// returns; otherwise the read races with the goroutines that copy the command's
+// output into the buffer. Run with `-race` to catch a regression.
+func TestExecuteCommandWithTimeoutKillPath(t *testing.T) {
+	// The child ignores SIGINT and continuously writes to stdout, so the
+	// interrupt is sent first and the kill path is taken while writers are active.
+	stdin := ""
+	_, err := executeCommandWithTimeout(
+		50*time.Millisecond,
+		"sh", &stdin,
+		"-c", "trap '' INT; while true; do echo x; done",
+	)
+	assert.Error(t, err)
+	assert.True(t, IsTimeout(err))
+}


### PR DESCRIPTION

`executeCommandWithTimeout` in `pkg/util/exec/exec.go` wires a single
`bytes.Buffer` to both `cmd.Stdout` and `cmd.Stderr`, then joins the command in a
goroutine via `done <- cmd.Wait()`. On the timeout path, after the interrupt
signal has already been sent, it calls `cmd.Process.Kill()` and immediately reads
the buffer with `strings.TrimSpace(b.String())` without waiting on the `done`
channel.

`cmd.Process.Kill()` only sends the signal; it does not wait for the process to
exit or for the internal output-copier goroutines that `os/exec` spawns in
`cmd.Start()` (and joins only in `cmd.Wait()`) to finish writing into the buffer.
So reading the buffer on the kill path races with those writers. The Go race
detector flags it: the read at `bytes.(*Buffer).String()` races a write via
`os/exec.(*Cmd).writerDescriptor.func1 -> io.Copy -> bytes.(*Buffer).ReadFrom`.
The other reads in the function are on the `case err := <-done:` branch, where
`cmd.Wait()` has already returned, so they are safe; only the timeout+kill read is
racy.

`executeCommandWithTimeout` backs `RunWithTimeout` and is used for
ceph/radosgw-admin CLI calls, so the timeout path runs in exactly the degraded
scenarios (a hung or slow command being killed) where a corrupted read of the
buffer is most likely and least welcome.

The fix waits on the existing buffered `done` channel after a successful
`Kill()`, before reading the buffer. The read then happens-after `cmd.Wait()`,
matching the already-safe `<-done` select branch. `SIGKILL` cannot be caught, so
the process terminates, `Wait()` returns, and the cap-1 `done` channel drains
once, with no deadlock and no goroutine leak. The non-timeout branch is
unchanged. The rare `Kill()`-failure sub-branch is intentionally left
non-blocking: blocking there could hang on an unkillable process, and it is
already a best-effort degraded return.

A regression test (`TestExecuteCommandWithTimeoutKillPath`) drives the kill path
with a child that ignores `SIGINT` while continuously writing to stdout, under a
short timeout. It fails under `-race` before this change and passes after.

### Testing

- `go test -race ./pkg/util/exec/ -run TestExecuteCommandWithTimeoutKillPath -count=1`
  fails (DATA RACE) without the fix and passes with it. Verified red->green by
  reverting only `exec.go`.
- `go test -race ./pkg/util/exec/ -count=1` -> ok
- `go build ./pkg/util/exec/...`, `gofmt`, `go vet`, `golangci-lint` -> clean.

### AI assistance disclosure (keep this, adapt the wording)

AI tooling assisted in drafting the regression test and this description; the fix,
its design tradeoffs, and all testing were reviewed and validated by me.

---

## PR template checklist (how each item applies)

- [x] Commit Message Formatting: conventional `core:` subject, 50 chars, blank
      line before body, `Signed-off-by` footer with a leading blank line, no
      emojis/em dashes. Follows the development-flow commit-structure guide.
- [x] Reviewed the developer guide on submitting a PR.
- [x] Reviewed AI guidelines (AI assisted): disclosure included above; commit body
      and PR text are Anas's own reasoning, not LLM output.
- [ ] Pending release notes: NOT needed. This is a bug fix on the timeout path with
      no breaking change and no Ceph-config override; `PendingReleaseNotes.md` is
      for breaking/notable changes only.
- [ ] Documentation: NOT needed (internal exec utility behavior; no user-facing
      surface changes).
- [x] Unit tests added: `TestExecuteCommandWithTimeoutKillPath`.
- [ ] Integration tests: NOT needed (unit-level race, no cluster behavior change).

Note on the "Resolves #" section: there is no tracking issue, so that section of
the template must be REMOVED (per the template's own instruction), not left blank.
