### PR TITLE
helm: add toolbox repository and tag settings

### DIFF
--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -89,10 +89,12 @@ The following table lists the configurable parameters of the rook-operator chart
 | `toolbox.affinity` | Toolbox affinity | `{}` |
 | `toolbox.containerSecurityContext` | Toolbox container security context | `{"capabilities":{"drop":["ALL"]},"runAsGroup":2016,"runAsNonRoot":true,"runAsUser":2016}` |
 | `toolbox.enabled` | Enable Ceph debugging pod deployment. See [toolbox](../Troubleshooting/ceph-toolbox.md) | `false` |
-| `toolbox.image` | Toolbox image, defaults to the image used by the Ceph cluster | `nil` |
+| `toolbox.image` | Toolbox image, superseded by `toolbox.repository` and `toolbox.tag` | the image used by the Ceph cluster |
 | `toolbox.labels` | Toolbox labels | `{}` |
 | `toolbox.priorityClassName` | Set the priority class for the toolbox if desired | `nil` |
+| `toolbox.repository` | The repository from which to pull the toolbox image | `.Values.cephImage.repository` |
 | `toolbox.resources` | Toolbox resources | `{"limits":{"memory":"1Gi"},"requests":{"cpu":"100m","memory":"128Mi"}}` |
+| `toolbox.tag` | The tag of the toolbox image | `.Values.cephImage.tag` |
 | `toolbox.tolerations` | Toolbox tolerations | `[]` |
 
 ### **Ceph Cluster Spec**

--- a/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/deployment.yaml
@@ -36,7 +36,13 @@ spec:
       {{- end }}
       containers:
         - name: rook-ceph-tools
-          image: {{ .Values.toolbox.image | default (printf "%s:%s" .Values.cephImage.repository .Values.cephImage.tag) }}
+          {{- if or .Values.toolbox.repository .Values.toolbox.tag }}
+          image: "{{ .Values.toolbox.repository | default .Values.cephImage.repository }}:{{ .Values.toolbox.tag | default .Values.cephImage.tag }}"
+          {{- else if .Values.toolbox.image }}
+          image: {{ .Values.toolbox.image | quote }}
+          {{- else }}
+          image: "{{ .Values.cephImage.repository }}:{{ .Values.cephImage.tag }}"
+          {{- end }}
           command:
             - /bin/bash
             - -c

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -24,7 +24,14 @@ configOverride:
 toolbox:
   # -- Enable Ceph debugging pod deployment. See [toolbox](../Troubleshooting/ceph-toolbox.md)
   enabled: false
-  # -- Toolbox image, defaults to the image used by the Ceph cluster
+  # -- The repository from which to pull the toolbox image
+  # @default -- `.Values.cephImage.repository`
+  repository: #quay.io/ceph/ceph
+  # -- The tag of the toolbox image
+  # @default -- `.Values.cephImage.tag`
+  tag: #v20.2.2
+  # -- Toolbox image, superseded by `toolbox.repository` and `toolbox.tag`
+  # @default -- the image used by the Ceph cluster
   image: #quay.io/ceph/ceph:v20.2.2
   # -- Toolbox tolerations
   tolerations: []


### PR DESCRIPTION
The operator image in the `rook-ceph` chart and the Ceph image in the `rook-ceph-cluster` chart are both configured as a repository and tag pair:

```yaml
# rook-ceph
image:
  repository: docker.io/rook/ceph
  tag: master

# rook-ceph-cluster
cephImage:
  repository: quay.io/ceph/ceph
  tag: v20.2.2
```

The toolbox was the exception, taking a single `toolbox.image` string. This adds `toolbox.repository` and `toolbox.tag`, so the toolbox image can be configured the same way as the others.

Either setting may be applied on its own. Whichever is left unset falls back to `cephImage.repository` or `cephImage.tag`, and both take precedence over `toolbox.image`, which continues to apply when neither is set:

| `toolbox.repository` | `toolbox.tag` | `toolbox.image` | rendered image |
| --- | --- | --- | --- |
| unset | unset | unset | `quay.io/ceph/ceph:v20.2.2` |
| unset | unset | `legacy/ceph:v18.2.0` | `legacy/ceph:v18.2.0` |
| `rook/ceph` | unset | unset | `rook/ceph:v20.2.2` |
| unset | `v19.2.3` | unset | `quay.io/ceph/ceph:v19.2.3` |
| `rook/ceph` | `v1.18.0` | unset | `rook/ceph:v1.18.0` |
| `rook/ceph` | unset | `legacy/ceph:v18.2.0` | `rook/ceph:v20.2.2` |

This is not a breaking change — an existing values.yaml renders exactly as it did before.

## Two commits

1. **`helm: add helm-unittest harness for the charts`** — the machinery from #18056, which @travisn approved the concept of. Adds [helm-unittest](https://github.com/helm-unittest/helm-unittest) pinned at v1.1.2, a `make test.helm` target run with `--strict`, a step in the existing `lint-test` job, and a suite covering the toolbox deployment as it behaves on master today.
2. **`helm: add toolbox repository and tag settings`** — the change above, extending that suite with the new precedence.

Splitting it this way makes the compatibility guarantee mechanical rather than assertive: **every `toolbox.image` case the first commit wrote passes unchanged under the second.** Reverting the second commit's template to the earlier breaking version (where `toolbox.image` was dropped) fails `prefers toolbox.image over the cephImage settings`, so the regression this PR was originally going to ship is now caught by CI rather than by review.

```console
$ make test.helm
 PASS  toolbox deployment	deploy/charts/rook-ceph-cluster/tests/toolbox_test.yaml
Tests:       13 passed, 13 total
```

Notes carried over from #18056: helm-unittest installs as a pinned standalone binary rather than via `helm plugin install` (its released binary does not need helm on PATH), the CI addition is a step in the existing `lint-test` job so no new status check is created and `.mergify.yml` needs no change, and suites are excluded from the packaged charts via `.helmignore`. The whole install-and-run step takes about a second in CI.

AI assistance: locating the change sites and existing `toolbox.image` references, drafting the values, template, harness, and test changes, and mutation-testing the suite to confirm it fails when the templates break.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
