### PR TITLE
docs: document the CI checks that gate a pull request, and add AGENTS.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,7 @@ Resolves #
 - [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
 - [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
   - Overwriting Ceph's configurations should be marked as breaking changes.
-- [ ] Documentation has been updated, if necessary.
-- [ ] Unit tests have been added, if necessary.
-- [ ] Integration tests have been added, if necessary.
+- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
+- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
+- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,9 @@ API, because those comments become the CRD descriptions.
 * Sign off every commit with `git commit -s`. A bot enforces the DCO.
 * Open pull requests against `master`, from a branch in a fork. Rebase onto upstream; never merge
     upstream into a branch.
+* If you do not have write access, keep no more than three pull requests open at once; the
+    repository enforces this. It does not apply to contributors with write access. Ask a maintainer
+    if you have a genuine need to exceed it.
 * Opening a pull request non-interactively, such as by passing a body to `gh pr create`, skips the
     template that GitHub would otherwise supply. Read
     [the template](.github/PULL_REQUEST_TEMPLATE.md) and fill in its checklist regardless.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository.
+
+This file is a map, not a rulebook. The contributor documentation is the authority, and everything
+below points into it rather than restating it, so that the two cannot disagree.
+
+Read the [AI guidelines](Documentation/Contributing/ai-guidelines.md) first. Rook does not accept
+contributions that lack human oversight.
+
+## Where the rules live
+
+Read the relevant section of the
+[developer guide](Documentation/Contributing/development-flow.md) before making a change:
+
+| To find out how to | Read |
+| ------------------ | ---- |
+| build, test, and lint, and what CI enforces | [Checks that gate a pull request](Documentation/Contributing/development-flow.md#checks-that-gate-a-pull-request) |
+| change anything under `pkg/apis` | [Generated Code and CRDs](Documentation/Contributing/development-flow.md#generated-code-and-crds) |
+| write a commit message | [Commit structure](Documentation/Contributing/development-flow.md#commit-structure) |
+| fill in the pull request checklist | [the pull request template](.github/PULL_REQUEST_TEMPLATE.md), which says what each item claims |
+| write tests | [Assertions](Documentation/Contributing/rook-test-framework.md#assertions) |
+
+Two of these are easy to miss. Building or testing with a bare `go` command does not necessarily
+match what CI runs, so use `make`. Changing a godoc comment under `pkg/apis` counts as changing the
+API, because those comments become the CRD descriptions.
+
+## Regardless of what else is read
+
+* Sign off every commit with `git commit -s`. A bot enforces the DCO.
+* Open pull requests against `master`, from a branch in a fork. Rebase onto upstream; never merge
+    upstream into a branch.
+* Opening a pull request non-interactively, such as by passing a body to `gh pr create`, skips the
+    template that GitHub would otherwise supply. Read
+    [the template](.github/PULL_REQUEST_TEMPLATE.md) and fill in its checklist regardless.
+* Disclose in the pull request description how AI tools assisted with the change.
+* Commit messages and review comments are the contributor's own reasoning to explain and own. Do
+    not submit raw model output as either.
+* Discuss significant changes in an issue before writing code. Large AI-generated pull requests
+    without prior design discussion will be rejected.

--- a/Documentation/Contributing/ai-guidelines.md
+++ b/Documentation/Contributing/ai-guidelines.md
@@ -16,7 +16,7 @@ In order to ensure legal guidelines, Rook requires human involvement and engagem
 ## Transparency requirements
 
 1. Contributors should disclose in pull request descriptions how AI tools assisted in development. E.g., generating substantial functions, documentation, and/or unit tests.
-2. Rook requires human sign-off. Signing commits using an AI tool, or listing AI tooling in commits using `co-authored-by`, `assisted-by`, `generated-by`, or using similar commit trailers is not necessary.
+2. Rook requires human sign-off. Sign commits with your own identity rather than an AI tool's. Commit trailers that credit AI tooling, such as `co-authored-by`, `assisted-by`, or `generated-by`, are permitted but not required.
 
 ## Best practices to respect maintainer time
 

--- a/Documentation/Contributing/development-flow.md
+++ b/Documentation/Contributing/development-flow.md
@@ -207,6 +207,13 @@ Before opening the PR:
 * If there are code changes, add unit tests and verify that all unit tests are passing. See [Unit Tests](#unit-tests) below on running unit tests.
 * Rebase on the latest upstream changes
 
+### Limit concurrent pull requests
+
+Contributors without write access should keep no more than three pull requests open at the same
+time, so that maintainer review — the project's limiting resource — is not spread too thin. The
+repository enforces this: with three open, merge or close one before opening the next. If you have a
+genuine need to exceed it, raise it with a maintainer first.
+
 ### Regression Testing
 
 All pull requests must pass all continuous integration (CI) tests before they can be merged. These tests

--- a/Documentation/Contributing/development-flow.md
+++ b/Documentation/Contributing/development-flow.md
@@ -218,6 +218,30 @@ as much as possible before pushing
 (a behavior that is not required but highly encouraged),
 the unit tests and various linters can easily be run locally.
 
+### Checks that gate a pull request
+
+Each of the following checks runs against every PR and must pass before it can be merged.
+Every one of them can be run locally, and doing so before pushing saves a full CI round trip:
+
+| Check | Run it locally | Applies to |
+| ----- | -------------- | ---------- |
+| Unit tests | `make test` | Go changes under `cmd/` and `pkg/` |
+| Go linters | `make golangci-lint` | any Go change |
+| Generated client and deepcopy code | `make codegen` | any change under `pkg/apis` |
+| CRD manifests and reference docs | `make crds` | any change under `pkg/apis` |
+| Commit message format | `make lint.commits` | every commit |
+| Markdown formatting | `make lint.markdown` | any change under `Documentation/` |
+
+!!! tip
+    Build and test through `make` rather than invoking `go` directly. The `make` targets set the
+    build flags and tags that Rook needs, so an ad-hoc `go build` or `go test` may not match what CI
+    runs. Run `make help` to see all targets.
+
+!!! note
+    `make test` only runs the unit tests under `cmd/` and `pkg/` (the `GO_SUBDIRS`). Test files
+    elsewhere, such as under `tests/framework/`, are compiled by the linters but are never run by
+    the unit test CI.
+
 ## Unit Tests
 
 From the root of your local Rook repo execute the following to run all of the unit tests:
@@ -267,6 +291,30 @@ Refer to the respective project website for more installation instructions.
 !!! tip
     Run `make help` to see a list of all possible make targets
 
+## Generated Code and CRDs
+
+Several checked-in files are generated from the API types under `pkg/apis` and must be regenerated
+whenever those types change:
+
+```console
+# Regenerates the deepcopy functions and the typed client under pkg/client
+make codegen
+
+# Regenerates the CRD manifests and the CRD reference documentation
+make crds
+```
+
+Commit the regenerated files together with the change that required them, in the same commit. CI
+fails if regenerating produces any diff.
+
+A change to `pkg/apis` means more than adding or removing a field. Editing the godoc comment on an
+exported type or field also requires regeneration, because those comments are copied verbatim into
+the `description` fields of the CRDs. Reword a comment and the following files change:
+
+* `deploy/examples/crds.yaml`
+* `deploy/charts/rook-ceph/templates/resources.yaml`
+* `Documentation/CRDs/specification.md`
+
 ## Integration Tests
 
 Rook's upstream continuous integration (CI) tests will run integration tests against your changes
@@ -301,6 +349,28 @@ Then I'm explaining how I fixed it.
 
 Signed-off-by: FirstName LastName <email address>
 ```
+
+The commit prefix must be one of the types listed under `rules.type-enum` in
+[`.commitlintrc.json`](https://github.com/rook/rook/blob/master/.commitlintrc.json). Only those
+types are accepted, so pick the closest match rather than inventing one after the package being
+changed.
+
+Separate any trailer from the body with a blank line, or commitlint reports
+`footer-leading-blank`. Note that commitlint decides what a trailer is by looking at the text: a
+line that begins with a word followed by a colon, or one that closes an issue, is treated as a
+trailer even when it was meant as prose. Wrapping a sentence so that a line happens to begin with
+`anywhere:` is enough to trigger this. Rewrap the line to avoid it. Mentioning an issue in the
+middle of a sentence is fine.
+
+Check the commit messages on your branch before pushing:
+
+```console
+make lint.commits
+```
+
+This runs the same commitlint that CI runs, over your branch's commits. It compares against
+`origin/master` by default; if your Rook upstream is a different remote, point it there with
+`make lint.commits COMMITLINT_BASE=upstream/master`.
 
 ### Commit History
 

--- a/Documentation/Contributing/rook-test-framework.md
+++ b/Documentation/Contributing/rook-test-framework.md
@@ -89,6 +89,29 @@ go test -v -timeout 1800s -run CephSmokeSuite github.com/rook/rook/tests/integra
 !!! info
     Only the golang test suites are documented to run locally. Canary and other tests have only ever been supported in the CI.
 
+## Assertions
+
+The tests use [testify](https://github.com/stretchr/testify), which offers two families of checks.
+`require` stops the current test immediately on failure. `assert` records the failure and keeps
+going. Which one to reach for depends on what the check is doing:
+
+* Use `require` for anything the rest of the test cannot proceed without: creating a resource,
+    fetching the object that is about to be inspected, decoding a response, waiting for setup to
+    finish. Continuing past one of these failures produces a nil dereference or a cascade of
+    confusing errors that hide the original one.
+* Use `assert` for the properties the test exists to verify, so that a single run reports every
+    property that is wrong rather than only the first. Use it for cleanup as well, so one failed
+    deletion does not strand the deletions after it.
+
+Never call `assert` or `require` inside the closure of a poll or retry helper. A failed assertion
+there defeats the retry, and testify's `Eventually` runs the closure on another goroutine, where
+`require` cannot safely stop the test. Have the closure return false while the condition is unmet,
+capture the value once it is met, and assert on it after the wait returns.
+
+!!! note
+    `FailNow`, and therefore `require`, only aborts the test goroutine it is called on. A `require`
+    inside a `t.Run` closure stops that subtest, not its siblings or its parent.
+
 ## Running tests on OpenShift
 
 1. Setup OpenShift environment and export KUBECONFIG

--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,15 @@ lint.markdown: check.container.runtime ## Check formatting of documentation sour
 lint.markdown-links: check.container.runtime
 	@$(DOCKERCMD) run --rm -v "$$PWD:/workspace" --entrypoint "/workspace/tests/scripts/check-markdown-links-internal.sh" ghcr.io/tcort/markdown-link-check:stable
 
+# The base ref that lint.commits checks against; every commit reachable from HEAD but not from it
+# is linted. It defaults to the remote-tracking master so a stale local master branch does not drag
+# already-merged upstream commits into the range. Override when the upstream is a different remote,
+# e.g. lint.commits COMMITLINT_BASE=upstream/master.
+COMMITLINT_BASE ?= origin/master
+.PHONY: lint.commits
+lint.commits: ## Check this branch's commit messages with commitlint (requires npx).
+	@npx --yes -p @commitlint/cli -p @commitlint/config-conventional commitlint --config .commitlintrc.json --from $(COMMITLINT_BASE) --to HEAD
+
 .PHONY: fix.markdown
 fix.markdown: check.container.runtime ## Check and fix formatting of documentation sources
 	@$(MARKDOWNLINT) "Documentation/**/**.md" "#Documentation/Helm-Charts/**" --fix --config .markdownlint-cli2.cjs

--- a/tests/scripts/check-markdown-links-internal.sh
+++ b/tests/scripts/check-markdown-links-internal.sh
@@ -17,7 +17,9 @@ fi
 MLC="${MLC_BASE_CMD} --config ${script_dir}/mlc_config.json --quiet"
 
 EXIT_CODE=0
-FILES=$(cd "$base_dir" && find Documentation/ -name '*.md')
+# AGENTS.md consists almost entirely of links into Documentation/. A stale link there silently
+# misdirects the reader, so check it alongside the documentation it points at.
+FILES=$(cd "$base_dir" && find Documentation/ -name '*.md' && echo AGENTS.md)
 BAD_FILES=""
 NUM_CHECKED_FILES=0
 NUM_BAD_FILES=0


### PR DESCRIPTION
The developer guide explains how to fork, rebase, run `make test`, and sign off a
commit. It does not mention most of the checks that actually decide whether a pull
request can merge: `make golangci-lint`, `make codegen`, `make crds`, and
commitlint each gate every PR, and none of them are documented. A contributor has
no way to learn about them short of pushing and reading a red CI run.

This adds the missing pieces to the developer guide:

- A table of the checks that gate a pull request, and the command that runs each
  one locally.
- A section on regenerating the client, deepcopy functions, CRD manifests, and
  CRD reference docs after a change under `pkg/apis`. This is the one that costs
  the most time when missed, because editing a godoc comment counts: those
  comments become the `description` fields of the CRDs, so rewording one and
  pushing reddens the whole build matrix.
- The commit message rules that are inferred rather than stated: the prefix must
  come from the type list in `.commitlintrc.json`, and commitlint decides what a
  trailer is from the shape of a line, so wrapping a sentence such that a line
  begins with a word followed by a colon fails `footer-leading-blank`.
- A `make lint.commits` target that runs the same commitlint CI runs over the
  branch's commits, so the commit message rules can be checked before pushing.
- What each pull request checkbox actually claims.
- That `make test` covers only `cmd/` and `pkg/`, so test files under
  `tests/framework/` are compiled but never run.

It also documents the `assert` and `require` convention the tests already follow,
since the choice between them is not arbitrary and is easy to get backwards.

It adds an `AGENTS.md`. AI coding agents read a file at that path by
convention, and there is none, so an agent working in this repository starts with
no knowledge of its conventions. The predictable results are unsigned commits,
invalid commit prefixes, `pkg/apis` changes with no regenerated CRDs, the AI
attribution trailers the AI guidelines ask contributors not to use, and pull
request checklists with every box ticked.

To keep `AGENTS.md` from becoming a second, drifting copy of the documentation, it
is written as a map rather than a rulebook: it links into `Documentation/` for
everything mechanical and states inline only the policy that must hold no matter
what else the reader skips. The link checker is extended to cover it, so a moved
page cannot leave it silently pointing at nothing. The other markdown files in the
repository root are deliberately left out of the link checker, as several already
contain dead external links unrelated to this change.

It also documents a limit on concurrent open pull requests: contributors
without write access should keep no more than three open at the same time. This is
stated in the developer guide and in `AGENTS.md`, and will be enforced by the
repository's pull request limit — set to three for users without write access —
once this merges. Contributors with write access are not restricted, so an active
contributor's tooling is not blocked by it. This policy was agreed among the
maintainers.

Finally, it updates the AI guidelines. They previously said that listing AI
tooling in a commit with a `co-authored-by`, `assisted-by`, or `generated-by`
trailer was not necessary, which read as discouragement and left contributors
unsure whether such a trailer was welcome at all. Per maintainer discussion those
trailers are fine, so the guidelines now say they are permitted but not required.
What the guidelines require is unchanged: sign-off is the human contributor's, and
AI assistance is disclosed in the pull request description.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

AI assistance: an AI agent located the undocumented checks by reading the
workflows and Makefile, verified each documented claim by running the tool in
question (including confirming that the link checker does not validate anchors,
and that commitlint rejects a body line beginning with a word and a colon),
audited the repository's closed-PR history to inform the concurrent-PR limit, and
drafted the wording.

