### PR TITLE
osd: retry activate fallback scan with whole disks only

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -219,7 +219,7 @@ sys.exit('no disk found with OSD ID $OSD_ID')
 		ceph-volume raw list $SCAN_DEVICES > "$OSD_LIST"
 		cat "$OSD_LIST"
 
-		if ! find_device < "$OSD_LIST" > /dev/null; then
+		if ! find_device < "$OSD_LIST" > /dev/null 2>&1; then
 			# On Ceph v20.2.2, 'ceph-volume raw list' has been observed to return no
 			# results at all when a node's partitioned OS disk is scanned together with
 			# other whole disks (see https://github.com/rook/rook/issues/17992). Retry

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -219,6 +219,19 @@ sys.exit('no disk found with OSD ID $OSD_ID')
 		ceph-volume raw list $SCAN_DEVICES > "$OSD_LIST"
 		cat "$OSD_LIST"
 
+		if ! find_device < "$OSD_LIST" > /dev/null; then
+			# On Ceph v20.2.2, 'ceph-volume raw list' has been observed to return no
+			# results at all when a node's partitioned OS disk is scanned together with
+			# other whole disks (see https://github.com/rook/rook/issues/17992). Retry
+			# with whole disks only, which still finds a renamed whole-disk OSD.
+			SCAN_DISKS_ONLY="$(lsblk --noheadings --paths --list --output NAME,TYPE | awk '$2 == "disk" {print $1}' | grep -vE '^/dev/(rbd|nbd|zram|drbd)' || true)"
+			if [[ -n "$SCAN_DISKS_ONLY" ]]; then
+				# shellcheck disable=SC2086 # word splitting of the device list is intended
+				ceph-volume raw list $SCAN_DISKS_ONLY > "$OSD_LIST"
+				cat "$OSD_LIST"
+			fi
+		fi
+
 		DEVICE="$(find_device < "$OSD_LIST")"
 	fi
 	[[ -z "$DEVICE" ]] && { echo "no device" ; exit 1 ; }


### PR DESCRIPTION
On a raw-mode OSD whose persisted device path (ROOK_BLOCK_PATH) is
stale after a reboot renamed /dev/sdX, the activate init container
falls back to a full scan built from lsblk, listing both "disk" and
"part" typed block devices and passing them all to a single
`ceph-volume raw list` invocation.

On Ceph v20.2.2, this combined scan has been reported to return `{}`
(no results at all) when a node's partitioned OS disk (e.g. /dev/sda
with /dev/sda1, /dev/sda2, /dev/sda5) is scanned together with other
whole OSD disks, even though the OSD data on those whole disks is
intact and individually readable. With DEVICE left empty, the init
container exits 1 and the OSD pod enters Init:CrashLoopBackOff. On the
reporter's cluster, this took down 10 of 12 OSDs after a single
reboot.

We can't just drop partition-typed devices from the scan list:
Rook's raw mode legitimately supports OSDs on partitions (see
pkg/daemon/ceph/osd/volume.go and its "raw mode on partition" test),
and the fallback must still be able to locate a renamed partition-
backed OSD.

Instead, if the combined disk+partition scan can't find the OSD ID,
retry with a second `ceph-volume raw list` scan restricted to whole
disks only. This mirrors the invocation the issue reporter verified
works directly against ceph-volume v20.2.2 (whole disks only,
including the unrelated OS disk). If this narrower scan also finds
nothing, behavior is unchanged from before: the script still exits 1.
This does not help a renamed partition-backed OSD hit this specific
ceph-volume failure mode, since the retry excludes partitions by
design, but it does recover the common whole-disk case reported here.

Validation: since this logic is a bash script embedded as a Go string
constant with no existing test harness executing it, and a live Ceph
v20.2.2 cluster isn't available in this environment, I extracted the
script and exercised it under bash with lsblk/ceph-volume replaced by
mocks that reproduce the reported failure (combined scan returns `{}`,
single-device and whole-disk-only scans succeed), confirming: (1) the
normal case is unaffected, (2) the whole-disk retry recovers the OSD
when the combined scan is empty, and (3) the script still fails
cleanly (exit 1) when no scan finds the OSD, matching pre-fix
behavior.

Also ran:
  go build ./pkg/operator/ceph/cluster/osd/...
  go test ./pkg/operator/ceph/cluster/osd/...
Both passed.

Fixes #17992

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
