### PR TITLE
mon: fix data race on failedMonSchedule during scheduling

### DIFF
--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -1001,14 +1001,18 @@ func (c *Cluster) assignMons(mons []*monConfig, monsToSkipReconcile sets.Set[str
 			result, err := waitForMonitorScheduling(c, deployment)
 			if err != nil {
 				log.NamespacedError(c.Namespace, logger, "failed to schedule mon %q. %v", mon.DaemonName, err)
+				resultLock.Lock()
 				failedMonSchedule = true
+				resultLock.Unlock()
 				return
 			}
 
 			nodeChoice := result.Node
 			if nodeChoice == nil {
 				log.NamespacedError(c.Namespace, logger, "failed to schedule monitor %q", mon.DaemonName)
+				resultLock.Lock()
 				failedMonSchedule = true
+				resultLock.Unlock()
 				return
 			}
 
@@ -1021,7 +1025,9 @@ func (c *Cluster) assignMons(mons []*monConfig, monsToSkipReconcile sets.Set[str
 				schedule, err = getNodeInfoFromNode(*nodeChoice)
 				if err != nil {
 					log.NamespacedError(c.Namespace, logger, "failed to get node info for node %q. %v", nodeChoice.Name, err)
+					resultLock.Lock()
 					failedMonSchedule = true
+					resultLock.Unlock()
 					return
 				}
 			} else {

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1597,4 +1598,51 @@ func TestFloatingMonLabelsAndSchedulingSkip(t *testing.T) {
 	assert.Contains(t, scheduled, "a")
 	assert.Contains(t, scheduled, "b")
 	assert.NotContains(t, scheduled, "c")
+}
+
+// TestAssignMonsConcurrentSchedulingFailure ensures assignMons does not race on
+// the shared failedMonSchedule flag when multiple mons fail to schedule at the
+// same time. Each mon is scheduled in its own goroutine, so several goroutines
+// can set failedMonSchedule concurrently. Run with -race to catch the write-write
+// data race.
+func TestAssignMonsConcurrentSchedulingFailure(t *testing.T) {
+	namespace := "ns"
+	c := newFloatingMonTestCluster(t, namespace)
+
+	origWaitForMonitorScheduling := waitForMonitorScheduling
+	defer func() { waitForMonitorScheduling = origWaitForMonitorScheduling }()
+
+	mons := []*monConfig{
+		{
+			ResourceName: "rook-ceph-mon-a", DaemonName: "a", Port: DefaultMsgr1Port,
+			DataPathMap: config.NewStatefulDaemonDataPathMap("/var/lib/rook", dataDirRelativeHostPath("a"), config.MonType, "a", namespace),
+		},
+		{
+			ResourceName: "rook-ceph-mon-b", DaemonName: "b", Port: DefaultMsgr1Port,
+			DataPathMap: config.NewStatefulDaemonDataPathMap("/var/lib/rook", dataDirRelativeHostPath("b"), config.MonType, "b", namespace),
+		},
+		{
+			ResourceName: "rook-ceph-mon-d", DaemonName: "d", Port: DefaultMsgr1Port,
+			DataPathMap: config.NewStatefulDaemonDataPathMap("/var/lib/rook", dataDirRelativeHostPath("d"), config.MonType, "d", namespace),
+		},
+	}
+
+	// release all scheduling goroutines at the same time so their concurrent
+	// writes to failedMonSchedule overlap, making the data race detectable
+	var ready sync.WaitGroup
+	ready.Add(len(mons))
+	start := make(chan struct{})
+	waitForMonitorScheduling = func(c *Cluster, d *apps.Deployment) (SchedulingResult, error) {
+		ready.Done()
+		<-start
+		return SchedulingResult{}, errors.New("mock scheduling failure")
+	}
+	go func() {
+		ready.Wait()
+		close(start)
+	}()
+
+	err := c.assignMons(mons, sets.New[string]())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to schedule mons")
 }


### PR DESCRIPTION
`assignMons` schedules each mon in its own goroutine and shares a
`failedMonSchedule` bool recording whether any mon failed to schedule. A
`resultLock` mutex already guards the sibling `c.mapping.Schedule[...]` map write
in those goroutines, but the three `failedMonSchedule = true` assignments were
made without holding it. When two or more mons fail to schedule at once, their
goroutines write the flag concurrently — a write-write data race (introduced in
`772865fa0`). It is benign in practice but a genuine race.

This guards each `failedMonSchedule = true` write with the existing `resultLock`,
matching the adjacent map update; no control-flow change. The post-`Wait()` read
stays unlocked because `Wait()` establishes happens-before ordering after every
write. A regression test (`TestAssignMonsConcurrentSchedulingFailure`) fails
several mons at once via a barrier so the writes overlap, and reports the race
under `-race` before the fix. Note: rook's unit CI does not run `-race`, so the
red-before/green-after is observable locally / under `-race`, not in default CI.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

---

Description rewritten by a maintainer to replace unreviewed PR-template
scaffolding (the original wrapped the text in a "delete this quote block" LLM
preamble). The original report and fix are by @anxkhn and the commit is
unchanged. Labeled `backport-release-1.20`.

AI assistance: the original change was submitted as AI-assisted (per the author's
checklist); this description was rewritten by a maintainer with AI assistance.
The code change itself is unmodified.
