### PR TITLE
test: extract the zone.json pool canary into its own package

### DIFF
--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -19,13 +19,10 @@ package integration
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -49,6 +46,7 @@ import (
 	userkeys "github.com/rook/rook/tests/integration/object/user/keys"
 	useropmask "github.com/rook/rook/tests/integration/object/user/opmask"
 	"github.com/rook/rook/tests/integration/object/util/sharedstore"
+	"github.com/rook/rook/tests/integration/object/zonepools"
 )
 
 const (
@@ -155,33 +153,6 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 	// covered by the keystone suite
 	createCephObjectStore(s.T(), helper, k8sh, installer, namespace, storeName, 1, tlsEnable, swiftAndKeystone)
 
-	// Canary test: verify all *_pool fields in zone.json are covered by Rook's zonePoolNSSuffix map.
-	// This catches new RGW pool fields added in newer Ceph versions that Rook doesn't yet handle,
-	// which would cause ghost default pools when shared pools are configured.
-	// Run right after store creation when the zone is fresh and definitely accessible.
-	s.T().Run("all zone.json pool fields are covered by Rook shared pool mapping", func(t *testing.T) {
-		output, err := installer.Execute("radosgw-admin",
-			[]string{"zone", "get", fmt.Sprintf("--rgw-zone=%s", storeName), fmt.Sprintf("--rgw-realm=%s", storeName)}, namespace)
-		require.NoError(t, err, "failed to get zone config; output: %s", output)
-		require.NotEmpty(t, output, "zone config is empty")
-
-		var zoneConfig map[string]interface{}
-		err = json.Unmarshal([]byte(output), &zoneConfig)
-		require.NoError(t, err, "failed to parse zone config JSON; output: %s", output)
-
-		knownPools := rgw.ZoneJsonPoolKeys()
-		for field, val := range zoneConfig {
-			if _, ok := val.(string); !ok {
-				continue
-			}
-			if !strings.HasSuffix(field, "_pool") {
-				continue
-			}
-			assert.Contains(t, knownPools, field,
-				"RGW zone.json contains unknown pool field %q — add it to zonePoolNSSuffix in pkg/operator/ceph/object/objectstore.go", field)
-		}
-	})
-
 	// test that a second object store can be created (and deleted) while the first exists
 	s.T().Run("run a second object store", func(t *testing.T) {
 		otherStoreName := "other-" + storeName
@@ -209,6 +180,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 	)
 	defer sharedObjectStore.Destroy()
 
+	zonepools.TestZonePools(s.T(), k8sh, sharedObjectStore)
 	bucketlifecycle.TestObjectBucketClaimLifecycle(s.T(), k8sh, sharedObjectStore)
 	bucketowner.TestObjectBucketClaimBucketOwner(s.T(), k8sh, sharedObjectStore)
 	bucketpolicy.TestObjectBucketClaimPolicy(s.T(), k8sh, sharedObjectStore)

--- a/tests/integration/object/README.md
+++ b/tests/integration/object/README.md
@@ -43,6 +43,7 @@ must not collide with std-lib package names (no `io`, no `http`).
 | `user/caps` | `object/user` | user capabilities |
 | `user/keys` | `object/user` | explicit S3 key management |
 | `user/opmask` | `object/user` | user op_mask |
+| `zonepools` | `object` | zone.json pool fields covered by Rook's shared-pool mapping |
 | reserved: `tests/integration/object/lifecycle`, `tests/integration/object/dependents` | | future conversions |
 
 Shared utilities live under `util/`:
@@ -210,5 +211,5 @@ verification; wire the dispatcher; delete the old code; retire
 | old test | target package(s) | still needs (build in that PR) |
 |---|---|---|
 | `testObjectStoreOperations` deletion-blocked-by-dependents | `tests/integration/object/dependents` | private-store fixture, store condition predicates in `wait4` |
-| `createCephObjectStore`/`runObjectE2ETestLite`/deletion asserts + zone.json canary | `tests/integration/object/lifecycle` | store create/health/delete helpers, `Sharedstore.Installer()` accessor |
+| `createCephObjectStore`/`runObjectE2ETestLite`/deletion asserts | `tests/integration/object/lifecycle` | store create/health/delete helpers |
 | upgrade-suite object usage | stays in upgrade suite | switch to typed clients + `wait4` |

--- a/tests/integration/object/util/sharedstore/sharedstore.go
+++ b/tests/integration/object/util/sharedstore/sharedstore.go
@@ -44,12 +44,19 @@ type Sharedstore struct {
 	adminClient *admin.API
 	snsClient   *sns.Client
 	objectStore *cephv1.CephObjectStore
+	installer   *installer.CephInstaller
 	tlsEnable   bool
 	destroy     func()
 }
 
 func (s *Sharedstore) AdminClient() *admin.API {
 	return s.adminClient
+}
+
+// Installer returns the suite installer, for tests that must run commands
+// (e.g. radosgw-admin) inside the cluster.
+func (s *Sharedstore) Installer() *installer.CephInstaller {
+	return s.installer
 }
 
 func (s *Sharedstore) SnsClient() *sns.Client {
@@ -76,7 +83,7 @@ func (s *Sharedstore) Destroy() {
 func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstaller, tlsEnable bool, namespace, storeName string, instances int32, allowedNamespaces ...string) *Sharedstore {
 	t.Helper()
 
-	s := &Sharedstore{tlsEnable: tlsEnable}
+	s := &Sharedstore{tlsEnable: tlsEnable, installer: installer}
 	ctx := context.TODO()
 	ns := namespace
 

--- a/tests/integration/object/zonepools/zonepools.go
+++ b/tests/integration/object/zonepools/zonepools.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package zonepools
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rgw "github.com/rook/rook/pkg/operator/ceph/object"
+	"github.com/rook/rook/tests/framework/utils"
+	"github.com/rook/rook/tests/integration/object/util/sharedstore"
+)
+
+// TestZonePools is a canary against the shared store's zone: it asserts every
+// *_pool field RGW writes into zone.json is covered by Rook's zonePoolNSSuffix
+// map. A pool field introduced by a newer Ceph version that Rook does not yet
+// map would otherwise silently spawn ghost default pools when shared pools are
+// configured — which is exactly the shared store's configuration.
+func TestZonePools(t *testing.T, k8sh *utils.K8sHelper, store *sharedstore.Sharedstore) {
+	t.Run("zone.json pool field coverage", func(t *testing.T) {
+		name := store.ObjectStore().Name
+		ns := store.ObjectStore().Namespace
+
+		output, err := store.Installer().Execute("radosgw-admin",
+			[]string{"zone", "get", fmt.Sprintf("--rgw-zone=%s", name), fmt.Sprintf("--rgw-realm=%s", name)}, ns)
+		require.NoError(t, err, "failed to get zone config; output: %s", output)
+		require.NotEmpty(t, output, "zone config is empty")
+
+		var zoneConfig map[string]any
+		err = json.Unmarshal([]byte(output), &zoneConfig)
+		require.NoError(t, err, "failed to parse zone config JSON; output: %s", output)
+
+		knownPools := rgw.ZoneJsonPoolKeys()
+		for field, val := range zoneConfig {
+			if _, ok := val.(string); !ok {
+				continue
+			}
+			if !strings.HasSuffix(field, "_pool") {
+				continue
+			}
+			assert.Contains(t, knownPools, field,
+				"RGW zone.json contains unknown pool field %q — add it to zonePoolNSSuffix in pkg/operator/ceph/object/objectstore.go", field)
+		}
+	})
+}


### PR DESCRIPTION
**Description of your changes:**

The canary that asserts every RGW `zone.json` `*_pool` field is covered by
Rook's `zonePoolNSSuffix` map (`ZoneJsonPoolKeys()`) was inline in
`runObjectE2ETest`, running against the legacy per-pass store before the
shared store existed.

This extracts it into a standalone `tests/integration/object/zonepools`
package (`TestZonePools`), following the shared-store package layout, and
repoints it at the **shared store** — the one fixture that actually
configures shared pools (`PoolPlacements`), which is exactly the scenario
the canary guards. The set of `*_pool` field names in `zone.json` is
Ceph-version-determined rather than shared-pool-determined, so the check is
at least as strong; it runs first among the shared-store packages so it
still validates a fresh, Ready zone, and is read-only so it cannot perturb
the shared fixture.

A `Sharedstore.Installer()` accessor is added so the packaged canary can run
`radosgw-admin` inside the cluster while keeping the uniform
`(t, k8sh, store)` package entry signature. This is the standalone base for
the in-flight object-store lifecycle/dependents conversions, which then no
longer need to home the canary or add the accessor themselves.

**AI assistance:** an AI agent located the inline canary and the imports it
orphaned, drafted the new package and the fixture accessor, and ran the
build, lint, and adversarial pre-PR review passes.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
