### PR TITLE
osd: archive crash on OSD removal

### DIFF
--- a/pkg/daemon/ceph/osd/remove.go
+++ b/pkg/daemon/ceph/osd/remove.go
@@ -222,7 +222,7 @@ func archiveCrash(clusterdContext *clusterd.Context, clusterInfo *client.Cluster
 		logger.Errorf("failed to list ceph crash. %v", err)
 		return
 	}
-	if crash != nil {
+	if len(crash) == 0 {
 		logger.Info("no ceph crash to silence")
 		return
 	}

--- a/pkg/daemon/ceph/osd/remove_test.go
+++ b/pkg/daemon/ceph/osd/remove_test.go
@@ -21,11 +21,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	oposd "github.com/rook/rook/pkg/operator/ceph/cluster/osd"
 	testexec "github.com/rook/rook/pkg/operator/test"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -160,4 +162,54 @@ func testVolumeClaim(name string) cephv1.VolumeClaimTemplate {
 	}}
 	claim.Name = name
 	return claim
+}
+
+func TestArchiveCrash(t *testing.T) {
+	t.Run("archives the crash for the removed osd", func(t *testing.T) {
+		crashList := `[
+			{
+				"crash_id": "2020-11-09_13:58:08.230130Z_ca918f58-c078-444d-a91a-bd972c14c155",
+				"entity_name": "osd.1"
+			},
+			{
+				"crash_id": "2020-11-09_13:58:08.230130Z_bd972c14-c155-444d-a91a-ca918f58c078",
+				"entity_name": "osd.0"
+			}
+		]`
+		archivedCrashID := ""
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			if args[0] == "crash" && args[1] == "ls" {
+				return crashList, nil
+			}
+			if args[0] == "crash" && args[1] == "archive" {
+				archivedCrashID = args[2]
+				return "", nil
+			}
+			return "", errors.Errorf("unexpected ceph command %q", args)
+		}
+		context := &clusterd.Context{Executor: executor}
+
+		archiveCrash(context, client.AdminTestClusterInfo("mycluster"), 0)
+		assert.Equal(t, "2020-11-09_13:58:08.230130Z_bd972c14-c155-444d-a91a-ca918f58c078", archivedCrashID)
+	})
+
+	t.Run("does not archive when there is no crash", func(t *testing.T) {
+		archiveCalled := false
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			if args[0] == "crash" && args[1] == "ls" {
+				return "[]", nil
+			}
+			if args[0] == "crash" && args[1] == "archive" {
+				archiveCalled = true
+				return "", nil
+			}
+			return "", errors.Errorf("unexpected ceph command %q", args)
+		}
+		context := &clusterd.Context{Executor: executor}
+
+		archiveCrash(context, client.AdminTestClusterInfo("mycluster"), 0)
+		assert.False(t, archiveCalled)
+	})
 }


### PR DESCRIPTION

> IMPORTANT (Rook AI-guidelines): reviewers want *your* reasoning, not generated
> text. Read the draft below, then rewrite the description in your own words before
> opening the PR. The AI-assistance disclosure line must stay. Do not add
> `co-authored-by` / `generated-by` / `assisted-by` commit trailers (the guidelines
> say they are not necessary).

```markdown
`archiveCrash` is supposed to silence the `RECENT_CRASH` Ceph health warning for
a removed OSD by archiving that OSD's crash. The early-return guard was inverted:

```go
if crash != nil {
    logger.Info("no ceph crash to silence")
    return
}
```

`GetCrash` -> `GetCrashList` unmarshals `ceph crash ls` output with
`json.Unmarshal(output, &crash)` where `crash` is `[]CrashList`. Unmarshaling a
JSON array always yields a non-nil slice (an empty list `[]` gives a non-nil,
zero-length slice; only a literal `null`, which `ceph crash ls` never emits,
gives nil). So `crash != nil` was always true: `archiveCrash` always logged
"no ceph crash to silence" and returned before the archive loop, making the
loop unreachable. The result is that OSD removal never archived the crash and
the health warning was left lingering, the exact situation the function exists
to prevent.

This changes the guard to `len(crash) == 0`, which short-circuits only the
genuinely-empty case (and is also safe for the theoretical nil case), so a
populated list now runs the archive loop as intended.

Added `TestArchiveCrash` covering both paths: a populated crash list (the crash
matching the removed `osd.<id>` is archived) and an empty list `[]` (nothing is
archived and the "no ceph crash to silence" path runs).

**AI assistance disclosure (per Rook AI guidelines):** an AI tool assisted in
locating the inverted guard and drafting the unit test. I reviewed the root
cause, the fix, and the test; I verified the fix and understand and own this
change.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
```

Note on the "Resolves #" line: the template says to remove that section when no
tracking issue is resolved. There is no matching upstream issue, so it is omitted
above. (Optional: you may open a short issue describing the bug first per Rook's
"consider opening an issue" best practice, then add `Resolves #N`.)
