### PR TITLE
osd: skip upgrades for OSDs pending migration when the last migration is incomplete

### DIFF
--- a/pkg/operator/ceph/cluster/osd/migrate_test.go
+++ b/pkg/operator/ceph/cluster/osd/migrate_test.go
@@ -24,6 +24,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -221,5 +222,59 @@ func TestIsLastOSDMigrationComplete(t *testing.T) {
 		result, err := isLastOSDMigrationComplete(c)
 		assert.NoError(t, err)
 		assert.Equal(t, true, result)
+	})
+}
+
+func TestStartOSDMigration(t *testing.T) {
+	namespace := "rook-ceph"
+	clientset := fake.NewClientset()
+	// PGs report as clean so migration is not blocked on PG health.
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			if args[0] == "status" {
+				return "{}", nil
+			}
+			return "", nil
+		},
+	}
+	ctx := &clusterd.Context{
+		Clientset: clientset,
+		Executor:  executor,
+	}
+	clusterInfo := &cephclient.ClusterInfo{
+		Namespace: namespace,
+		Context:   context.TODO(),
+	}
+	clusterInfo.SetName("mycluster")
+	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
+
+	c := New(ctx, clusterInfo, cephv1.ClusterSpec{}, "rook/rook:master")
+	c.spec.Storage.Migration.Confirmation = OSDMigrationConfirmation
+	c.spec.Storage.Store.Type = "newStore"
+
+	t.Run("pending OSDs are returned without starting a new migration when the previous one is incomplete", func(t *testing.T) {
+		// osd.2 still runs on the old store, so it is pending migration.
+		d2 := getDummyDeploymentOnNode(clientset, c, "node2", 2)
+		d2.Labels[osdStore] = "oldStore"
+		createDeploymentOrPanic(clientset, d2)
+
+		// osd.1 was already migrated but its deployment has not been recreated yet, so the
+		// previous migration is still in progress.
+		err := createMigrationConfigmap("1", namespace, clientset)
+		assert.NoError(t, err)
+
+		migrationConfig, err := c.startOSDMigration()
+		// The reconcile must keep flowing (no error) so the interrupted OSD can be recreated
+		// downstream, while still returning the pending OSDs so the caller removes them from
+		// the update queue.
+		assert.NoError(t, err)
+		assert.NotNil(t, migrationConfig)
+		assert.Equal(t, []int{2}, migrationConfig.getOSDIds())
+
+		// No new migration must be started while the previous one is incomplete: osd.2's
+		// deployment must still exist and no OSD may be recorded for migration.
+		assert.Nil(t, c.migrateOSD)
+		_, err = clientset.AppsV1().Deployments(namespace).Get(context.TODO(), "rook-ceph-osd-2", metav1.GetOptions{})
+		assert.NoError(t, err)
 	})
 }

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -393,22 +393,26 @@ func (c *Cluster) startOSDMigration() (*migrationConfig, error) {
 	}
 
 	if !pgsHealhty {
-		return nil, errors.Wrapf(err, "failed to start migration due to unhealthy PGs")
-	}
-
-	// skip migration if previously migrated OSD is not up yet.
-	migrationComplete, err := isLastOSDMigrationComplete(c)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to check if the last migration was successful or not")
-	}
-
-	if !migrationComplete {
-		return nil, errors.Wrapf(err, "migration of the last OSD is not complete")
+		return nil, errors.New("failed to start migration due to unhealthy PGs")
 	}
 
 	migrationConfig, err := c.newMigrationConfig()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get new OSD migration config")
+	}
+
+	migrationComplete, err := isLastOSDMigrationComplete(c)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to check if the last migration was successful or not")
+	}
+
+	// If the previously migrated OSD's deployment has not been recreated yet, don't start
+	// migrating another OSD. Return the pending set (rather than aborting the reconcile) so the
+	// caller still keeps those OSDs out of the update queue, while the reconcile continues on to
+	// recreate the interrupted OSD so the migration can resume on a later reconcile.
+	if !migrationComplete {
+		log.NamespacedInfo(c.clusterInfo.Namespace, logger, "previously migrated OSD is not recreated yet, deferring migration of the next OSD")
+		return migrationConfig, nil
 	}
 
 	// delete deployment of the osd that needs migration


### PR DESCRIPTION
`startOSDMigration` guards against upgrading OSDs while a migration is in
progress by returning the set of OSDs pending migration, which the caller removes
from the update queue. When the last-migrated OSD's deployment has not been
recreated yet, `isLastOSDMigrationComplete` returns `(false, nil)`;
`startOSDMigration` then ran `return nil, errors.Wrapf(err, ...)` with `err`
already nil, and `errors.Wrapf(nil, ...)` is nil — collapsing to `(nil, nil)`,
the same value used to signal "no migration requested". The caller therefore
skipped pruning, and OSDs still pending migration could be upgraded/restarted
mid-migration — the exact regression that #14776's pruning guard prevented
(introduced by the later refactor `85c81946c`).

This returns the freshly computed pending config in that case so the caller still
prunes, without starting a new migration and without aborting the reconcile.

**Design note (reviewer attention):** the incomplete state is only reachable
after an interrupted prior reconcile, and the code that recreates the interrupted
OSD runs later in `Start`. Aborting here (as the original PR did, via a hard
error) would leave that OSD deleted and wedge every later reconcile — the cluster
could not self-heal. Returning a nil error keeps the recreation path running; the
cluster controller owns/watches the OSD Deployments, so recreation enqueues the
next reconcile, which sees the migration complete and advances the next OSD —
master's existing one-OSD-per-reconcile cadence, unchanged. Reinstating #14776's
explicit end-of-`Start` requeue was considered but would require `Start` to
return more than an `error`, and is unnecessary given the owned-Deployment watch.

The regression test asserts the pending set is returned and no additional OSD is
migrated while a prior migration is still in progress.

Supersedes #17966 by @anxkhn — carried forward with the reconcile-wedging hard
error replaced by the return-pending-set fix above, the test updated to match,
and a corrected commit message (title clarified to name the actual behavior).
Authorship preserved (author @anxkhn, plus a maintainer sign-off).

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

---

AI assistance: an AI tool helped locate the `(nil, nil)` regression and draft the
fix and this description; this PR carries forward the AI-assisted contribution
from #17966, re-implementing it to keep reconcile self-healing and correcting the
commit.
