### PR TITLE
object: return an error when the multisite zone is not found

### DIFF
--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -671,7 +671,7 @@ func (r *ReconcileCephObjectStore) retrieveMultisiteZone(store *cephv1.CephObjec
 	_, err := RunAdminCommandNoMultisite(objContext, true, "zone", "get", realmArg, zoneGroupArg, zoneArg)
 	if err != nil {
 		// ENOENT mean "No such file or directory"
-		if code, err := exec.ExtractExitCode(err); err == nil && code == int(syscall.ENOENT) {
+		if code, ok := exec.ExitStatus(err); ok && code == int(syscall.ENOENT) {
 			return waitForRequeueIfObjectStoreNotReady, errors.Wrapf(err, "ceph zone %q not found", store.Spec.Zone.Name)
 		} else {
 			return waitForRequeueIfObjectStoreNotReady, errors.Wrapf(err, "radosgw-admin zone get failed with code %d", code)

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"os"
 	"reflect"
+	"syscall"
 	"testing"
 	"time"
 
@@ -46,6 +47,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
+	kexec "k8s.io/client-go/util/exec"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -975,6 +977,62 @@ func TestCephObjectStoreControllerZoneNotReady(t *testing.T) {
 			assert.True(t, res.RequeueAfter > 0, "expected requeue while waiting for zone Ready")
 		})
 	}
+}
+
+func TestRetrieveMultisiteZone(t *testing.T) {
+	// When "radosgw-admin zone get" fails with ENOENT the Ceph zone does not exist
+	// yet (the CephObjectZone is configured asynchronously by its own controller).
+	// retrieveMultisiteZone must return a non-nil error so the caller requeues and
+	// waits for the zone, instead of proceeding to reconcile the object store
+	// against a zone that is not there.
+	zoneName := "zone-a"
+	zoneGroupName := "zonegroup-a"
+	realmName := "realm-a"
+
+	objectStore := &cephv1.CephObjectStore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      store,
+			Namespace: namespace,
+		},
+	}
+	objectStore.Spec.Zone.Name = zoneName
+
+	newReconciler := func(zoneGetErr error) *ReconcileCephObjectStore {
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
+				if args[0] == "zone" && args[1] == "get" {
+					return "", zoneGetErr
+				}
+				return "", nil
+			},
+		}
+		return &ReconcileCephObjectStore{
+			context:     &clusterd.Context{Executor: executor},
+			clusterInfo: client.AdminTestClusterInfo(namespace),
+		}
+	}
+
+	t.Run("zone not found returns an error and requeues", func(t *testing.T) {
+		enoentErr := kexec.CodeExitError{Err: errors.New("exit status 2"), Code: int(syscall.ENOENT)}
+		r := newReconciler(enoentErr)
+
+		res, err := r.retrieveMultisiteZone(objectStore, zoneGroupName, realmName)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+		assert.NotContains(t, err.Error(), "failed with code")
+		assert.True(t, res.RequeueAfter > 0, "expected requeue while waiting for the zone to be created")
+	})
+
+	t.Run("other zone get failure returns an error and requeues", func(t *testing.T) {
+		otherErr := kexec.CodeExitError{Err: errors.New("exit status 13"), Code: int(syscall.EACCES)}
+		r := newReconciler(otherErr)
+
+		res, err := r.retrieveMultisiteZone(objectStore, zoneGroupName, realmName)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed with code")
+		assert.NotContains(t, err.Error(), "not found")
+		assert.True(t, res.RequeueAfter > 0, "expected requeue on a zone get failure")
+	})
 }
 
 func TestCephObjectExternalStoreController(t *testing.T) {


### PR DESCRIPTION
because there is no upstream tracking issue)

`retrieveMultisiteZone` swallowed the "zone not found" failure and returned a
nil error, so the object store reconcile did not requeue and instead proceeded to
reconcile the service, admin ops endpoint, and pools as if the multisite zone
existed.

The cause is `exec.ExtractExitCode`, which returns `(code, nil)` on success and
shadows the outer command error inside the `if`/`else`:

```go
if code, err := exec.ExtractExitCode(err); err == nil && code == int(syscall.ENOENT) {
    return waitForRequeueIfObjectStoreNotReady, errors.Wrapf(err, "ceph zone %q not found", store.Spec.Zone.Name)
} else {
    return waitForRequeueIfObjectStoreNotReady, errors.Wrapf(err, "radosgw-admin zone get failed with code %d", code)
}
```

In the ENOENT branch the shadowed `err` is always nil (that branch only runs when
`err == nil`), and in the `else` branch it is nil whenever the exit code was
extracted successfully. `errors.Wrapf(nil, ...)` returns nil, so the function
returned `(waitForRequeueIfObjectStoreNotReady, nil)`. The caller only propagates
the requeue when the error is non-nil, so the requeue was discarded.

The "zone not found" case is a normal transient state during multisite bootstrap:
the `CephObjectZone` is configured asynchronously by its own controller, so
`radosgw-admin zone get` can legitimately fail with ENOENT until the zone is
created. That is exactly when the reconcile should back off and requeue.

This switches to `exec.ExitStatus`, matching the zonegroup, realm, and zone
controllers. It returns `(code, ok)` without shadowing `err`, so both branches
return the real, non-nil command error and the caller requeues until the zone
exists.

Adds `TestRetrieveMultisiteZone` covering both the ENOENT (zone not found) path
and a non-ENOENT failure path, asserting each returns a non-nil error and a
requeue.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the developer guide.
- [x] Reviewed the developer guide on Submitting a Pull Request
- [x] Reviewed AI guidelines, if AI assisted with the PR.
- [ ] Pending release notes updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

Notes on the unchecked boxes (decide before submitting):
- Pending release notes: this is a bug fix, not a breaking/notable feature. Rook's
  PendingReleaseNotes is for breaking/notable changes, so leaving it unchecked/out
  is defensible. If you want it noted, add a one-line bug-fix entry.
- Docs / integration tests: none needed for this internal control-flow fix; the
  unit test is the right level.

AI-assistance disclosure (required by Rook's AI guidelines): add a short sentence
in your own words stating AI assisted with investigation/tests but you reviewed
and own the change. Do not omit this.

---

## The change (surgical: 2 files)

`pkg/operator/ceph/object/controller.go` (1 line, at retrieveMultisiteZone):

```diff
-		if code, err := exec.ExtractExitCode(err); err == nil && code == int(syscall.ENOENT) {
+		if code, ok := exec.ExitStatus(err); ok && code == int(syscall.ENOENT) {
```

`pkg/operator/ceph/object/controller_test.go` (+58): new `TestRetrieveMultisiteZone`
with two subtests (ENOENT -> "not found"; EACCES -> "failed with code"), each
asserting a non-nil error and `RequeueAfter > 0`. Imports `syscall` and
`kexec "k8s.io/client-go/util/exec"`.
