### PR TITLE
nvmeof: set nvmeof-meta application tag on .nvmeof pool

### DIFF
--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -200,6 +200,8 @@ func CreatePoolWithPGs(context *clusterd.Context, clusterInfo *ClusterInfo, clus
 		pool.Application = "nfs"
 	case ".rgw.root":
 		pool.Application = "rgw"
+	case ".nvmeof":
+		pool.Application = "nvmeof-meta"
 	}
 
 	if pool.IsReplicated() {

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -50,6 +50,7 @@ func TestCreatePool(t *testing.T) {
 	p := &cephv1.NamedPoolSpec{}
 	enabledMetricsApp := false
 	enabledMgrApp := false
+	enabledNvmeofApp := false
 	clusterInfo := cephclient.AdminTestClusterInfo("mycluster")
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
@@ -76,11 +77,14 @@ func TestCreatePool(t *testing.T) {
 					}
 					assert.Equal(t, "enable", args[3])
 					if args[5] != "rbd" {
-						if args[4] == ".mgr" {
+						switch args[4] {
+						case ".mgr":
 							enabledMgrApp = true
-							assert.Equal(t, ".mgr", args[4])
 							assert.Equal(t, "mgr", args[5])
-						} else {
+						case ".nvmeof":
+							enabledNvmeofApp = true
+							assert.Equal(t, "nvmeof-meta", args[5])
+						default:
 							fmt.Printf("pool - %v", args)
 							assert.Fail(t, fmt.Sprintf("invalid pool %q", args[4]))
 						}
@@ -120,6 +124,16 @@ func TestCreatePool(t *testing.T) {
 		err := createPool(context, clusterInfo, clusterSpec, p)
 		assert.Nil(t, err)
 		assert.True(t, enabledMgrApp)
+	})
+
+	t.Run("built-in nvmeof pool", func(t *testing.T) {
+		p.Name = ".nvmeof"
+		p.Replicated.Size = 1
+		p.Replicated.RequireSafeReplicaSize = false
+		p.Application = ""
+		err := createPool(context, clusterInfo, clusterSpec, p)
+		assert.Nil(t, err)
+		assert.True(t, enabledNvmeofApp)
 	})
 
 	t.Run("ec pool", func(t *testing.T) {


### PR DESCRIPTION
The `.nvmeof` pool was incorrectly tagged with the rbd application and initialized as an rbd pool. 
Add `.nvmeof` to the `built-in` pool switch so it gets the `nvmeof-meta` application tag instead, and skip rbd pool init.

Based on Ceph: https://github.com/ceph/ceph/pull/70035


Tested locally on minikube
```
1.Create rook with private image quay.io/oviner/rook:jul24_1

2.Create CephBlockPool + CephNVMeOFGateway
apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  name: builtin-nvmeof
  namespace: rook-ceph # namespace:cluster
spec:
  name: .nvmeof
  failureDomain: osd
  replicated:
    size: 1
    requireSafeReplicaSize: false
---
apiVersion: ceph.rook.io/v1
kind: CephNVMeOFGateway
metadata:
  name: nvmeof
  namespace: rook-ceph # namespace:cluster
spec:
  group: group-a
  instances: 1
  hostNetwork: false

3. check the application tag on the .nvmeof pool 
$ kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- ceph osd pool application get .nvmeof
{
    "nvmeof-meta": {}
}

)$ kubectl -n rook-ceph get cephblockpool builtin-nvmeof 
NAME             PHASE   TYPE         FAILUREDOMAIN   AGE
builtin-nvmeof   Ready   Replicated   osd             3m34s
```


<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
