### PR TITLE
rgw: force delete the rgw accounts by looking at the force annotation

### DIFF
--- a/design/ceph/object/rgw-user-accounts.md
+++ b/design/ceph/object/rgw-user-accounts.md
@@ -93,6 +93,7 @@ When a CephObjectStoreAccount resource is updated, the controller will:
 - If the root user was created (i.e., `spec.rootUser.skipCreate` is not `true`), the controller will first delete the root user via the admin ops API.
 - Then delete the account itself via the admin ops API.
 - Customer should ensure that all the additional users and buckets associated with the account are deleted before the deletion of the account or else the account deletion will fail.
+- If `rook.io/force-deletion: true` annotation is added to the `CephObjectStoreAccount` account CR, then it will force delete the account and its associated buckets and users.
 
 ## Root Account Users
 

--- a/pkg/operator/ceph/object/account.go
+++ b/pkg/operator/ceph/object/account.go
@@ -18,9 +18,14 @@ package object
 
 import (
 	"context"
+	"fmt"
+	"syscall"
 
 	"github.com/ceph/go-ceph/rgw/admin"
 	"github.com/pkg/errors"
+	"github.com/rook/rook/pkg/util/exec"
+	"github.com/rook/rook/pkg/util/log"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // GetAccount retrieves account information from RGW using the admin ops API.
@@ -67,14 +72,44 @@ func ModifyAccount(ctx context.Context, adminOpsContext *AdminOpsContext, accoun
 }
 
 // DeleteAccount removes an RGW account using the admin ops API.
-func DeleteAccount(ctx context.Context, adminOpsContext *AdminOpsContext, accountID string) error {
+func DeleteAccount(nsName types.NamespacedName, ctx context.Context, adminOpsContext *AdminOpsContext, accountID string) error {
 	if accountID == "" {
 		return errors.New("account ID cannot be empty")
 	}
 
 	err := adminOpsContext.AdminOpsClient.DeleteAccount(ctx, accountID)
 	if err != nil {
+		// If account doesn't exist, consider it successful (idempotent)
+		if errors.Is(err, admin.ErrNoSuchKey) {
+			log.NamedInfo(nsName, logger, "account %q not found, considering deletion successful", accountID)
+			return nil
+		}
 		return errors.Wrapf(err, "failed to delete account %q", accountID)
+	}
+
+	return nil
+}
+
+// ForceDeleteAccount removes an RGW account, even if it has associated users or buckets.
+func ForceDeleteAccount(nsName types.NamespacedName, adminOpsContext *AdminOpsContext, accountID string) error {
+	if accountID == "" {
+		return errors.New("account ID cannot be empty")
+	}
+
+	// run the cli cmd using --purge-data flag
+	if adminOpsContext == nil {
+		return errors.New("adminOpsContext cannot be nil")
+	}
+	// Rook should use admin ops API for this, but `--purge-data` isn't integrated yet. Swap this implementation when it is.
+	account := fmt.Sprintf("--account-id=%s", accountID)
+	_, err := runAdminCommand(&adminOpsContext.Context, false, "account", "rm", "--purge-data", account)
+	if err != nil {
+		// If account doesn't exist, consider it successful (idempotent)
+		if code, ok := exec.ExitStatus(err); ok && code == int(syscall.ENOENT) {
+			log.NamedInfo(nsName, logger, "account %q not found, considering force-deletion successful", accountID)
+			return nil
+		}
+		return errors.Wrapf(err, "failed to force delete account %q using CLI", accountID)
 	}
 
 	return nil

--- a/pkg/operator/ceph/object/account/controller.go
+++ b/pkg/operator/ceph/object/account/controller.go
@@ -204,14 +204,9 @@ func (r *ReconcileObjectStoreAccount) reconcile(request reconcile.Request) (reco
 	// Validate the object store has been initialized
 	opsCtx, objectStore, err := object.InitializeObjectStoreContext(r.context, r.clusterInfo, r.client, r.opManagerContext, cephObjectStoreAccount.Spec.Store, newMultisiteAdminOpsCtxFunc)
 	if err != nil {
-		if !cephObjectStoreAccount.GetDeletionTimestamp().IsZero() {
+		if !cephObjectStoreAccount.GetDeletionTimestamp().IsZero() && kerrors.IsNotFound(err) {
 			log.NamedDebug(request.NamespacedName, logger, "deleting object store account")
 			r.recorder.Eventf(cephObjectStoreAccount, nil, corev1.EventTypeNormal, string(cephv1.ReconcileStarted), string(cephv1.ReconcileStarted), "deleting CephObjectStoreAccount %q", cephObjectStoreAccount.Name)
-
-			err := r.deleteAccount(cephObjectStoreAccount)
-			if err != nil {
-				return reconcile.Result{}, *cephObjectStoreAccount, errors.Wrapf(err, "failed to delete ceph object store account %q", cephObjectStoreAccount.Name)
-			}
 
 			// Remove finalizer
 			err = opcontroller.RemoveFinalizer(r.opManagerContext, r.client, cephObjectStoreAccount)
@@ -456,14 +451,19 @@ func (r *ReconcileObjectStoreAccount) deleteAccount(cephObjectStoreAccount *ceph
 
 	log.NamedInfo(nsName, logger, "deleting account %q", accountID)
 
-	err = object.DeleteAccount(r.opManagerContext, r.objContext, accountID)
-	if err != nil {
-		// If account doesn't exist, consider it successful (idempotent)
-		if errors.Is(err, admin.ErrNoSuchKey) {
-			log.NamedInfo(nsName, logger, "account %q not found, considering deletion successful", accountID)
-			return nil
+	// if `rook.io/force-deletion` annotation is set to true, we will force delete the account even if it contains S3 resources
+	if opcontroller.ForceDeleteRequested(cephObjectStoreAccount.Annotations) {
+		log.NamedInfo(nsName, logger, "force-deletion annotation set to true, forcing deletion of account %q", accountID)
+		err = object.ForceDeleteAccount(nsName, r.objContext, accountID)
+		if err != nil {
+			return errors.Wrapf(err, "failed to force delete account %q", accountID)
 		}
-		return errors.Wrapf(err, "failed to delete account %q", accountID)
+	} else {
+		log.NamedInfo(nsName, logger, "force-deletion annotation not set for account %q, manual cleanup may be required if the account contains S3 resources", accountID)
+		err = object.DeleteAccount(nsName, r.opManagerContext, r.objContext, accountID)
+		if err != nil {
+			return errors.Wrapf(err, "failed to delete account %q, manual cleanup may be required if the account contains S3 resources", accountID)
+		}
 	}
 
 	log.NamedInfo(nsName, logger, "successfully deleted account %q", accountID)


### PR DESCRIPTION
if the account cr has a force delete annotation, forcefully remove the account, even if it contatins data in it, using the purge data flag

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
