### PR TITLE
csi: update VolumeGroupSnapshot examples from beta to v1

### DIFF
--- a/deploy/examples/csi/cephfs/groupsnapshot.yaml
+++ b/deploy/examples/csi/cephfs/groupsnapshot.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: groupsnapshot.storage.k8s.io/v1beta1
+apiVersion: groupsnapshot.storage.k8s.io/v1
 kind: VolumeGroupSnapshot
 metadata:
   name: cephfs-groupsnapshot

--- a/deploy/examples/csi/cephfs/groupsnapshotclass.yaml
+++ b/deploy/examples/csi/cephfs/groupsnapshotclass.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: groupsnapshot.storage.k8s.io/v1beta1
+apiVersion: groupsnapshot.storage.k8s.io/v1
 kind: VolumeGroupSnapshotClass
 metadata:
   name: csi-cephfsplugin-groupsnapclass


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

ceph-csi has updated the VolumeGroupSnapshot API version to v1. Update the example YAMLs to use groupsnapshot.storage.k8s.io/v1 instead of v1beta1.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
