### PR TITLE
osd: archive crash on OSD removal

### DIFF
--- a/pkg/daemon/ceph/osd/remove.go
+++ b/pkg/daemon/ceph/osd/remove.go
@@ -222,22 +222,24 @@ func archiveCrash(clusterdContext *clusterd.Context, clusterInfo *client.Cluster
 		logger.Errorf("failed to list ceph crash. %v", err)
 		return
 	}
-	if crash != nil {
+	if len(crash) == 0 {
 		logger.Info("no ceph crash to silence")
 		return
 	}
 
-	var crashID string
+	osdEntity := fmt.Sprintf("osd.%d", osdID)
+	matched := false
 	for _, c := range crash {
-		if c.Entity == fmt.Sprintf("osd.%d", osdID) {
-			crashID = c.ID
-			break
+		if c.Entity != osdEntity {
+			continue
+		}
+		matched = true
+		if err := client.ArchiveCrash(clusterdContext, clusterInfo, c.ID); err != nil {
+			logger.Errorf("failed to archive the crash %q. %v", c.ID, err)
 		}
 	}
-
-	err = client.ArchiveCrash(clusterdContext, clusterInfo, crashID)
-	if err != nil {
-		logger.Errorf("failed to archive the crash %q. %v", crashID, err)
+	if !matched {
+		logger.Infof("no ceph crash for osd.%d to silence", osdID)
 	}
 }
 

--- a/pkg/daemon/ceph/osd/remove_test.go
+++ b/pkg/daemon/ceph/osd/remove_test.go
@@ -21,11 +21,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	oposd "github.com/rook/rook/pkg/operator/ceph/cluster/osd"
 	testexec "github.com/rook/rook/pkg/operator/test"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -160,4 +162,88 @@ func testVolumeClaim(name string) cephv1.VolumeClaimTemplate {
 	}}
 	claim.Name = name
 	return claim
+}
+
+func TestArchiveCrash(t *testing.T) {
+	newExecutor := func(crashList string, archived *[]string) *exectest.MockExecutor {
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			if args[0] == "crash" && args[1] == "ls" {
+				return crashList, nil
+			}
+			if args[0] == "crash" && args[1] == "archive" {
+				*archived = append(*archived, args[2])
+				return "", nil
+			}
+			return "", errors.Errorf("unexpected ceph command %q", args)
+		}
+		return executor
+	}
+
+	t.Run("archives the crash for the removed osd", func(t *testing.T) {
+		crashList := `[
+			{
+				"crash_id": "2020-11-09_13:58:08.230130Z_ca918f58-c078-444d-a91a-bd972c14c155",
+				"entity_name": "osd.1"
+			},
+			{
+				"crash_id": "2020-11-09_13:58:08.230130Z_bd972c14-c155-444d-a91a-ca918f58c078",
+				"entity_name": "osd.0"
+			}
+		]`
+		var archived []string
+		context := &clusterd.Context{Executor: newExecutor(crashList, &archived)}
+
+		archiveCrash(context, client.AdminTestClusterInfo("mycluster"), 0)
+		assert.Equal(t, []string{"2020-11-09_13:58:08.230130Z_bd972c14-c155-444d-a91a-ca918f58c078"}, archived)
+	})
+
+	t.Run("archives every crash for the removed osd", func(t *testing.T) {
+		// ceph crash ls is oldest-first and includes already-archived entries, so an osd
+		// with more than one crash must have all of them archived, not just the first match.
+		crashList := `[
+			{
+				"crash_id": "2020-11-09_13:58:08.230130Z_00000000-0000-0000-0000-000000000000",
+				"entity_name": "osd.0"
+			},
+			{
+				"crash_id": "2020-11-09_13:58:08.230130Z_ca918f58-c078-444d-a91a-bd972c14c155",
+				"entity_name": "osd.1"
+			},
+			{
+				"crash_id": "2020-11-09_13:58:08.230130Z_bd972c14-c155-444d-a91a-ca918f58c078",
+				"entity_name": "osd.0"
+			}
+		]`
+		var archived []string
+		context := &clusterd.Context{Executor: newExecutor(crashList, &archived)}
+
+		archiveCrash(context, client.AdminTestClusterInfo("mycluster"), 0)
+		assert.Equal(t, []string{
+			"2020-11-09_13:58:08.230130Z_00000000-0000-0000-0000-000000000000",
+			"2020-11-09_13:58:08.230130Z_bd972c14-c155-444d-a91a-ca918f58c078",
+		}, archived)
+	})
+
+	t.Run("does not archive when there is no crash", func(t *testing.T) {
+		var archived []string
+		context := &clusterd.Context{Executor: newExecutor("[]", &archived)}
+
+		archiveCrash(context, client.AdminTestClusterInfo("mycluster"), 0)
+		assert.Empty(t, archived)
+	})
+
+	t.Run("does not archive when no crash matches the removed osd", func(t *testing.T) {
+		crashList := `[
+			{
+				"crash_id": "2020-11-09_13:58:08.230130Z_ca918f58-c078-444d-a91a-bd972c14c155",
+				"entity_name": "osd.1"
+			}
+		]`
+		var archived []string
+		context := &clusterd.Context{Executor: newExecutor(crashList, &archived)}
+
+		archiveCrash(context, client.AdminTestClusterInfo("mycluster"), 0)
+		assert.Empty(t, archived)
+	})
 }


### PR DESCRIPTION
`archiveCrash` is meant to silence the `RECENT_CRASH` health warning for a
removed OSD, but its early-return guard was inverted: `GetCrashList` unmarshals
`ceph crash ls` into a non-nil slice on every success, so `if crash != nil` was
always true, the "no crash to silence" branch never ran, and the archive loop
was effectively unreachable — the crash was never archived and the warning
lingered. Guarding on `len(crash) == 0` fixes it.

Reviving the loop surfaced two latent bugs it had masked, both fixed here:
- with a non-empty list but no entry for the removed OSD, the crash id stayed
  empty and the code ran `ceph crash archive ""` → mgr EINVAL, a spurious error
  on routine removals; the archive is now skipped when nothing matches;
- the loop broke on the first match, but `ceph crash ls` is oldest-first and
  includes already-archived entries, so an OSD with several crashes had only its
  oldest archived while `RECENT_CRASH` persisted; all matching entries are now
  archived (`ceph crash archive <id>` is idempotent, so re-archiving is a no-op).

The test is extended to all four cases (single match, several matches, empty
list, non-empty with no match → nothing archived).

Supersedes #17967 by @anxkhn — carried forward with the two additional fixes and
a corrected commit message. Authorship preserved (author @anxkhn, plus a
maintainer sign-off). Note: #17976 (by @magic-peach) proposes the same one-line
guard without a test and additionally fixes an unrelated fd leak in
`pkg/util/file.go`; that fd-leak fix is not included here and should be preserved
separately.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

---

AI assistance: an AI tool helped locate the inverted guard and the two latent
bugs and draft the fix and this description; this PR carries forward the
AI-assisted contribution from #17967 with a corrected commit.
