### PR TITLE
object: return an error when reconciled rgw user has no keys

### DIFF
--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -494,7 +494,7 @@ func (r *ReconcileObjectStoreUser) createOrUpdateCephUser(u *cephv1.CephObjectSt
 		// use the keys already set on the user & remove all but one key
 		if len(liveUser.Keys) == 0 {
 			// something is wrong, there should be at least one key
-			return errors.Wrapf(err, "no keys set for user %q", u.Name)
+			return errors.Errorf("no keys set for user %q", u.Name)
 		}
 
 		targetUser.Keys = []admin.UserKeySpec{liveUser.Keys[0]}

--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -597,6 +597,79 @@ func TestCreateOrUpdateCephUser(t *testing.T) {
 	})
 }
 
+func TestCreateOrUpdateCephUserNoKeys(t *testing.T) {
+	// Set DEBUG logging
+	capnslog.SetGlobalLogLevel(capnslog.DEBUG)
+
+	objectUser := &cephv1.CephObjectStoreUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: cephv1.ObjectStoreUserSpec{
+			Store: store,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CephObjectStoreUser",
+		},
+	}
+
+	// A live RGW user the API returned with no access keys. The user spec also
+	// carries no explicit keys, so createOrUpdateCephUser falls back to the live
+	// user's keys and must surface an error since there are none.
+	//nolint:gosec // only test values, not a real secret
+	userNoKeysJSON := `{
+	"user_id": "my-user",
+	"display_name": "my-user",
+	"max_buckets": 1000,
+	"keys": [],
+	"swift_keys": [],
+	"caps": [],
+	"op_mask": "read, write, delete",
+	"bucket_quota": {"enabled": false, "max_size": -1, "max_objects": -1},
+	"user_quota": {"enabled": false, "max_size": -1, "max_objects": -1},
+	"type": "rgw"
+}`
+
+	mockClient := &cephobject.MockClient{
+		MockDo: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path != "rook-ceph-rgw-my-store.mycluster.svc/admin/user" {
+				return nil, fmt.Errorf("unexpected url path %q", req.URL.Path)
+			}
+
+			if req.Method == http.MethodGet && req.URL.RawQuery == "format=json&uid=my-user" {
+				return &http.Response{
+					StatusCode: 200,
+					Body:       io.NopCloser(bytes.NewReader([]byte(userNoKeysJSON))),
+				}, nil
+			}
+
+			if req.Method == http.MethodPut && req.URL.RawQuery == "enabled=false&format=json&max-objects=-1&max-size=-1&quota=&quota-type=user&uid=my-user" {
+				return &http.Response{
+					StatusCode: 200,
+					Body:       io.NopCloser(bytes.NewReader([]byte(userNoKeysJSON))),
+				}, nil
+			}
+
+			return nil, fmt.Errorf("unexpected request: %q. method %q. path %q", req.URL.RawQuery, req.Method, req.URL.Path)
+		},
+	}
+	adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient)
+	assert.NoError(t, err)
+	r := &ReconcileObjectStoreUser{
+		objContext: &cephobject.AdminOpsContext{
+			AdminOpsClient: adminClient,
+		},
+		opManagerContext: context.TODO(),
+	}
+
+	userConfig, err := generateUserConfig(objectUser)
+	require.NoError(t, err)
+	err = r.createOrUpdateCephUser(objectUser, userConfig)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no keys set for user")
+}
+
 func TestValidateUser(t *testing.T) {
 	r := &ReconcileObjectStoreUser{}
 


### PR DESCRIPTION
"Resolves #" section is intentionally omitted)

In `createOrUpdateCephUser`, when a `CephObjectStoreUser` spec carries no explicit
keys, the reconciler falls back to the keys already set on the live RGW user. If
that live user also has zero keys, the code intends to fail (per its inline comment
"something is wrong, there should be at least one key"), but it built the error with
`errors.Wrapf(err, ...)` at a point where `err` is already `nil`: the most recent
assignment to `err` is the `SetUserQuota` call just above, which is checked and
returned on failure, so control only reaches the keys guard when `err == nil`.

`github.com/pkg/errors.Wrapf(nil, ...)` returns `nil`, so the function returned
success on a user the operator itself had just flagged as broken. The caller treats
`nil` as success, logs "created/updated ceph object user", and the
`CephObjectStoreUser` is marked `Ready`, silently hiding the fault.

This constructs the error with `errors.Errorf` instead, so the intended failure is
surfaced rather than swallowed. `errors.Errorf` is already imported and used
elsewhere in the same file.

A regression test (`TestCreateOrUpdateCephUserNoKeys`) is added that stands up a
fake RGW admin-ops server returning a live user with an empty `keys` list and
asserts a non-nil "no keys set for user" error. It fails against the old code
(the reconcile wrongly succeeded) and passes with the fix.

AI assistance: this change was developed with AI assistance (analysis of the
swallowed-error path and drafting the regression test); I reviewed, tested, and
own the change.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the developer guide.
- [x] Reviewed the developer guide on Submitting a Pull Request.
- [x] Reviewed AI guidelines, since AI assisted with the PR.
- [ ] Pending release notes updated with breaking and/or notable changes for the next minor release.
  - (Not applicable: this is an internal bug fix on an exceptional error path, not a breaking change or a user-facing notable change. Leave unchecked or remove the line if you agree.)
- [ ] Documentation has been updated, if necessary.
  - (Not applicable: no user-facing behavior/API/docs change.)
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
  - (Not applicable: covered by a unit test; the path needs a keyless RGW user, which the unit-level fake reproduces without a live cluster.)

--------------------------------------------------------------------------------
## The change (for your quick review)

Production, `pkg/operator/ceph/object/user/controller.go` (guard at line 495-497):

```go
 		if len(liveUser.Keys) == 0 {
 			// something is wrong, there should be at least one key
-			return errors.Wrapf(err, "no keys set for user %q", u.Name)
+			return errors.Errorf("no keys set for user %q", u.Name)
 		}
```

Test, `pkg/operator/ceph/object/user/controller_test.go`: new
`TestCreateOrUpdateCephUserNoKeys` (+73 lines), self-contained (kept separate from
`TestCreateOrUpdateCephUser` because it needs the GET to return a keyless user).

Diffstat: `controller.go` +1/-1, `controller_test.go` +73/-0. No new imports.
