### PR TITLE
pool: support CRUSH MSR rules for EC pools

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -7188,6 +7188,34 @@ k8s.io/apimachinery/pkg/api/resource.Quantity
 Value must be a multiple of 4096 (4Ki).</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>crushNumFailureDomains</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Number of failure domains to use for erasure coded chunk placement.
+When specified along with crushOSDsPerFailureDomain, a CRUSH MSR rule will be created
+that distributes chunks across this many failure domains.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>crushOSDsPerFailureDomain</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Number of OSDs allowed per failure domain for erasure coded chunk placement.
+When specified along with crushNumFailureDomains, a CRUSH MSR rule will be created
+that allows up to this many chunks on OSDs within each failure domain.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="ceph.rook.io/v1.ExternalSpec">ExternalSpec

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -468,6 +468,22 @@ spec:
                         This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                       minimum: 0
                       type: integer
+                    crushNumFailureDomains:
+                      description: |-
+                        Number of failure domains to use for erasure coded chunk placement.
+                        When specified along with crushOSDsPerFailureDomain, a CRUSH MSR rule will be created
+                        that distributes chunks across this many failure domains.
+                      format: int32
+                      minimum: 1
+                      type: integer
+                    crushOSDsPerFailureDomain:
+                      description: |-
+                        Number of OSDs allowed per failure domain for erasure coded chunk placement.
+                        When specified along with crushNumFailureDomains, a CRUSH MSR rule will be created
+                        that allows up to this many chunks on OSDs within each failure domain.
+                      format: int32
+                      minimum: 1
+                      type: integer
                     dataChunks:
                       description: |-
                         Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type).
@@ -494,6 +510,9 @@ spec:
                     - codingChunks
                     - dataChunks
                   type: object
+                  x-kubernetes-validations:
+                    - message: crushNumFailureDomains and crushOSDsPerFailureDomain must be specified together
+                      rule: has(self.crushNumFailureDomains) == has(self.crushOSDsPerFailureDomain)
                 failureDomain:
                   description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
                   type: string
@@ -7791,6 +7810,22 @@ spec:
                               This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                             minimum: 0
                             type: integer
+                          crushNumFailureDomains:
+                            description: |-
+                              Number of failure domains to use for erasure coded chunk placement.
+                              When specified along with crushOSDsPerFailureDomain, a CRUSH MSR rule will be created
+                              that distributes chunks across this many failure domains.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          crushOSDsPerFailureDomain:
+                            description: |-
+                              Number of OSDs allowed per failure domain for erasure coded chunk placement.
+                              When specified along with crushNumFailureDomains, a CRUSH MSR rule will be created
+                              that allows up to this many chunks on OSDs within each failure domain.
+                            format: int32
+                            minimum: 1
+                            type: integer
                           dataChunks:
                             description: |-
                               Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type).
@@ -7817,6 +7852,9 @@ spec:
                           - codingChunks
                           - dataChunks
                         type: object
+                        x-kubernetes-validations:
+                          - message: crushNumFailureDomains and crushOSDsPerFailureDomain must be specified together
+                            rule: has(self.crushNumFailureDomains) == has(self.crushOSDsPerFailureDomain)
                       failureDomain:
                         description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
                         type: string
@@ -8001,6 +8039,22 @@ spec:
                             This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
+                        crushNumFailureDomains:
+                          description: |-
+                            Number of failure domains to use for erasure coded chunk placement.
+                            When specified along with crushOSDsPerFailureDomain, a CRUSH MSR rule will be created
+                            that distributes chunks across this many failure domains.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        crushOSDsPerFailureDomain:
+                          description: |-
+                            Number of OSDs allowed per failure domain for erasure coded chunk placement.
+                            When specified along with crushNumFailureDomains, a CRUSH MSR rule will be created
+                            that allows up to this many chunks on OSDs within each failure domain.
+                          format: int32
+                          minimum: 1
+                          type: integer
                         dataChunks:
                           description: |-
                             Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type).
@@ -8027,6 +8081,9 @@ spec:
                         - codingChunks
                         - dataChunks
                       type: object
+                      x-kubernetes-validations:
+                        - message: crushNumFailureDomains and crushOSDsPerFailureDomain must be specified together
+                          rule: has(self.crushNumFailureDomains) == has(self.crushOSDsPerFailureDomain)
                     failureDomain:
                       description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
                       type: string
@@ -12942,6 +12999,22 @@ spec:
                             This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
+                        crushNumFailureDomains:
+                          description: |-
+                            Number of failure domains to use for erasure coded chunk placement.
+                            When specified along with crushOSDsPerFailureDomain, a CRUSH MSR rule will be created
+                            that distributes chunks across this many failure domains.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        crushOSDsPerFailureDomain:
+                          description: |-
+                            Number of OSDs allowed per failure domain for erasure coded chunk placement.
+                            When specified along with crushNumFailureDomains, a CRUSH MSR rule will be created
+                            that allows up to this many chunks on OSDs within each failure domain.
+                          format: int32
+                          minimum: 1
+                          type: integer
                         dataChunks:
                           description: |-
                             Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type).
@@ -12968,6 +13041,9 @@ spec:
                         - codingChunks
                         - dataChunks
                       type: object
+                      x-kubernetes-validations:
+                        - message: crushNumFailureDomains and crushOSDsPerFailureDomain must be specified together
+                          rule: has(self.crushNumFailureDomains) == has(self.crushOSDsPerFailureDomain)
                     failureDomain:
                       description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
                       type: string
@@ -14599,6 +14675,22 @@ spec:
                             This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
+                        crushNumFailureDomains:
+                          description: |-
+                            Number of failure domains to use for erasure coded chunk placement.
+                            When specified along with crushOSDsPerFailureDomain, a CRUSH MSR rule will be created
+                            that distributes chunks across this many failure domains.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        crushOSDsPerFailureDomain:
+                          description: |-
+                            Number of OSDs allowed per failure domain for erasure coded chunk placement.
+                            When specified along with crushNumFailureDomains, a CRUSH MSR rule will be created
+                            that allows up to this many chunks on OSDs within each failure domain.
+                          format: int32
+                          minimum: 1
+                          type: integer
                         dataChunks:
                           description: |-
                             Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type).
@@ -14625,6 +14717,9 @@ spec:
                         - codingChunks
                         - dataChunks
                       type: object
+                      x-kubernetes-validations:
+                        - message: crushNumFailureDomains and crushOSDsPerFailureDomain must be specified together
+                          rule: has(self.crushNumFailureDomains) == has(self.crushOSDsPerFailureDomain)
                     failureDomain:
                       description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
                       type: string
@@ -15712,6 +15807,22 @@ spec:
                             This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
+                        crushNumFailureDomains:
+                          description: |-
+                            Number of failure domains to use for erasure coded chunk placement.
+                            When specified along with crushOSDsPerFailureDomain, a CRUSH MSR rule will be created
+                            that distributes chunks across this many failure domains.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        crushOSDsPerFailureDomain:
+                          description: |-
+                            Number of OSDs allowed per failure domain for erasure coded chunk placement.
+                            When specified along with crushNumFailureDomains, a CRUSH MSR rule will be created
+                            that allows up to this many chunks on OSDs within each failure domain.
+                          format: int32
+                          minimum: 1
+                          type: integer
                         dataChunks:
                           description: |-
                             Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type).
@@ -15738,6 +15849,9 @@ spec:
                         - codingChunks
                         - dataChunks
                       type: object
+                      x-kubernetes-validations:
+                        - message: crushNumFailureDomains and crushOSDsPerFailureDomain must be specified together
+                          rule: has(self.crushNumFailureDomains) == has(self.crushOSDsPerFailureDomain)
                     failureDomain:
                       description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
                       type: string
@@ -15917,6 +16031,22 @@ spec:
                             This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
+                        crushNumFailureDomains:
+                          description: |-
+                            Number of failure domains to use for erasure coded chunk placement.
+                            When specified along with crushOSDsPerFailureDomain, a CRUSH MSR rule will be created
+                            that distributes chunks across this many failure domains.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        crushOSDsPerFailureDomain:
+                          description: |-
+                            Number of OSDs allowed per failure domain for erasure coded chunk placement.
+                            When specified along with crushNumFailureDomains, a CRUSH MSR rule will be created
+                            that allows up to this many chunks on OSDs within each failure domain.
+                          format: int32
+                          minimum: 1
+                          type: integer
                         dataChunks:
                           description: |-
                             Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type).
@@ -15943,6 +16073,9 @@ spec:
                         - codingChunks
                         - dataChunks
                       type: object
+                      x-kubernetes-validations:
+                        - message: crushNumFailureDomains and crushOSDsPerFailureDomain must be specified together
+                          rule: has(self.crushNumFailureDomains) == has(self.crushOSDsPerFailureDomain)
                     failureDomain:
                       description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
                       type: string

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -470,6 +470,22 @@ spec:
                         This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                       minimum: 0
                       type: integer
+                    crushNumFailureDomains:
+                      description: |-
+                        Number of failure domains to use for erasure coded chunk placement.
+                        When specified along with crushOSDsPerFailureDomain, a CRUSH MSR rule will be created
+                        that distributes chunks across this many failure domains.
+                      format: int32
+                      minimum: 1
+                      type: integer
+                    crushOSDsPerFailureDomain:
+                      description: |-
+                        Number of OSDs allowed per failure domain for erasure coded chunk placement.
+                        When specified along with crushNumFailureDomains, a CRUSH MSR rule will be created
+                        that allows up to this many chunks on OSDs within each failure domain.
+                      format: int32
+                      minimum: 1
+                      type: integer
                     dataChunks:
                       description: |-
                         Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type).
@@ -496,6 +512,9 @@ spec:
                     - codingChunks
                     - dataChunks
                   type: object
+                  x-kubernetes-validations:
+                    - message: crushNumFailureDomains and crushOSDsPerFailureDomain must be specified together
+                      rule: has(self.crushNumFailureDomains) == has(self.crushOSDsPerFailureDomain)
                 failureDomain:
                   description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
                   type: string
@@ -7786,6 +7805,22 @@ spec:
                               This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                             minimum: 0
                             type: integer
+                          crushNumFailureDomains:
+                            description: |-
+                              Number of failure domains to use for erasure coded chunk placement.
+                              When specified along with crushOSDsPerFailureDomain, a CRUSH MSR rule will be created
+                              that distributes chunks across this many failure domains.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          crushOSDsPerFailureDomain:
+                            description: |-
+                              Number of OSDs allowed per failure domain for erasure coded chunk placement.
+                              When specified along with crushNumFailureDomains, a CRUSH MSR rule will be created
+                              that allows up to this many chunks on OSDs within each failure domain.
+                            format: int32
+                            minimum: 1
+                            type: integer
                           dataChunks:
                             description: |-
                               Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type).
@@ -7812,6 +7847,9 @@ spec:
                           - codingChunks
                           - dataChunks
                         type: object
+                        x-kubernetes-validations:
+                          - message: crushNumFailureDomains and crushOSDsPerFailureDomain must be specified together
+                            rule: has(self.crushNumFailureDomains) == has(self.crushOSDsPerFailureDomain)
                       failureDomain:
                         description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
                         type: string
@@ -7996,6 +8034,22 @@ spec:
                             This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
+                        crushNumFailureDomains:
+                          description: |-
+                            Number of failure domains to use for erasure coded chunk placement.
+                            When specified along with crushOSDsPerFailureDomain, a CRUSH MSR rule will be created
+                            that distributes chunks across this many failure domains.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        crushOSDsPerFailureDomain:
+                          description: |-
+                            Number of OSDs allowed per failure domain for erasure coded chunk placement.
+                            When specified along with crushNumFailureDomains, a CRUSH MSR rule will be created
+                            that allows up to this many chunks on OSDs within each failure domain.
+                          format: int32
+                          minimum: 1
+                          type: integer
                         dataChunks:
                           description: |-
                             Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type).
@@ -8022,6 +8076,9 @@ spec:
                         - codingChunks
                         - dataChunks
                       type: object
+                      x-kubernetes-validations:
+                        - message: crushNumFailureDomains and crushOSDsPerFailureDomain must be specified together
+                          rule: has(self.crushNumFailureDomains) == has(self.crushOSDsPerFailureDomain)
                     failureDomain:
                       description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
                       type: string
@@ -12931,6 +12988,22 @@ spec:
                             This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
+                        crushNumFailureDomains:
+                          description: |-
+                            Number of failure domains to use for erasure coded chunk placement.
+                            When specified along with crushOSDsPerFailureDomain, a CRUSH MSR rule will be created
+                            that distributes chunks across this many failure domains.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        crushOSDsPerFailureDomain:
+                          description: |-
+                            Number of OSDs allowed per failure domain for erasure coded chunk placement.
+                            When specified along with crushNumFailureDomains, a CRUSH MSR rule will be created
+                            that allows up to this many chunks on OSDs within each failure domain.
+                          format: int32
+                          minimum: 1
+                          type: integer
                         dataChunks:
                           description: |-
                             Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type).
@@ -12957,6 +13030,9 @@ spec:
                         - codingChunks
                         - dataChunks
                       type: object
+                      x-kubernetes-validations:
+                        - message: crushNumFailureDomains and crushOSDsPerFailureDomain must be specified together
+                          rule: has(self.crushNumFailureDomains) == has(self.crushOSDsPerFailureDomain)
                     failureDomain:
                       description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
                       type: string
@@ -14588,6 +14664,22 @@ spec:
                             This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
+                        crushNumFailureDomains:
+                          description: |-
+                            Number of failure domains to use for erasure coded chunk placement.
+                            When specified along with crushOSDsPerFailureDomain, a CRUSH MSR rule will be created
+                            that distributes chunks across this many failure domains.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        crushOSDsPerFailureDomain:
+                          description: |-
+                            Number of OSDs allowed per failure domain for erasure coded chunk placement.
+                            When specified along with crushNumFailureDomains, a CRUSH MSR rule will be created
+                            that allows up to this many chunks on OSDs within each failure domain.
+                          format: int32
+                          minimum: 1
+                          type: integer
                         dataChunks:
                           description: |-
                             Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type).
@@ -14614,6 +14706,9 @@ spec:
                         - codingChunks
                         - dataChunks
                       type: object
+                      x-kubernetes-validations:
+                        - message: crushNumFailureDomains and crushOSDsPerFailureDomain must be specified together
+                          rule: has(self.crushNumFailureDomains) == has(self.crushOSDsPerFailureDomain)
                     failureDomain:
                       description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
                       type: string
@@ -15698,6 +15793,22 @@ spec:
                             This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
+                        crushNumFailureDomains:
+                          description: |-
+                            Number of failure domains to use for erasure coded chunk placement.
+                            When specified along with crushOSDsPerFailureDomain, a CRUSH MSR rule will be created
+                            that distributes chunks across this many failure domains.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        crushOSDsPerFailureDomain:
+                          description: |-
+                            Number of OSDs allowed per failure domain for erasure coded chunk placement.
+                            When specified along with crushNumFailureDomains, a CRUSH MSR rule will be created
+                            that allows up to this many chunks on OSDs within each failure domain.
+                          format: int32
+                          minimum: 1
+                          type: integer
                         dataChunks:
                           description: |-
                             Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type).
@@ -15724,6 +15835,9 @@ spec:
                         - codingChunks
                         - dataChunks
                       type: object
+                      x-kubernetes-validations:
+                        - message: crushNumFailureDomains and crushOSDsPerFailureDomain must be specified together
+                          rule: has(self.crushNumFailureDomains) == has(self.crushOSDsPerFailureDomain)
                     failureDomain:
                       description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
                       type: string
@@ -15903,6 +16017,22 @@ spec:
                             This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
+                        crushNumFailureDomains:
+                          description: |-
+                            Number of failure domains to use for erasure coded chunk placement.
+                            When specified along with crushOSDsPerFailureDomain, a CRUSH MSR rule will be created
+                            that distributes chunks across this many failure domains.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        crushOSDsPerFailureDomain:
+                          description: |-
+                            Number of OSDs allowed per failure domain for erasure coded chunk placement.
+                            When specified along with crushNumFailureDomains, a CRUSH MSR rule will be created
+                            that allows up to this many chunks on OSDs within each failure domain.
+                          format: int32
+                          minimum: 1
+                          type: integer
                         dataChunks:
                           description: |-
                             Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type).
@@ -15929,6 +16059,9 @@ spec:
                         - codingChunks
                         - dataChunks
                       type: object
+                      x-kubernetes-validations:
+                        - message: crushNumFailureDomains and crushOSDsPerFailureDomain must be specified together
+                          rule: has(self.crushNumFailureDomains) == has(self.crushOSDsPerFailureDomain)
                     failureDomain:
                       description: 'The failure domain: osd/host/(region or zone if available) - technically also any type in the crush map'
                       type: string

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1434,6 +1434,7 @@ type QuotaSpec struct {
 }
 
 // ErasureCodedSpec represents the spec for erasure code in a pool
+// +kubebuilder:validation:XValidation:message="crushNumFailureDomains and crushOSDsPerFailureDomain must be specified together",rule="has(self.crushNumFailureDomains) == has(self.crushOSDsPerFailureDomain)"
 type ErasureCodedSpec struct {
 	// Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type).
 	// This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
@@ -1457,6 +1458,20 @@ type ErasureCodedSpec struct {
 	// +kubebuilder:validation:Enum={"4Ki","16Ki","64Ki","256Ki","1Mi"}
 	// +optional
 	StripeUnit *resource.Quantity `json:"stripeUnit,omitempty"`
+
+	// Number of failure domains to use for erasure coded chunk placement.
+	// When specified along with crushOSDsPerFailureDomain, a CRUSH MSR rule will be created
+	// that distributes chunks across this many failure domains.
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	CrushNumFailureDomains int32 `json:"crushNumFailureDomains,omitempty"`
+
+	// Number of OSDs allowed per failure domain for erasure coded chunk placement.
+	// When specified along with crushNumFailureDomains, a CRUSH MSR rule will be created
+	// that allows up to this many chunks on OSDs within each failure domain.
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	CrushOSDsPerFailureDomain int32 `json:"crushOSDsPerFailureDomain,omitempty"`
 }
 
 // +genclient

--- a/pkg/daemon/ceph/client/erasure-code-profile.go
+++ b/pkg/daemon/ceph/client/erasure-code-profile.go
@@ -92,6 +92,12 @@ func CreateErasureCodeProfile(context *clusterd.Context, clusterInfo *ClusterInf
 	if pool.DeviceClass != "" {
 		profilePairs = append(profilePairs, fmt.Sprintf("crush-device-class=%s", pool.DeviceClass))
 	}
+	if pool.ErasureCoded.CrushNumFailureDomains > 0 {
+		profilePairs = append(profilePairs, fmt.Sprintf("crush-num-failure-domains=%d", pool.ErasureCoded.CrushNumFailureDomains))
+	}
+	if pool.ErasureCoded.CrushOSDsPerFailureDomain > 0 {
+		profilePairs = append(profilePairs, fmt.Sprintf("crush-osds-per-failure-domain=%d", pool.ErasureCoded.CrushOSDsPerFailureDomain))
+	}
 	if pool.ErasureCoded.StripeUnit != nil && !pool.ErasureCoded.StripeUnit.IsZero() {
 		stripeBytes, ok := pool.ErasureCoded.StripeUnit.AsInt64()
 		if !ok {

--- a/pkg/daemon/ceph/client/erasure-code-profile_test.go
+++ b/pkg/daemon/ceph/client/erasure-code-profile_test.go
@@ -29,27 +29,33 @@ import (
 )
 
 func TestCreateProfile(t *testing.T) {
-	testCreateProfile(t, "", "myroot", "")
+	testCreateProfile(t, "", "myroot", "", 0, 0)
 }
 
 func TestCreateProfileWithFailureDomain(t *testing.T) {
-	testCreateProfile(t, "osd", "", "")
+	testCreateProfile(t, "osd", "", "", 0, 0)
 }
 
 func TestCreateProfileWithDeviceClass(t *testing.T) {
-	testCreateProfile(t, "osd", "", "hdd")
+	testCreateProfile(t, "osd", "", "hdd", 0, 0)
 }
 
-func testCreateProfile(t *testing.T, failureDomain, crushRoot, deviceClass string) {
+func TestCreateProfileWithMSR(t *testing.T) {
+	testCreateProfile(t, "host", "", "", 5, 3)
+}
+
+func testCreateProfile(t *testing.T, failureDomain, crushRoot, deviceClass string, failureDomains, osdsPerDomain int32) {
 	stripeUnit := resource.MustParse("4Ki")
 	spec := cephv1.PoolSpec{
 		FailureDomain: failureDomain,
 		CrushRoot:     crushRoot,
 		DeviceClass:   deviceClass,
 		ErasureCoded: cephv1.ErasureCodedSpec{
-			DataChunks:   2,
-			CodingChunks: 3,
-			StripeUnit:   &stripeUnit,
+			DataChunks:                2,
+			CodingChunks:              3,
+			StripeUnit:                &stripeUnit,
+			CrushNumFailureDomains:    failureDomains,
+			CrushOSDsPerFailureDomain: osdsPerDomain,
 		},
 	}
 
@@ -80,6 +86,14 @@ func testCreateProfile(t *testing.T, failureDomain, crushRoot, deviceClass strin
 				}
 				if deviceClass != "" {
 					assert.Equal(t, fmt.Sprintf("crush-device-class=%s", deviceClass), args[nextArg])
+					nextArg++
+				}
+				if failureDomains > 0 {
+					assert.Equal(t, fmt.Sprintf("crush-num-failure-domains=%d", failureDomains), args[nextArg])
+					nextArg++
+				}
+				if osdsPerDomain > 0 {
+					assert.Equal(t, fmt.Sprintf("crush-osds-per-failure-domain=%d", osdsPerDomain), args[nextArg])
 					nextArg++
 				}
 				if spec.ErasureCoded.StripeUnit != nil && !spec.ErasureCoded.StripeUnit.IsZero() {


### PR DESCRIPTION
Added failureDomains and osdsPerDomain fields to the ErasureCodedSpec, which maps to the crush-num-failure-domains and crush-osds-per-failure-domain Ceph EC profile parameters. This enables creating EC pools that distribute chunks across fewer, larger hosts without needing one host per data chunk.

Closes #17929 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
