### PR TITLE
build: exclude helm dep archives from chart package prerequisites

### DIFF
--- a/build/makelib/helm.mk
+++ b/build/makelib/helm.mk
@@ -51,7 +51,11 @@ $(HELM): | $(TOOLS_HOST_DIR)
 	@rm -fr $(TOOLS_HOST_DIR)/tmp
 
 define helm.chart
-$(HELM_OUTPUT_DIR)/$(1)-$(VERSION).tgz: $(HELM) $(HELM_OUTPUT_DIR) helm.dependency.update.$(1) $(shell find $(HELM_CHARTS_DIR)/$(1) -type f)
+# Exclude dependency archives (charts/*.tgz) from the prerequisites: the
+# helm.dependency.update recipe deletes and re-fetches them mid-build, so a
+# stale archive captured at parse time would leave make failing on a missing
+# prerequisite.
+$(HELM_OUTPUT_DIR)/$(1)-$(VERSION).tgz: $(HELM) $(HELM_OUTPUT_DIR) helm.dependency.update.$(1) $(shell find $(HELM_CHARTS_DIR)/$(1) -type f ! -name '*.tgz')
 	@echo === helm package $(1)
 	@rm -rf $(OUTPUT_DIR)/$(1)
 	@cp -aL $(HELM_CHARTS_DIR)/$(1) $(OUTPUT_DIR)


### PR DESCRIPTION
The chart package rule captures `find` output over the chart directory as its prerequisite list when make parses the makefile, including any dependency archives already sitting in `charts/`. The `helm.dependency.update` recipe then runs `helm dependency update`, which deletes archives that no longer match the Chart.yaml pins. An archive left by an earlier build at a different ref — an older version pin, or another branch — is thus frozen as a prerequisite and deleted mid-run, and make stops:

```
make: *** No rule to make target '.../deploy/charts/rook-ceph/charts/ceph-csi-operator-1.0.1.tgz',
  needed by '.../_output/charts/rook-ceph-v1.20.0-alpha.0.509.g75e64b00b.tgz'.  Stop.
```

This hits any tree built before the csi-operator pin moved from 1.0.1 to 1.0.4 (a3e02e607) on the next `make`, and recurs on every future pin change and on branch switches (release-1.19 pins 0.6.0). The failed run self-heals the tree, so it looks like a one-shot mystery failure.

Exclude `*.tgz` files from the prerequisite find. The archives never carried staleness information anyway: `helm.dependency.update` is a non-file target that is always considered remade, so the package target re-runs every build regardless. Verified by planting a stale `ceph-csi-operator-1.0.1.tgz` in a clean tree: `make helm.build` fails as above before this change and packages both charts after it.

AI assistance: Claude Code diagnosed the parse-time prerequisite race, drafted the makefile edit, commit message, and this description, and reproduced/validated the failure and fix locally.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.