### PR TITLE
nfs: support custom NFS server port

### DIFF
--- a/Documentation/CRDs/ceph-nfs-crd.md
+++ b/Documentation/CRDs/ceph-nfs-crd.md
@@ -103,6 +103,10 @@ The `server` spec sets configuration for Rook-created NFS-Ganesha server pods.
     Supported values: `NIV_NULL | NIV_FATAL | NIV_MAJ | NIV_CRIT | NIV_WARN | NIV_EVENT | NIV_INFO | NIV_DEBUG | NIV_MID_DEBUG | NIV_FULL_DEBUG | NB_LOG_LEVEL`
 * `hostNetwork`: Whether host networking is enabled for the NFS server pod(s). If not set, the network
     settings from the CephCluster CR will be applied.
+* `port`: The port the NFS server will listen on for NFS clients. Defaults to `2049`.
+    Useful when host networking is enabled and the default NFS port is already in use on the host.
+    The operator-created Service uses the same port. Clients and any user-created exposure Services
+    (LoadBalancer or NodePort) must use this port as well.
 
 ### Security
 

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -8259,6 +8259,19 @@ bool
 </tr>
 <tr>
 <td>
+<code>port</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The port the NFS server (NFS-Ganesha) will listen on for NFS clients. Defaults to 2049.
+Useful when host networking is enabled and the default NFS port is already in use.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>livenessProbe</code><br/>
 <em>
 <a href="#ceph.rook.io/v1.ProbeSpec">

--- a/Documentation/Storage-Configuration/NFS/nfs.md
+++ b/Documentation/Storage-Configuration/NFS/nfs.md
@@ -147,14 +147,23 @@ the export path and leaving the directory as just `/`.
 mount -t nfs4 -o proto=tcp <nfs-service-address>:/<export-path> <mount-location>
 ```
 
+!!! note
+    If `spec.server.port` is set to a non-default value, clients must mount using that port 
+    (for example `-o proto=tcp,port=<port>`).
+
 
 ## Exposing the NFS server outside of the Kubernetes cluster
+
+Rook creates a ClusterIP Service for each NFS server instance (headless when host networking is
+enabled). To expose NFS outside the cluster, create your own Service. Rook does not manage
+LoadBalancer or NodePort Services for NFS.
 
 Use a LoadBalancer Service to expose an NFS server (and its exports) outside of the Kubernetes
 cluster. The Service's endpoint can be used as the NFS service address when
 [mounting the export manually](#mounting-exports). We provide an example Service here:
-[`deploy/examples/nfs-load-balancer.yaml`](https://github.com/rook/rook/tree/master/deploy/examples).
+[`deploy/examples/nfs-load-balancer.yaml`](https://github.com/rook/rook/blob/master/deploy/examples/nfs-load-balancer.yaml).
 
+Modify the example for a NodePort service as needed following [Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport).
 
 ## NFS Security
 Security options for NFS are documented [here](nfs-security.md).

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -11515,6 +11515,14 @@ spec:
                           type: array
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    port:
+                      description: |-
+                        The port the NFS server (NFS-Ganesha) will listen on for NFS clients. Defaults to 2049.
+                        Useful when host networking is enabled and the default NFS port is already in use.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
                     priorityClassName:
                       description: PriorityClassName sets the priority class on the pods
                       type: string

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -11508,6 +11508,14 @@ spec:
                           type: array
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    port:
+                      description: |-
+                        The port the NFS server (NFS-Ganesha) will listen on for NFS clients. Defaults to 2049.
+                        Useful when host networking is enabled and the default NFS port is already in use.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
                     priorityClassName:
                       description: PriorityClassName sets the priority class on the pods
                       type: string

--- a/deploy/examples/nfs-load-balancer.yaml
+++ b/deploy/examples/nfs-load-balancer.yaml
@@ -1,3 +1,7 @@
+#################################################################################################################
+# Example of a user-managed LoadBalancer Service to expose an NFS server outside the cluster.
+#################################################################################################################
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,8 +10,11 @@ metadata:
 spec:
   ports:
     - name: nfs
-      port: 2049
-  type: LoadBalancer
+      port: 2049 # Must match CephNFS.spec.server.port (default 2049)
+      targetPort: 2049
+      # Optional when type is NodePort; omit to let Kubernetes allocate one
+      # nodePort: 32049
+  type: LoadBalancer # or NodePort if desired
   externalTrafficPolicy: Local
   selector:
     app: rook-ceph-nfs

--- a/deploy/examples/nfs.yaml
+++ b/deploy/examples/nfs.yaml
@@ -58,7 +58,7 @@ spec:
     # The logging levels: NIV_NULL | NIV_FATAL | NIV_MAJ | NIV_CRIT | NIV_WARN | NIV_EVENT | NIV_INFO | NIV_DEBUG | NIV_MID_DEBUG |NIV_FULL_DEBUG |NB_LOG_LEVEL
     logLevel: NIV_INFO
 
-    # Allow liveness-probe via pod's nfs port (TCP 2049)
+    # Allow liveness-probe via pod's NFS port
     # livenessProbe:
     #   disabled: false
 

--- a/pkg/apis/ceph.rook.io/v1/nfs.go
+++ b/pkg/apis/ceph.rook.io/v1/nfs.go
@@ -49,6 +49,17 @@ func (n *CephNFS) IsHostNetwork(c *ClusterSpec) bool {
 	return c.Network.IsHost()
 }
 
+// DefaultNFSPort is the default port NFS-Ganesha listens on for NFS clients.
+const DefaultNFSPort int32 = 2049
+
+// GetPort returns the NFS listen port, or the default (2049) if unset.
+func (n *CephNFS) GetPort() int32 {
+	if n.Spec.Server.Port != 0 {
+		return n.Spec.Server.Port
+	}
+	return DefaultNFSPort
+}
+
 func (sec *NFSSecuritySpec) Validate() error {
 	if sec == nil {
 		return nil

--- a/pkg/apis/ceph.rook.io/v1/nfs_test.go
+++ b/pkg/apis/ceph.rook.io/v1/nfs_test.go
@@ -23,6 +23,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+func TestCephNFS_GetPort(t *testing.T) {
+	nfs := &CephNFS{}
+	assert.Equal(t, DefaultNFSPort, nfs.GetPort())
+
+	nfs.Spec.Server.Port = 12049
+	assert.Equal(t, int32(12049), nfs.GetPort())
+}
+
 func TestNFSSecuritySpec_Validate(t *testing.T) {
 	isFailing := true
 	isOkay := false

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -3070,6 +3070,13 @@ type GaneshaServerSpec struct {
 	// +optional
 	HostNetwork *bool `json:"hostNetwork,omitempty"`
 
+	// The port the NFS server (NFS-Ganesha) will listen on for NFS clients. Defaults to 2049.
+	// Useful when host networking is enabled and the default NFS port is already in use.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+	// +optional
+	Port int32 `json:"port,omitempty"`
+
 	// A liveness-probe to verify that Ganesha server has valid run-time state.
 	// If LivenessProbe.Disabled is false and LivenessProbe.Probe is nil uses default probe.
 	// +optional

--- a/pkg/operator/ceph/nfs/config.go
+++ b/pkg/operator/ceph/nfs/config.go
@@ -109,12 +109,14 @@ func getGaneshaConfig(n *cephv1.CephNFS, version cephver.CephVersion, name strin
 	nodeID := getNFSNodeID(n, name)
 	userID := getNFSUserID(nodeID)
 	url := getRadosURL(n)
+	port := n.GetPort()
 	return `
 NFS_CORE_PARAM {
 	Enable_NLM = false;
 	Enable_RQUOTA = false;
 	Protocols = 4;
 	allow_set_io_flusher_fail = true;
+	NFS_Port = ` + fmt.Sprintf("%d", port) + `;
 }
 
 MDCACHE {

--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -30,7 +30,6 @@ import (
 	"github.com/rook/rook/pkg/util/log"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -41,13 +40,13 @@ const (
 	AppName               = "rook-ceph-nfs"
 	ganeshaContainerName  = "nfs-ganesha"
 	ganeshaConfigVolume   = "ganesha-config"
-	nfsPort               = 2049
 	ganeshaPid            = "/var/run/ganesha/ganesha.pid"
 	nfsGaneshaMetricsPort = 9587
 )
 
 func (r *ReconcileCephNFS) generateCephNFSService(nfs *cephv1.CephNFS, cfg daemonConfig) *v1.Service {
 	labels := getLabels(nfs, cfg.ID, true)
+	nfsPort := nfs.GetPort()
 
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -92,16 +91,13 @@ func (r *ReconcileCephNFS) createCephNFSService(nfs *cephv1.CephNFS, cfg daemonC
 		return errors.Wrapf(err, "failed to set owner reference to ceph nfs %q", s)
 	}
 
-	svc, err := r.context.Clientset.CoreV1().Services(nfs.Namespace).Create(r.opManagerContext, s, metav1.CreateOptions{})
+	// Update the svc if it already exists so a changed spec.server.port takes effect.
+	svc, err := k8sutil.CreateOrUpdateService(r.opManagerContext, r.context.Clientset, nfs.Namespace, s)
 	if err != nil {
-		if !kerrors.IsAlreadyExists(err) {
-			return errors.Wrap(err, "failed to create ganesha service")
-		}
-		log.NamedInfo(nsName, logger, "ceph nfs service already created")
-		return nil
+		return errors.Wrap(err, "failed to create or update ganesha service")
 	}
 
-	log.NamedInfo(nsName, logger, "ceph nfs service running at %s:%d", svc.Spec.ClusterIP, nfsPort)
+	log.NamedInfo(nsName, logger, "ceph nfs service running at %s:%d", svc.Spec.ClusterIP, nfs.GetPort())
 	return nil
 }
 
@@ -262,10 +258,12 @@ func (r *ReconcileCephNFS) daemonContainer(nfs *cephv1.CephNFS, cfg daemonConfig
 
 func (r *ReconcileCephNFS) defaultGaneshaLivenessProbe(nfs *cephv1.CephNFS) *v1.Probe {
 	failureThreshold := int32(10)
+	nfsPort := nfs.GetPort()
 	cephVersionWithRpcinfo := version.CephVersion{Major: 18, Minor: 2, Extra: 1}
 	if r.clusterInfo.CephVersion.IsAtLeast(cephVersionWithRpcinfo) {
 		// liveness-probe using rpcinfo utility
-		return controller.GenerateLivenessProbeViaRpcinfo(nfsPort, failureThreshold)
+		//nolint:gosec // G115: port is CRD-validated to 1-65535
+		return controller.GenerateLivenessProbeViaRpcinfo(uint16(nfsPort), failureThreshold)
 	}
 	// liveness-probe using K8s builtin TCP-socket action
 	return controller.GenerateLivenessProbeTcpPort(nfsPort, failureThreshold)

--- a/pkg/operator/ceph/nfs/spec_test.go
+++ b/pkg/operator/ceph/nfs/spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nfs
 
 import (
+	"context"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -34,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -456,4 +458,128 @@ func TestDeploymentSpec(t *testing.T) {
 		assert.Equal(t, ganeshaCont.LivenessProbe.FailureThreshold, int32(10))
 		assert.GreaterOrEqual(t, ganeshaCont.LivenessProbe.TimeoutSeconds, int32(5))
 	})
+
+	t.Run("custom nfs port", func(t *testing.T) {
+		customPort := int32(12049)
+		nfs := &cephv1.CephNFS{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-nfs",
+				Namespace: "rook-ceph-test-ns",
+			},
+			Spec: cephv1.NFSGaneshaSpec{
+				Server: cephv1.GaneshaServerSpec{
+					Active: 1,
+					Port:   customPort,
+				},
+			},
+		}
+
+		r, cfg := newDeploymentSpecTest(t)
+		d, err := r.makeDeployment(nfs, cfg)
+		assert.NoError(t, err)
+
+		var ganeshaCont *v1.Container
+		for i := range d.Spec.Template.Spec.Containers {
+			if d.Spec.Template.Spec.Containers[i].Name == "nfs-ganesha" {
+				ganeshaCont = &d.Spec.Template.Spec.Containers[i]
+				break
+			}
+		}
+		assert.NotNil(t, ganeshaCont)
+		assert.NotNil(t, ganeshaCont.LivenessProbe)
+		assert.NotNil(t, ganeshaCont.LivenessProbe.Exec)
+		// rpcinfo encodes the port in network byte order as 127.0.0.1.<hi>.<lo>
+		assert.Contains(t, ganeshaCont.LivenessProbe.Exec.Command, "127.0.0.1.47.17")
+
+		svc := r.generateCephNFSService(nfs, cfg)
+		assert.Equal(t, customPort, svc.Spec.Ports[0].Port)
+		assert.Equal(t, intstr.FromInt(int(customPort)), svc.Spec.Ports[0].TargetPort)
+		assert.Empty(t, svc.Spec.ClusterIP)
+	})
+
+	t.Run("hostNetwork keeps headless service with custom port", func(t *testing.T) {
+		hostNetwork := true
+		customPort := int32(12049)
+		nfs := &cephv1.CephNFS{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-nfs",
+				Namespace: "rook-ceph-test-ns",
+			},
+			Spec: cephv1.NFSGaneshaSpec{
+				Server: cephv1.GaneshaServerSpec{
+					Active:      1,
+					Port:        customPort,
+					HostNetwork: &hostNetwork,
+				},
+			},
+		}
+
+		r, cfg := newDeploymentSpecTest(t)
+		svc := r.generateCephNFSService(nfs, cfg)
+		assert.Equal(t, v1.ClusterIPNone, svc.Spec.ClusterIP)
+		assert.Equal(t, customPort, svc.Spec.Ports[0].Port)
+		assert.Equal(t, intstr.FromInt(int(customPort)), svc.Spec.Ports[0].TargetPort)
+	})
+}
+
+func TestCreateOrUpdateCephNFSServicePort(t *testing.T) {
+	nfs := &cephv1.CephNFS{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-nfs",
+			Namespace: "rook-ceph-test-ns",
+		},
+		TypeMeta: controllerTypeMeta,
+		Spec: cephv1.NFSGaneshaSpec{
+			Server: cephv1.GaneshaServerSpec{
+				Active: 1,
+			},
+		},
+	}
+
+	r, cfg := newDeploymentSpecTest(t)
+
+	err := r.createCephNFSService(nfs, cfg)
+	assert.NoError(t, err)
+
+	svc, err := r.context.Clientset.CoreV1().Services(nfs.Namespace).Get(context.TODO(), instanceName(nfs, cfg.ID), metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, cephv1.DefaultNFSPort, svc.Spec.Ports[0].Port)
+
+	expected := svc.DeepCopy()
+	expected.Spec.Ports[0].Port = 12049
+	expected.Spec.Ports[0].TargetPort = intstr.FromInt(12049)
+
+	nfs.Spec.Server.Port = 12049
+	err = r.createCephNFSService(nfs, cfg)
+	assert.NoError(t, err)
+
+	svc, err = r.context.Clientset.CoreV1().Services(nfs.Namespace).Get(context.TODO(), instanceName(nfs, cfg.ID), metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, expected.Labels, svc.Labels)
+	assert.Equal(t, expected.Spec, svc.Spec)
+}
+
+func TestGetGaneshaConfigNFSPort(t *testing.T) {
+	nfs := &cephv1.CephNFS{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-nfs",
+			Namespace: "rook-ceph",
+		},
+		Spec: cephv1.NFSGaneshaSpec{
+			RADOS: cephv1.GaneshaRADOSSpec{
+				Pool:      ".nfs",
+				Namespace: "my-nfs",
+			},
+			Server: cephv1.GaneshaServerSpec{
+				Active: 1,
+			},
+		},
+	}
+
+	cfg := getGaneshaConfig(nfs, cephver.Squid, "a")
+	assert.Contains(t, cfg, "NFS_Port = 2049;")
+
+	nfs.Spec.Server.Port = 12049
+	cfg = getGaneshaConfig(nfs, cephver.Squid, "a")
+	assert.Contains(t, cfg, "NFS_Port = 12049;")
 }


### PR DESCRIPTION
Add configurable NFS listen port via `CephNFS` `spec.server.port` (default 2049) so host-network deployments can avoid conflicts on the default port. Includes unit tests and docs/examples for exposure.

**Issue resolved by this Pull Request:**
Resolves #15472

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.