### PR TITLE
ci: Simplify canary-arm64 image selection to a matrix variable 

### DIFF
--- a/.github/workflows/ceph-arm64-suite-test.yml
+++ b/.github/workflows/ceph-arm64-suite-test.yml
@@ -1,0 +1,75 @@
+name: Reusable Ceph arm64 suite integration tests
+on:
+  # ONLY on.workflow_call ; call this from other files if needed
+  workflow_call:
+    inputs:
+      ceph_images:
+        description: "JSON list of Ceph images for creating Ceph cluster"
+        required: true
+        type: string
+
+defaults:
+  run:
+    # reference: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell
+    shell: bash --noprofile --norc -eo pipefail -x {0}
+
+permissions:
+  contents: read
+
+jobs:
+  canary-arm64:
+    runs-on: [ubuntu-22.04-arm]
+    strategy:
+      fail-fast: false
+      matrix:
+        ceph-image: ${{ fromJson(inputs.ceph_images) }}
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: consider tmate debugging
+        uses: ./.github/workflows/tmate_debug
+        with:
+          use-tmate: ${{ secrets.USE_TMATE }}
+
+      - name: setup cluster resources
+        uses: ./.github/workflows/integration-test-setup-cluster-resources
+        with:
+          kubernetes-version: "v1.36.1"
+
+      - name: set Ceph image for ${{ matrix.ceph-image }}
+        run: tests/scripts/github-action-helper.sh replace_ceph_image deploy/examples/cluster-test.yaml "${{ matrix.ceph-image }}"
+
+      - name: validate-yaml
+        run: tests/scripts/github-action-helper.sh validate_yaml
+
+      - name: use local disk and create partitions for osds
+        run: |
+          tests/scripts/github-action-helper.sh use_local_disk
+          tests/scripts/github-action-helper.sh create_partitions_for_osds
+
+      - name: deploy cluster
+        run: |
+          # Use the official build images for the nightly arm tests instead of rebuilding
+          export USE_LOCAL_BUILD=false
+          # removing liveness probes since the env is slow and the probe is killing the daemons
+          yq write -d0 -i deploy/examples/cluster-test.yaml "spec.healthCheck.livenessProbe.mon.disabled" true
+          yq write -d0 -i deploy/examples/cluster-test.yaml "spec.healthCheck.livenessProbe.mgr.disabled" true
+          yq write -d0 -i deploy/examples/cluster-test.yaml "spec.healthCheck.livenessProbe.osd.disabled" true
+          tests/scripts/github-action-helper.sh deploy_cluster
+          tests/scripts/github-action-helper.sh deploy_all_additional_resources_on_cluster
+
+      - name: wait for prepare pod
+        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 2
+
+      - name: wait for ceph to be ready
+        run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready all 2
+
+      - name: collect common logs
+        if: always()
+        uses: ./.github/workflows/collect-logs
+        with:
+          name: ${{ github.job }}-${{ matrix.ceph-image }}

--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -20,55 +20,11 @@ env:
 
 jobs:
   canary-arm64:
-    runs-on: [ubuntu-22.04-arm]
     if: github.repository == 'rook/rook'
-
-    steps:
-      - name: checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-
-      - name: consider tmate debugging
-        uses: ./.github/workflows/tmate_debug
-        with:
-          use-tmate: ${{ secrets.USE_TMATE }}
-
-      - name: setup cluster resources
-        uses: ./.github/workflows/integration-test-setup-cluster-resources
-        with:
-          kubernetes-version: "v1.36.1"
-
-      - name: validate-yaml
-        run: tests/scripts/github-action-helper.sh validate_yaml
-
-      - name: use local disk and create partitions for osds
-        run: |
-          tests/scripts/github-action-helper.sh use_local_disk
-          tests/scripts/github-action-helper.sh create_partitions_for_osds
-
-      - name: deploy cluster
-        run: |
-          # Use the official build images for the nightly arm tests instead of rebuilding
-          export USE_LOCAL_BUILD=false
-          # removing liveness probes since the env is slow and the probe is killing the daemons
-          yq write -d0 -i deploy/examples/cluster-test.yaml "spec.healthCheck.livenessProbe.mon.disabled" true
-          yq write -d0 -i deploy/examples/cluster-test.yaml "spec.healthCheck.livenessProbe.mgr.disabled" true
-          yq write -d0 -i deploy/examples/cluster-test.yaml "spec.healthCheck.livenessProbe.osd.disabled" true
-          tests/scripts/github-action-helper.sh deploy_cluster
-          tests/scripts/github-action-helper.sh deploy_all_additional_resources_on_cluster
-
-      - name: wait for prepare pod
-        run: tests/scripts/github-action-helper.sh wait_for_prepare_pod 2
-
-      - name: wait for ceph to be ready
-        run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready all 2
-
-      - name: collect common logs
-        if: always()
-        uses: ./.github/workflows/collect-logs
-        with:
-          name: canary-arm64
+    uses: ./.github/workflows/ceph-arm64-suite-test.yml
+    with:
+      ceph_images: '["quay.io/ceph/ceph:v20"]'
+    secrets: inherit
 
   ceph-suite-tests:
     if: github.repository == 'rook/rook'

--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -23,7 +23,7 @@ jobs:
     if: github.repository == 'rook/rook'
     uses: ./.github/workflows/ceph-arm64-suite-test.yml
     with:
-      ceph_images: '["quay.io/ceph/ceph:v20"]'
+      ceph_images: '["quay.io/ceph/ceph:v21", "quay.ceph.io/ceph-ci/ceph:main-arm64", "quay.ceph.io/ceph-ci/ceph:squid-release-arm64", "quay.ceph.io/ceph-ci/ceph:tentacle-arm64", "quay.ceph.io/ceph-ci/ceph:umbrella-release-arm64"]'
     secrets: inherit
 
   ceph-suite-tests:


### PR DESCRIPTION
Replace the ceph-suite-version + case-statement image mapping with a literal ARM64_CEPH_IMAGES list matrixed directly, matching the pattern used by the canary-tests job. Adding or changing an arm64 test image is now a single variable change.

Resolves #17625

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.


Signed-off-by: Pasan Chamikara <pasan.chamikara@owasp.org>