### PR TITLE
csi: do not log peer bootstrap token secret

### DIFF
--- a/pkg/operator/ceph/csi/peermap/config.go
+++ b/pkg/operator/ceph/csi/peermap/config.go
@@ -348,7 +348,10 @@ func decodePeerToken(token string) (*cephclient.PeerToken, error) {
 		return nil, errors.Wrap(err, "failed to unmarshal decoded token")
 	}
 
-	logger.Debugf("peer cluster info %+v", decodedTokenToGo)
+	// Log only the non-sensitive fields; the token embeds the peer cluster's
+	// cephx auth key (decodedTokenToGo.Key), which must never be logged.
+	logger.Debugf("decoded peer cluster info fsid=%q clientID=%q monHost=%q namespace=%q",
+		decodedTokenToGo.ClusterFSID, decodedTokenToGo.ClientID, decodedTokenToGo.MonHost, decodedTokenToGo.Namespace)
 
 	return &decodedTokenToGo, nil
 }

--- a/pkg/operator/ceph/csi/peermap/config_test.go
+++ b/pkg/operator/ceph/csi/peermap/config_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package peermap
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -26,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/pkg/capnslog"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/clusterd"
@@ -404,6 +406,23 @@ func TestDecodePeerToken(t *testing.T) {
 	// Invalid token
 	_, err = decodePeerToken("invalidToken")
 	assert.Error(t, err)
+}
+
+func TestDecodePeerTokenDoesNotLogSecret(t *testing.T) {
+	// The peer token embeds the peer cluster's cephx auth key, which must never
+	// be written to the operator logs, even at debug level.
+	logBuf := bytes.NewBuffer([]byte{})
+	capnslog.SetFormatter(capnslog.NewLogFormatter(logBuf, "", 0))
+	capnslog.SetGlobalLogLevel(capnslog.DEBUG)
+
+	decodedToken, err := decodePeerToken(fakeTokenPeer1)
+	assert.NoError(t, err)
+
+	logOutput := logBuf.String()
+	assert.NotEmpty(t, decodedToken.Key)
+	assert.NotContains(t, logOutput, decodedToken.Key)
+	// The non-sensitive fields are still useful for diagnostics.
+	assert.Contains(t, logOutput, decodedToken.Namespace)
 }
 
 func TestCreateOrUpdateConfig(t *testing.T) {


### PR DESCRIPTION
`decodePeerToken()` in `pkg/operator/ceph/csi/peermap/config.go` decoded the
base64 RBD-mirror bootstrap peer token into a `cephclient.PeerToken` and logged
the whole struct at debug level (`logger.Debugf("peer cluster info %+v", ...)`).
`PeerToken` embeds `Key`, the peer cluster's cephx auth secret, so with
`ROOK_LOG_LEVEL=DEBUG` that credential was written to the operator log in
plaintext (CWE-532, sensitive information in a log file).

This logs only the non-sensitive fields (fsid, client id, mon host, namespace),
keeping the message useful for diagnostics while dropping `Key`. A regression
test (`TestDecodePeerTokenDoesNotLogSecret`) captures the debug output and
asserts the key is absent while a non-sensitive field is still present;
restoring the old `%+v` line makes it fail.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

---

Description rewritten by a maintainer for accuracy: the original reworded the
checklist and checked the Documentation and Integration-tests boxes for changes
not in the diff; it now uses the verbatim template with only the applicable
boxes checked, and the unfilled AI-disclosure template comment is removed. The
original report and fix are by @anxkhn and the commit is unchanged. Labeled
`backport-release-1.20` (backported security fix).

AI assistance: the original change was submitted as AI-assisted (per the author's
checklist); this description was rewritten by a maintainer with AI assistance.
The code change itself is unmodified.
