### PR TITLE
osd: list scan devices individually in raw activate fallback

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -215,11 +215,21 @@ sys.exit('no disk found with OSD ID $OSD_ID')
 		# supported for CI and local testing.
 		SCAN_DEVICES="$(lsblk --noheadings --paths --list --output NAME,TYPE | awk '$2 == "disk" || $2 == "part" {print $1}' | grep -vE '^/dev/(rbd|nbd|zram|drbd)' || true)"
 		[[ -z "$SCAN_DEVICES" ]] && { echo "no devices to scan for OSD $OSD_ID" ; exit 1 ; }
+		# List the devices one at a time: ceph-volume folds the whole scan list into a
+		# single ceph-bluestore-tool call and reports {} for the entire scan when that
+		# one process fails, so a single unreadable device would otherwise hide every
+		# OSD from the scan. On Ceph v20.2.x, sub-4KiB devices (e.g. the 1KiB extended-
+		# partition node of an MBR-partitioned OS disk) crash the batched call exactly
+		# that way (https://tracker.ceph.com/issues/76354).
+		DEVICE=""
 		# shellcheck disable=SC2086 # word splitting of the device list is intended
-		ceph-volume raw list $SCAN_DEVICES > "$OSD_LIST"
-		cat "$OSD_LIST"
-
-		DEVICE="$(find_device < "$OSD_LIST")"
+		for DEV in $SCAN_DEVICES; do
+			ceph-volume raw list "$DEV" > "$OSD_LIST" || continue
+			cat "$OSD_LIST"
+			if DEVICE="$(find_device < "$OSD_LIST")"; then
+				break
+			fi
+		done
 	fi
 	[[ -z "$DEVICE" ]] && { echo "no device" ; exit 1 ; }
 


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #17992

**What is this PR about? / Why do we need it?**

The raw-mode activate init container's device-rename fallback passes its entire lsblk-derived scan list to a single `ceph-volume raw list` invocation. ceph-volume folds every device into one batched `ceph-bluestore-tool show-label` call and treats any non-zero exit from it as "no devices found", so a single unreadable device blanks the whole scan and activation fails with "no device" even though the OSD's BlueStore data is intact and individually readable.

On Ceph v20.2.x, a block device smaller than 4KiB deterministically aborts that batched call ([tracker.ceph.com/issues/76354](https://tracker.ceph.com/issues/76354): `KernelDevice::_aio_stop()`'s wake-up read fails its `is_valid_io` assert after the device size rounds down to 0; fixed on ceph main by ceph/ceph#69971 on 2026-07-20, with no tentacle backport yet, so the abort is present in every released v20.2.x). The 1KiB extended-partition container node of an MBR-partitioned OS disk is exactly such a device, so on nodes with an MBR OS disk the fallback scan always returns `{}`, and every raw-mode OSD on the node enters `Init:CrashLoopBackOff` after a reboot reorders `/dev/sdX` names — 10 of 12 OSDs down in the #17992 report. Reproducible without cluster hardware: in a `quay.io/ceph/ceph:v20.2.2` container, `ceph-bluestore-tool show-label` with a 1KiB `--dev` among its arguments SIGABRTs, and `ceph-volume raw list` over the same set prints `{}` and exits 0.

This PR lists the scan devices one at a time, skipping devices whose listing fails or reports no match, and stopping at the first device whose listing contains the wanted OSD id. One poisoned device can then no longer hide the OSD from the fallback, whichever ceph bug or device quirk poisons it. The per-device loop also keeps the fallback usable when an unrelated device's listing yields entries the ID parser cannot digest (the BlueFS DB entries of #17983), and it deliberately keeps partitions in the scan — OSDs on partitions are supported, so narrowing the scan to whole disks (#18003's approach) would leave partition-hosted OSDs unfindable while still failing whenever a whole disk is unreadable. The osd-prepare job's listing was hardened the same way for the same ceph line in #17882 (merged); this change closes the equivalent gap on the activate path, which runs on every OSD pod start rather than once at creation.

**AI assistance:** AI (Claude Code) root-caused the failure (reproduced the ceph-bluestore-tool abort against `quay.io/ceph/ceph:v20.2.1`/`v20.2.2` containers and bisected it to ceph tracker 76354), located the change site, and drafted the shell edit, the commit message, and this description.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

