### PR TITLE
fix: correct inverted nil check in archiveCrash and fix file descriptor leak

### DIFF
--- a/pkg/daemon/ceph/osd/remove.go
+++ b/pkg/daemon/ceph/osd/remove.go
@@ -222,7 +222,7 @@ func archiveCrash(clusterdContext *clusterd.Context, clusterInfo *client.Cluster
 		logger.Errorf("failed to list ceph crash. %v", err)
 		return
 	}
-	if crash != nil {
+	if len(crash) == 0 {
 		logger.Info("no ceph crash to silence")
 		return
 	}

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -47,6 +47,8 @@ func CreateTempFile(content string) (*os.File, error) {
 	// Write content into file
 	err = os.WriteFile(file.Name(), []byte(content), 0o400)
 	if err != nil {
+		file.Close()
+		os.Remove(file.Name())
 		return nil, errors.Wrap(err, "failed to write content into file")
 	}
 	return file, nil


### PR DESCRIPTION
## Summary
- Fix inverted nil check in `archiveCrash`: change `crash != nil` to `len(crash) == 0`
- Fix file descriptor leak in `CreateTempFile`: close file and remove temp on write error

## Motivation
### Bug 1: archiveCrash never silences crash warnings
The condition `crash != nil` was checked after a successful `GetCrash()` call. In Go, a successfully-decoded JSON array (even an empty one) yields a non-nil slice. This means the function always returns early with "no ceph crash to silence", and the loop that archives crash warnings is dead code. As a result, when an OSD is removed, its associated crash warnings in `ceph health` are never silenced.

### Bug 2: File descriptor leak in CreateTempFile
If `os.WriteFile` fails, the opened `*os.File` is returned as `nil` to the caller, but the file descriptor is never closed and the temp file is never removed. In a long-running operator process, repeated failures accumulate leaked file descriptors.

## Changes
| File | Change |
|------|--------|
| `pkg/daemon/ceph/osd/remove.go:225` | `crash != nil` → `len(crash) == 0` |
| `pkg/util/file.go:49-50` | Add `file.Close()` and `os.Remove(file.Name())` on write error |

## Testing
- [x] Existing tests pass

Signed-off-by: Akanksha Trehun <magic-peach@users.noreply.github.com>