### PR TITLE
object: return an error when the multisite zone is not found

### DIFF
--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -671,7 +671,7 @@ func (r *ReconcileCephObjectStore) retrieveMultisiteZone(store *cephv1.CephObjec
 	_, err := RunAdminCommandNoMultisite(objContext, true, "zone", "get", realmArg, zoneGroupArg, zoneArg)
 	if err != nil {
 		// ENOENT mean "No such file or directory"
-		if code, err := exec.ExtractExitCode(err); err == nil && code == int(syscall.ENOENT) {
+		if code, ok := exec.ExitStatus(err); ok && code == int(syscall.ENOENT) {
 			return waitForRequeueIfObjectStoreNotReady, errors.Wrapf(err, "ceph zone %q not found", store.Spec.Zone.Name)
 		} else {
 			return waitForRequeueIfObjectStoreNotReady, errors.Wrapf(err, "radosgw-admin zone get failed with code %d", code)

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -20,7 +20,9 @@ package object
 import (
 	"context"
 	"os"
+	osexec "os/exec"
 	"reflect"
+	"syscall"
 	"testing"
 	"time"
 
@@ -39,6 +41,7 @@ import (
 	"github.com/rook/rook/pkg/util/dependents"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -46,6 +49,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
+	kexec "k8s.io/client-go/util/exec"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -975,6 +979,89 @@ func TestCephObjectStoreControllerZoneNotReady(t *testing.T) {
 			assert.True(t, res.RequeueAfter > 0, "expected requeue while waiting for zone Ready")
 		})
 	}
+}
+
+func TestRetrieveMultisiteZone(t *testing.T) {
+	// When "radosgw-admin zone get" fails with ENOENT the Ceph zone does not exist
+	// yet (the CephObjectZone is configured asynchronously by its own controller).
+	// retrieveMultisiteZone must return a non-nil error so the caller requeues and
+	// waits for the zone, instead of proceeding to reconcile the object store
+	// against a zone that is not there.
+	zoneName := "zone-a"
+	zoneGroupName := "zonegroup-a"
+	realmName := "realm-a"
+
+	objectStore := &cephv1.CephObjectStore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      store,
+			Namespace: namespace,
+		},
+	}
+	objectStore.Spec.Zone.Name = zoneName
+
+	newReconciler := func(zoneGetErr error) *ReconcileCephObjectStore {
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
+				if args[0] == "zone" && args[1] == "get" {
+					return "", zoneGetErr
+				}
+				return "", nil
+			},
+		}
+		return &ReconcileCephObjectStore{
+			context:     &clusterd.Context{Executor: executor},
+			clusterInfo: client.AdminTestClusterInfo(namespace),
+		}
+	}
+
+	t.Run("zone not found returns an error and requeues", func(t *testing.T) {
+		enoentErr := kexec.CodeExitError{Err: errors.New("exit status 2"), Code: int(syscall.ENOENT)}
+		r := newReconciler(enoentErr)
+
+		res, err := r.retrieveMultisiteZone(objectStore, zoneGroupName, realmName)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+		assert.NotContains(t, err.Error(), "failed with code")
+		assert.True(t, res.RequeueAfter > 0, "expected requeue while waiting for the zone to be created")
+	})
+
+	t.Run("other zone get failure returns an error and requeues", func(t *testing.T) {
+		otherErr := kexec.CodeExitError{Err: errors.New("exit status 13"), Code: int(syscall.EACCES)}
+		r := newReconciler(otherErr)
+
+		res, err := r.retrieveMultisiteZone(objectStore, zoneGroupName, realmName)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed with code")
+		assert.NotContains(t, err.Error(), "not found")
+		assert.True(t, res.RequeueAfter > 0, "expected requeue on a zone get failure")
+	})
+
+	t.Run("os/exec ExitError from the non-multus path is handled", func(t *testing.T) {
+		// The non-multus path returns *exec.ExitError (os/exec), not the
+		// kexec.CodeExitError the multus proxy path returns. Use a real one so
+		// ExitStatus is exercised on the type that occurs without Multus; the
+		// ENOENT branch itself is covered by the kexec subtest above.
+		realErr := osexec.Command("false").Run() // genuine *exec.ExitError, exit code 1
+		require.IsType(t, &osexec.ExitError{}, realErr)
+		r := newReconciler(realErr)
+
+		res, err := r.retrieveMultisiteZone(objectStore, zoneGroupName, realmName)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed with code")
+		assert.True(t, res.RequeueAfter > 0, "expected requeue on a zone get failure")
+	})
+
+	t.Run("error ExitStatus cannot classify still requeues", func(t *testing.T) {
+		// An error that is neither *exec.ExitError nor kexec.CodeExitError makes
+		// ExitStatus return (0, false); the fix must still surface a non-nil
+		// error so the caller requeues rather than proceeding.
+		r := newReconciler(errors.New("connection refused"))
+
+		res, err := r.retrieveMultisiteZone(objectStore, zoneGroupName, realmName)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed with code")
+		assert.True(t, res.RequeueAfter > 0, "expected requeue on a zone get failure")
+	})
 }
 
 func TestCephObjectExternalStoreController(t *testing.T) {


### PR DESCRIPTION
`retrieveMultisiteZone` gates the object-store reconcile on the backing Ceph
zone existing: it runs `radosgw-admin zone get` and, on failure, returns a
non-nil error so the caller requeues. That gate was dead code. The ENOENT check
declared an inner `err` from `exec.ExtractExitCode` that shadowed the outer
command error, and `ExtractExitCode` returns a nil error for the ordinary exit
failures `radosgw-admin` produces, so both branches wrapped a nil and
`errors.Wrapf(nil, ...)` is nil — the requeue was dropped and reconcile ran on,
standing up the RGW service, admin-ops endpoint, and deployment for a multisite
store whose backing zone does not exist.

This restores `exec.ExitStatus` (which returns `(code, ok)` and leaves `err`
unshadowed), matching the sibling realm/zonegroup/zone controllers, so a failed
`zone get` requeues until the zone exists.

The gate was correct when `fc579f4520` introduced it in 2020 with
`exec.ExitStatus`; `bd58790c31` ("proxy ceph commands when multus is
configured", 2021) swapped it to `exec.ExtractExitCode` as an unrelated
drive-by, inverting the contract — the archaeology requested on the original PR.

Supersedes #17970 by @anxkhn — carried forward with the `require.Error` fix and a
corrected commit message. Authorship preserved (author @anxkhn, plus a
maintainer sign-off). @BlaineEXE — this addresses your change request: the
`fc579f4520` → `bd58790c31` history is now in the commit body as the regression
evidence you asked for.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

---

AI assistance: an AI tool helped locate the shadowed-error regression and draft
the fix, the archaeology, and this description; this PR carries forward the
AI-assisted contribution from #17970 with a corrected commit.
