### PR TITLE
core: fix data race reading exec output on timeout

### DIFF
--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -39,6 +39,11 @@ const TimeoutWaitingForMessage = "exec timeout waiting for"
 
 var CephCommandsTimeout = 15 * time.Second
 
+// outputDrainGracePeriod bounds how long executeCommandWithTimeout waits for the
+// os/exec output-copier goroutines to drain after killing a timed-out process,
+// so a killed command that orphaned a pipe holder cannot block the caller forever.
+var outputDrainGracePeriod = 500 * time.Millisecond
+
 // Executor is the main interface for all the exec commands
 type Executor interface {
 	ExecuteCommand(command string, arg ...string) error
@@ -122,14 +127,26 @@ func executeCommandWithTimeout(timeout time.Duration, command string, stdin *str
 		case <-time.After(timeout):
 			if interruptSent {
 				logger.Infof("%s process %s to return after interrupt signal was sent. Sending kill signal to the process", TimeoutWaitingForMessage, command)
-				var e error
 				if err := cmd.Process.Kill(); err != nil {
 					logger.Errorf("Failed to kill process %s: %v", command, err)
-					e = fmt.Errorf("%s the command %s to return after interrupt signal was sent. Tried to kill the process but that failed: %v", TimeoutWaitingForMessage, command, err)
-				} else {
-					e = fmt.Errorf("%s the command %s to return", TimeoutWaitingForMessage, command)
+					// The process may still be running with the output-copier
+					// goroutines writing into b, so don't read it here.
+					return "", fmt.Errorf("%s the command %s to return; sent an interrupt, then the kill failed: %v", TimeoutWaitingForMessage, command, err)
 				}
-				return strings.TrimSpace(b.String()), e
+				// Kill() only signals the process; the os/exec goroutines that copy
+				// its output into b are joined only by cmd.Wait() (done). Reading b
+				// before done fires races with those writers, so wait for them. Bound
+				// the wait, though — a killed process can leave an orphaned descendant
+				// holding the output pipe open (a D-state cryptsetup/dmsetup child, or
+				// the downstream of a "sh -c '... | head'" pipeline), so cmd.Wait() may
+				// never return. Give up on the captured output after a grace period
+				// rather than blocking the caller forever.
+				select {
+				case <-done:
+					return strings.TrimSpace(b.String()), fmt.Errorf("%s the command %s to return", TimeoutWaitingForMessage, command)
+				case <-time.After(outputDrainGracePeriod):
+					return "", fmt.Errorf("%s the command %s to return", TimeoutWaitingForMessage, command)
+				}
 			}
 
 			logger.Infof("%s process %s to return. Sending interrupt signal to the process", TimeoutWaitingForMessage, command)

--- a/pkg/util/exec/exec_test.go
+++ b/pkg/util/exec/exec_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kexec "k8s.io/utils/exec"
@@ -201,4 +202,25 @@ func TestExecuteCommandWithTimeout(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestExecuteCommandWithTimeoutKillPath exercises the timeout branch where the
+// command ignores the interrupt signal and must be killed, while it keeps
+// writing to stdout. The output buffer must only be read after cmd.Wait()
+// returns; otherwise the read races with the goroutines that copy the command's
+// output into the buffer. Run with `-race` to catch a regression.
+func TestExecuteCommandWithTimeoutKillPath(t *testing.T) {
+	// The child ignores SIGINT and continuously writes to stdout, so the
+	// interrupt is sent first and the kill path is taken while writers are active.
+	// The per-phase timeout must be generous enough that sh installs its SIGINT
+	// trap before the interrupt arrives on a loaded runner; otherwise sh dies on
+	// the interrupt and the kill path under test is never exercised.
+	stdin := ""
+	_, err := executeCommandWithTimeout(
+		500*time.Millisecond,
+		"sh", &stdin,
+		"-c", "trap '' INT; while true; do echo x; done",
+	)
+	require.Error(t, err)
+	assert.True(t, IsTimeout(err))
 }


### PR DESCRIPTION
`executeCommandWithTimeout` wires a single `bytes.Buffer` to both `cmd.Stdout`
and `cmd.Stderr` and joins the command via `cmd.Wait()` in a goroutine. On the
timeout kill path it called `cmd.Process.Kill()` and then read that buffer
without waiting for `cmd.Wait()` to return — but `Kill()` only signals the
process; it does not wait for os/exec's output-copier goroutine (joined only by
`cmd.Wait`) to finish, so the read races the still-running writer, which the race
detector flags.

The buffer is now read only once the copier has drained, signalled by
`cmd.Wait()` on the `done` channel.

**Design note (reviewer attention):** a killed process can leave an orphaned
descendant holding the output pipe open — a D-state `cryptsetup`/`dmsetup` child,
or the downstream of a `sh -c '... | head'` pipeline (both are real callers:
`encryption.go`, `rados.go`) — so `cmd.Wait()` may never return. Rather than an
unconditional `<-done` (which would reintroduce the unbounded block that #12818
deliberately avoided), the drain is **bounded**: `select { case <-done: return
buffer; case <-time.After(500ms): return "" }`. On the grace branch — and on a
failed `Kill()` — the buffer is never read, so there is no concurrent access; on
the normal kill the `<-done` arm wins in microseconds. 500ms is a short bound
against the timeouts already consumed (e.g. 2×15s), and returning `""` + the
correct `IsTimeout` error is graceful. The `exec.CommandContext`+`WaitDelay`
alternative was considered but rejected as an orthogonal refactor of the
signal-escalation on rook's most sensitive exec path. The pre-existing goroutine
leak in the orphan case is unchanged (not this fix's scope).

A regression test drives the kill path with a child that ignores SIGINT while
writing to stdout; it fails under `-race` before this change.

Supersedes #17964 by @anxkhn — carried forward with the unbounded `<-done`
replaced by the bounded drain above, the test timeout raised off a racy 50ms, a
`require.Error` fix, and a corrected commit message. Authorship preserved (author
@anxkhn, plus a maintainer sign-off).

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

---

AI assistance: an AI tool helped locate the race and draft the fix and this
description; this PR carries forward the AI-assisted contribution from #17964,
re-implementing the drain to be bounded and correcting the commit.
