### PR TITLE
Ci canary arm64 add v19 v20

### DIFF
--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -23,7 +23,7 @@ jobs:
     if: github.repository == 'rook/rook'
     uses: ./.github/workflows/ceph-arm64-suite-test.yml
     with:
-      ceph_images: '["quay.io/ceph/ceph:v21", "quay.ceph.io/ceph-ci/ceph:main-arm64", "quay.ceph.io/ceph-ci/ceph:squid-release-arm64", "quay.ceph.io/ceph-ci/ceph:tentacle-arm64", "quay.ceph.io/ceph-ci/ceph:umbrella-release-arm64"]'
+      ceph_images: '["quay.io/ceph/ceph:v19", "quay.io/ceph/ceph:v20", "quay.io/ceph/ceph:v21", "quay.ceph.io/ceph-ci/ceph:main-arm64", "quay.ceph.io/ceph-ci/ceph:squid-release-arm64", "quay.ceph.io/ceph-ci/ceph:tentacle-arm64", "quay.ceph.io/ceph-ci/ceph:umbrella-release-arm64"]'
     secrets: inherit
 
   ceph-suite-tests:


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->


Adds the ceph images quay.io/ceph/ceph:v19, and quay.io/ceph/ceph:v20 to canary-arm64 job of `.github/workflows/daily-nightly-jobs.yml`
Got previously handled via https://github.com/rook/rook/pull/17974 except for adding v19, and v20
Resolves #17625


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
