### PR TITLE
external: resolve node secret names via annotations for external cluster

### DIFF
--- a/deploy/examples/import-external-cluster.sh
+++ b/deploy/examples/import-external-cluster.sh
@@ -222,6 +222,7 @@ function importCsiRBDNodeSecret() {
       "rook-$CSI_RBD_NODE_SECRET_NAME" \
       -p "{\"stringData\":{\"userID\":\"$userID\",\"userKey\":\"$CSI_RBD_NODE_SECRET\"}}"
   fi
+  $KUBECTL -n "$NAMESPACE" annotate secret "rook-$CSI_RBD_NODE_SECRET_NAME" --overwrite csi.rook.io/RBDNodeSecret="true"
 }
 
 function importCsiRBDProvisionerSecret() {

--- a/pkg/operator/ceph/csi/config.go
+++ b/pkg/operator/ceph/csi/config.go
@@ -54,7 +54,12 @@ const (
 func CreateUpdateClientProfileRadosNamespace(ctx context.Context, c client.Client, clusterInfo *cephclient.ClusterInfo, cephBlockPoolRadosNamespaceName, clusterID string) error {
 	logger.Info("creating ceph-csi clientProfile CR for rados namespace")
 
-	rbdSecretName, err := getSecretNameByAnnotation(c, ctx, clusterInfo.Namespace, "csi.rook.io/RBDProvisionerSecret", CsiRBDProvisionerSecret)
+	rbdProvisionerSecretName, err := getSecretNameByAnnotation(c, ctx, clusterInfo.Namespace, "csi.rook.io/RBDProvisionerSecret", CsiRBDProvisionerSecret)
+	if err != nil {
+		return err
+	}
+
+	rbdNodeSecretName, err := getSecretNameByAnnotation(c, ctx, clusterInfo.Namespace, "csi.rook.io/RBDNodeSecret", CsiRBDNodeSecret)
 	if err != nil {
 		return err
 	}
@@ -70,7 +75,11 @@ func CreateUpdateClientProfileRadosNamespace(ctx context.Context, c client.Clien
 			RadosNamespace: cephBlockPoolRadosNamespaceName,
 			CephCsiSecrets: &csiopv1.CephCsiSecretsSpec{
 				ControllerPublishSecret: v1.SecretReference{
-					Name:      rbdSecretName,
+					Name:      rbdProvisionerSecretName,
+					Namespace: clusterInfo.Namespace,
+				},
+				NodePublishSecret: v1.SecretReference{
+					Name:      rbdNodeSecretName,
 					Namespace: clusterInfo.Namespace,
 				},
 			},


### PR DESCRIPTION
Add annotations to RBD node secrets in import-external-cluster.sh so that externally created secrets with custom names can be discovered at runtime. Update CreateUpdateClientProfileRadosNamespace to look up secrets by annotation instead of using hardcoded names.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
