### PR TITLE
rgw: Fix an object store comment typo

### DIFF
--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -933,7 +933,7 @@ func adjustZoneDefaultPools(objContext *Context, zone map[string]interface{}, sp
 		// default pool is not presented in shared pool spec
 		return zone, nil
 	}
-	// add zone namespace to metadata pool to safely share accorss rgw instances or zones.
+	// add zone namespace to metadata pool to safely share across rgw instances or zones.
 	// in non-multisite case zone name equals to rgw instance name
 	defaultMetaPool = defaultMetaPool + ":" + name
 	for pool, nsSuffix := range zonePoolNSSuffix {


### PR DESCRIPTION
This fixes a comment typo caught by the codespell CI check.
Backport of a single commit from #17908. 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
