### PR TITLE
csi: add v1 VolumeGroupSnapshot examples for RBD and NFS

### DIFF
--- a/deploy/examples/csi/nfs/groupsnapshot.yaml
+++ b/deploy/examples/csi/nfs/groupsnapshot.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: groupsnapshot.storage.k8s.io/v1
+kind: VolumeGroupSnapshot
+metadata:
+  name: nfs-groupsnapshot
+spec:
+  source:
+    selector:
+      matchLabels:
+        # The PVCs require this label for them to be
+        # included in the VolumeGroupSnapshot
+        group: snapshot-test
+  volumeGroupSnapshotClassName: csi-nfsplugin-groupsnapclass

--- a/deploy/examples/csi/nfs/groupsnapshotclass.yaml
+++ b/deploy/examples/csi/nfs/groupsnapshotclass.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: groupsnapshot.storage.k8s.io/v1
+kind: VolumeGroupSnapshotClass
+metadata:
+  name: csi-nfsplugin-groupsnapclass
+driver: rook-ceph.nfs.csi.ceph.com # csi-provisioner-name
+parameters:
+  # Specify a string that identifies your cluster. Ceph CSI supports any
+  # unique string. When Ceph CSI is deployed by Rook use the Rook namespace,
+  # for example "rook-ceph".
+  clusterID: rook-ceph # namespace:cluster
+  fsName: myfs
+  csi.storage.k8s.io/group-snapshotter-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/group-snapshotter-secret-namespace: rook-ceph
+deletionPolicy: Delete

--- a/deploy/examples/csi/rbd/groupsnapshot.yaml
+++ b/deploy/examples/csi/rbd/groupsnapshot.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: groupsnapshot.storage.k8s.io/v1
+kind: VolumeGroupSnapshot
+metadata:
+  name: rbd-groupsnapshot
+spec:
+  source:
+    selector:
+      matchLabels:
+        # The PVCs require this label for them to be
+        # included in the VolumeGroupSnapshot
+        group: snapshot-test
+  volumeGroupSnapshotClassName: csi-rbdplugin-groupsnapclass

--- a/deploy/examples/csi/rbd/groupsnapshotclass.yaml
+++ b/deploy/examples/csi/rbd/groupsnapshotclass.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: groupsnapshot.storage.k8s.io/v1
+kind: VolumeGroupSnapshotClass
+metadata:
+  name: csi-rbdplugin-groupsnapclass
+driver: rook-ceph.rbd.csi.ceph.com # csi-provisioner-name
+parameters:
+  # Specify a string that identifies your cluster. Ceph CSI supports any
+  # unique string. When Ceph CSI is deployed by Rook use the Rook namespace,
+  # for example "rook-ceph".
+  clusterID: rook-ceph # namespace:cluster
+  pool: replicapool
+  csi.storage.k8s.io/group-snapshotter-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/group-snapshotter-secret-namespace: rook-ceph
+deletionPolicy: Delete


### PR DESCRIPTION

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

Add VolumeGroupSnapshotClass and VolumeGroupSnapshot example manifests for RBD and NFS, similar to the existing CephFS examples.

> @subhamkrai, Rook only has VolumeGroupSnapshot manifests for CephFS only. Do you think it will be good to add for other drivers as well?

Sounds good to add for other drivers as well

_Originally posted by @subhamkrai in https://github.com/rook/rook/issues/17994#issuecomment-5020767748_
            

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
