### PR TITLE
external: add watcher to the rns controler for watching csi and clien…

### DIFF
--- a/pkg/operator/ceph/pool/radosnamespace/controller.go
+++ b/pkg/operator/ceph/pool/radosnamespace/controller.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -46,8 +47,10 @@ import (
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -97,7 +100,7 @@ func Add(mgr manager.Manager, context *clusterd.Context, opManagerContext contex
 	}); err != nil {
 		return fmt.Errorf("failed to index CephRadosNamespaceName by %s: %v", cephRNSNameIndex, err)
 	}
-	return add(mgr, newReconciler(mgr, context, opManagerContext, opConfig))
+	return add(opManagerContext, mgr, newReconciler(mgr, context, opManagerContext, opConfig))
 }
 
 // newReconciler returns a new reconcile.Reconciler
@@ -113,7 +116,7 @@ func newReconciler(mgr manager.Manager, context *clusterd.Context, opManagerCont
 	}
 }
 
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
+func add(opManagerContext context.Context, mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
 	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})
 	if err != nil {
@@ -139,7 +142,71 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Build handler to map events to CephBlockPoolRadosNamespace reconcile requests
+	clientProfileHandler, err := opcontroller.ObjectToCRMapper[*cephv1.CephBlockPoolRadosNamespaceList, *csiopv1.ClientProfile](
+		opManagerContext,
+		mgr.GetClient(),
+		&cephv1.CephBlockPoolRadosNamespaceList{},
+		mgr.GetScheme(),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Watch for ClientProfile changes
+	err = c.Watch(
+		source.Kind(
+			mgr.GetCache(),
+			&csiopv1.ClientProfile{TypeMeta: metav1.TypeMeta{Kind: "ClientProfile", APIVersion: fmt.Sprintf("%s/%s", csiopv1.GroupVersion.Group, csiopv1.GroupVersion.Version)}},
+			handler.TypedEnqueueRequestsFromMapFunc(clientProfileHandler),
+			opcontroller.WatchControllerPredicate[*csiopv1.ClientProfile](mgr.GetScheme()),
+		),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Build handler to map Secret events to CephBlockPoolRadosNamespace reconcile requests
+	secretHandler, err := opcontroller.ObjectToCRMapper[*cephv1.CephBlockPoolRadosNamespaceList, *corev1.Secret](
+		opManagerContext,
+		mgr.GetClient(),
+		&cephv1.CephBlockPoolRadosNamespaceList{},
+		mgr.GetScheme(),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Watch for CSI secret changes (rbd provisioner/node secrets)
+	err = c.Watch(
+		source.Kind(
+			mgr.GetCache(),
+			&corev1.Secret{TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: corev1.SchemeGroupVersion.String()}},
+			handler.TypedEnqueueRequestsFromMapFunc(secretHandler),
+			predicate.TypedFuncs[*corev1.Secret]{
+				CreateFunc: func(e event.TypedCreateEvent[*corev1.Secret]) bool {
+					return isCSIRBDSecret(e.Object.GetName())
+				},
+				UpdateFunc: func(e event.TypedUpdateEvent[*corev1.Secret]) bool {
+					return isCSIRBDSecret(e.ObjectNew.GetName())
+				},
+				DeleteFunc: func(e event.TypedDeleteEvent[*corev1.Secret]) bool {
+					return isCSIRBDSecret(e.Object.GetName())
+				},
+			},
+		),
+	)
+	if err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// check on for rbd secrets
+func isCSIRBDSecret(name string) bool {
+	return strings.HasPrefix(name, csi.CsiRBDProvisionerSecret) ||
+		strings.HasPrefix(name, csi.CsiRBDNodeSecret)
 }
 
 // Reconcile reads that state of the cluster for a CephBlockPoolRadosNamespace

--- a/pkg/operator/ceph/pool/radosnamespace/controller_test.go
+++ b/pkg/operator/ceph/pool/radosnamespace/controller_test.go
@@ -708,3 +708,26 @@ func TestGetRadosNamespaceName(t *testing.T) {
 		})
 	}
 }
+
+func TestIsCSIRBDSecret(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"rbd provisioner secret exact", csi.CsiRBDProvisionerSecret, true},
+		{"rbd node secret exact", csi.CsiRBDNodeSecret, true},
+		{"rbd provisioner secret with suffix", csi.CsiRBDProvisionerSecret + "-cluster1", true},
+		{"rbd node secret with suffix", csi.CsiRBDNodeSecret + "-cluster1", true},
+		{"cephfs node secret", csi.CsiCephFSNodeSecret, false},
+		{"cephfs provisioner secret", csi.CsiCephFSProvisionerSecret, false},
+		{"unrelated secret", "my-app-secret", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isCSIRBDSecret(tt.input))
+		})
+	}
+}


### PR DESCRIPTION
…t profile

if the csi secret is updated or a client profile is updated we need a re-reconile of rns
So added the watcher for it

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
