### PR TITLE
docs: Fix CSI driver liveness monitoring details

### DIFF
--- a/Documentation/Storage-Configuration/Monitoring/ceph-monitoring.md
+++ b/Documentation/Storage-Configuration/Monitoring/ceph-monitoring.md
@@ -270,18 +270,19 @@ After this you only need to create the service monitor as stated above.
 
 ### CSI Liveness
 
-To integrate CSI liveness into ceph monitoring we will need to deploy
-a service and service monitor.
+To integrate CSI liveness into Ceph monitoring we will need to deploy a service monitor.
 
 ```console
 kubectl create -f csi-metrics-service-monitor.yaml
 ```
 
-This will create the service monitor to have prometheus monitor CSI
+This will create the service monitor to have prometheus monitor all CSI plugins where liveness metrics are enabled.
+The Ceph CSI operator takes care of creating the corresponding services.
 
 !!! note
     Please note that the liveness sidecar is disabled by default.
-    To enable it set `CSI_ENABLE_LIVENESS` to `true` in the Rook operator settings (operator.yaml).
+    When manually managing the drivers set `spec.liveness.metricsPort` in the Driver spec.
+    When using the ceph-csi-drivers Helm chart set `operatorConfig.driverSpecDefaults.liveness.enabled: true` or `drivers.$driver.liveness.enabled: true` in the values.
 
 ### Collecting RBD per-image IO statistics
 


### PR DESCRIPTION
With #17176 management of the CSI drivers was moved to the ceph-csi-drivers chart. This changed the way liveness monitoring for the drivers has to be configured.
The ceph-csi-drivers Chart currently has no way of enabling the liveness sidecar, so this change depends on ceph/ceph-csi-operator#549 and might need further adjustment.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
