### PR TITLE
core: parse subvolumegroup bytes_quota reported as "infinite"

### DIFF
--- a/pkg/daemon/ceph/client/subvolumegroup.go
+++ b/pkg/daemon/ceph/client/subvolumegroup.go
@@ -96,6 +96,38 @@ type subvolumeGroupInfo struct {
 	DataPool   string `json:"data_pool"`
 }
 
+// UnmarshalJSON handles the bytes_quota field, which Ceph reports as the JSON
+// string "infinite" when no quota is set (see Ceph's Group.info) and as a
+// number otherwise. The "infinite" sentinel is mapped to 0 (unlimited).
+func (s *subvolumeGroupInfo) UnmarshalJSON(data []byte) error {
+	type subvolumeGroupInfoAlias subvolumeGroupInfo
+	aux := &struct {
+		BytesQuota json.RawMessage `json:"bytes_quota"`
+		*subvolumeGroupInfoAlias
+	}{
+		subvolumeGroupInfoAlias: (*subvolumeGroupInfoAlias)(s),
+	}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	if len(aux.BytesQuota) == 0 || string(aux.BytesQuota) == "null" {
+		s.BytesQuota = 0
+		return nil
+	}
+
+	var quotaStr string
+	if err := json.Unmarshal(aux.BytesQuota, &quotaStr); err == nil {
+		if quotaStr == "infinite" {
+			s.BytesQuota = 0
+			return nil
+		}
+		return errors.Errorf("unexpected bytes_quota value %q", quotaStr)
+	}
+
+	return json.Unmarshal(aux.BytesQuota, &s.BytesQuota)
+}
+
 // getCephFSSubVolumeGroupInfo get subvolumegroup info of the group name.
 // volName is the name of the Ceph FS volume, the same as the CephFilesystem CR name.
 func getCephFSSubVolumeGroupInfo(context *clusterd.Context, clusterInfo *ClusterInfo, volName, groupName string) (*subvolumeGroupInfo, error) {

--- a/pkg/daemon/ceph/client/subvolumegroup_test.go
+++ b/pkg/daemon/ceph/client/subvolumegroup_test.go
@@ -19,7 +19,10 @@ package client
 import (
 	"testing"
 
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -78,4 +81,45 @@ func TestValidatePinningValues(t *testing.T) {
 	var testData1 cephv1.CephFilesystemSubVolumeGroupSpecPinning
 	err = validatePinningValues(testData1)
 	assert.NoError(t, err)
+}
+
+func TestGetCephFSSubVolumeGroupInfo(t *testing.T) {
+	tests := []struct {
+		name             string
+		output           string
+		expectedQuota    int64
+		expectedDataPool string
+	}{
+		{
+			name:             "finite quota",
+			output:           `{"bytes_quota":1099511627776,"bytes_used":0,"data_pool":"myfs-replicated"}`,
+			expectedQuota:    1099511627776,
+			expectedDataPool: "myfs-replicated",
+		},
+		{
+			// Ceph reports bytes_quota as the string "infinite" when no quota is set.
+			name:             "infinite quota",
+			output:           `{"bytes_quota":"infinite","bytes_used":0,"data_pool":"myfs-replicated"}`,
+			expectedQuota:    0,
+			expectedDataPool: "myfs-replicated",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &exectest.MockExecutor{}
+			executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+				logger.Infof("Command: %s %v", command, args)
+				if args[0] == "fs" && args[1] == "subvolumegroup" && args[2] == "info" {
+					return tt.output, nil
+				}
+				return "", errors.Errorf("unexpected ceph command %q", args)
+			}
+
+			svgInfo, err := getCephFSSubVolumeGroupInfo(&clusterd.Context{Executor: executor}, AdminTestClusterInfo("mycluster"), "myfs", "csi")
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedQuota, svgInfo.BytesQuota)
+			assert.Equal(t, tt.expectedDataPool, svgInfo.DataPool)
+		})
+	}
 }


### PR DESCRIPTION
Ceph's `mgr/volumes` reports a subvolume group's `bytes_quota` as the string
`"infinite"` when no quota is set. `getCephFSSubVolumeGroupInfo` parsed the info
response into a struct with an integer `BytesQuota`, so the parse failed for
every quota-less group; the error was then swallowed by an `ExitStatus` type
switch that does not unwrap the wrapped error, so the caller silently received a
zero-valued result instead of the group's real state.

This adds JSON handling for the `"infinite"` sentinel (mapping it to the
no-quota value rather than failing the parse), restoring the no-shrink behavior
intended by #14036, plus a table-driven `TestGetCephFSSubVolumeGroupInfo`
covering the `"infinite"`, numeric, and empty forms.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

---

Description rewritten by a maintainer to restore the verbatim PR-template
checklist (the original reworded the items). The original report and fix are by
@anxkhn and the commit is unchanged.

AI assistance: the original change was submitted as AI-assisted (per the author's
checklist); this description was rewritten by a maintainer with AI assistance.
The code change itself is unmodified.
