### PR TITLE
osd: skip auxiliary entries in raw device scan

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -190,7 +190,7 @@ else
 		python3 -c "
 import sys, json
 for _, info in json.load(sys.stdin).items():
-	if info['osd_id'] == $OSD_ID:
+	if info.get('osd_id') == $OSD_ID:
 		print(info['device'], end='')
 		print('found device: ' + info['device'], file=sys.stderr) # log the disk we found to stderr
 		sys.exit(0)  # don't keep processing once the disk is found

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -18,7 +18,10 @@ limitations under the License.
 package osd
 
 import (
+	"bytes"
 	"context"
+	"os/exec"
+	"strings"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -38,6 +41,41 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
+
+func TestRawOSDActivationFindDevice(t *testing.T) {
+	const fixture = `{
+		"bluefs-db": {
+			"device_db": "/dev/mapper/cephmeta-meta--0_rimage_1",
+			"osd_uuid": "bluefs-db"
+		},
+		"osd": {
+			"device": "/dev/sdb",
+			"osd_id": 3,
+			"osd_uuid": "osd"
+		}
+	}`
+
+	const commandPrefix = "python3 -c \""
+	start := strings.Index(activateOSDOnNodeCode, commandPrefix)
+	if !assert.NotEqual(t, -1, start, "find_device Python command not found") {
+		return
+	}
+
+	script := activateOSDOnNodeCode[start+len(commandPrefix):]
+	end := strings.Index(script, "\n\"")
+	if !assert.NotEqual(t, -1, end, "find_device Python command terminator not found") {
+		return
+	}
+	script = strings.ReplaceAll(script[:end], "$OSD_ID", "3")
+
+	cmd := exec.Command("python3", "-c", script) //nolint:gosec // the script is generated entirely by Rook
+	cmd.Stdin = strings.NewReader(fixture)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
+	assert.NoError(t, err, stderr.String())
+	assert.Equal(t, "/dev/sdb", string(output))
+}
 
 func TestPodContainer(t *testing.T) {
 	cluster := &Cluster{rookVersion: "23", clusterInfo: cephclient.AdminTestClusterInfo("myosd")}


### PR DESCRIPTION
## What
- ignore `ceph-volume raw list` entries that do not include `osd_id`
- add a regression test with a BlueFS DB-only entry before the matching OSD

## Why
Ceph 19.2.4 can include auxiliary BlueFS DB entries in raw-list output. Those entries do not contain `osd_id`, so the activation parser raised `KeyError` before reaching the requested OSD device.

Fixes #17983

## Tests
- `go test ./pkg/operator/ceph/cluster/osd -run ^'TestRawOSDActivationFindDevice$' -count=1`
- `go test ./pkg/operator/ceph/cluster/osd -count=1`
- `make -C /tmp/rook-worker4 ROOT_DIR=/tmp/rook-worker4 lint.fmt`
- `make -C /tmp/rook-worker4 ROOT_DIR=/tmp/rook-worker4 lint.vet`
- `make -C /tmp/rook-worker4 ROOT_DIR=/tmp/rook-worker4 golangci-lint`
