### PR TITLE
object: return an error when reconciled rgw user has no keys

### DIFF
--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -507,7 +507,7 @@ func (r *ReconcileObjectStoreUser) createOrUpdateCephUser(u *cephv1.CephObjectSt
 		// use the keys already set on the user & remove all but one key
 		if len(liveUser.Keys) == 0 {
 			// something is wrong, there should be at least one key
-			return errors.Wrapf(err, "no keys set for user %q", u.Name)
+			return errors.Errorf("no keys set for user %q", u.Name)
 		}
 
 		targetUser.Keys = []admin.UserKeySpec{liveUser.Keys[0]}

--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -650,6 +650,79 @@ func TestGenerateUserConfigCephVersionChecks(t *testing.T) {
 	})
 }
 
+func TestCreateOrUpdateCephUserNoKeys(t *testing.T) {
+	// Set DEBUG logging
+	capnslog.SetGlobalLogLevel(capnslog.DEBUG)
+
+	objectUser := &cephv1.CephObjectStoreUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: cephv1.ObjectStoreUserSpec{
+			Store: store,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CephObjectStoreUser",
+		},
+	}
+
+	// A live RGW user the API returned with no access keys. The user spec also
+	// carries no explicit keys, so createOrUpdateCephUser falls back to the live
+	// user's keys and must surface an error since there are none.
+	//nolint:gosec // only test values, not a real secret
+	userNoKeysJSON := `{
+	"user_id": "my-user",
+	"display_name": "my-user",
+	"max_buckets": 1000,
+	"keys": [],
+	"swift_keys": [],
+	"caps": [],
+	"op_mask": "read, write, delete",
+	"bucket_quota": {"enabled": false, "max_size": -1, "max_objects": -1},
+	"user_quota": {"enabled": false, "max_size": -1, "max_objects": -1},
+	"type": "rgw"
+}`
+
+	mockClient := &cephobject.MockClient{
+		MockDo: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path != "rook-ceph-rgw-my-store.mycluster.svc/admin/user" {
+				return nil, fmt.Errorf("unexpected url path %q", req.URL.Path)
+			}
+
+			if req.Method == http.MethodGet && req.URL.RawQuery == "format=json&uid=my-user" {
+				return &http.Response{
+					StatusCode: 200,
+					Body:       io.NopCloser(bytes.NewReader([]byte(userNoKeysJSON))),
+				}, nil
+			}
+
+			if req.Method == http.MethodPut && req.URL.RawQuery == "enabled=false&format=json&max-objects=-1&max-size=-1&quota=&quota-type=user&uid=my-user" {
+				return &http.Response{
+					StatusCode: 200,
+					Body:       io.NopCloser(bytes.NewReader([]byte(userNoKeysJSON))),
+				}, nil
+			}
+
+			return nil, fmt.Errorf("unexpected request: %q. method %q. path %q", req.URL.RawQuery, req.Method, req.URL.Path)
+		},
+	}
+	adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient)
+	assert.NoError(t, err)
+	r := &ReconcileObjectStoreUser{
+		objContext: &cephobject.AdminOpsContext{
+			AdminOpsClient: adminClient,
+		},
+		opManagerContext: context.TODO(),
+	}
+
+	userConfig, err := generateUserConfig(objectUser, cephver.Minimum)
+	require.NoError(t, err)
+	err = r.createOrUpdateCephUser(objectUser, userConfig)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no keys set for user")
+}
+
 func TestValidateUser(t *testing.T) {
 	r := &ReconcileObjectStoreUser{}
 


### PR DESCRIPTION
`createOrUpdateCephUser` falls back to the live RGW user's keys when the desired
user carries none. If that live user also has zero keys the reconciler intends
to fail, but it built the error with `errors.Wrapf(err, ...)` at a point where
`err` is already nil — and `errors.Wrapf(nil, ...)` returns nil, so the failure
was swallowed and the function returned success on a user it had itself flagged
as broken. Reconcile then reached `generateCephUserSecret`, which indexes
`userConfig.Keys[0]` and panicked on the empty slice; the deferred
`RecoverAndLogException` caught the panic, so the reconcile was abandoned before
the Ready status update and — because the recovered `Reconcile` returns a zero
result with a nil error — was not requeued either.

This constructs the error with `errors.Errorf` so the intended failure surfaces,
and adds a regression test for the keyless-live-user path.

Supersedes #17981 by @anxkhn — carried forward onto current master (the original
branch had conflicts), with the added test updated to the post-#17250
`generateUserConfig` signature and the commit message corrected. Authorship is
preserved on the commit (author @anxkhn, plus a maintainer sign-off).

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

---

AI assistance: an AI tool helped locate the swallowed error and draft the fix and
this description; this PR carries forward the AI-assisted contribution from
#17981 with a corrected, rebased commit.
