### PR TITLE
ci: Daily CI tests to run all stable and devel versions of Ceph

### DIFF
--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.repository == 'rook/rook'
     uses: ./.github/workflows/ceph-suite-integration-test.yml
     with:
-      ceph_suite_versions: '["squid-devel", "tentacle-devel", "umbrella-devel", "main"]'
+      ceph_suite_versions: '["squid", "squid-devel", "tentacle", "tentacle-devel", "umbrella", "umbrella-devel", "main"]'
       object_suite_tests: '["TestWithoutTLS", "TestWithTLS"]'
     secrets: inherit
 

--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -42,6 +42,7 @@ jobs:
     secrets: inherit
 
   check-markdown-links:
+    if: github.repository == 'rook/rook'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -45,6 +45,7 @@ const (
 	// test with the latest releases
 	squidTestImage    = "quay.io/ceph/ceph:v19"
 	tentacleTestImage = "quay.io/ceph/ceph:v20"
+	umbrellaTestImage = "quay.io/ceph/ceph:v21"
 	// test with the current development versions
 	squidDevelTestImage    = "quay.ceph.io/ceph-ci/ceph:squid"
 	tentacleDevelTestImage = "quay.ceph.io/ceph-ci/ceph:tentacle"
@@ -71,6 +72,7 @@ var (
 	SquidVersion                 = cephv1.CephVersionSpec{Image: squidTestImage}
 	SquidDevelVersion            = cephv1.CephVersionSpec{Image: squidDevelTestImage}
 	TentacleVersion              = cephv1.CephVersionSpec{Image: tentacleTestImage}
+	UmbrellaVersion              = cephv1.CephVersionSpec{Image: umbrellaTestImage}
 	TentacleDevelVersion         = cephv1.CephVersionSpec{Image: tentacleDevelTestImage, AllowUnsupported: true}
 	UmbrellaDevelVersion         = cephv1.CephVersionSpec{Image: umbrellaDevelTestImage, AllowUnsupported: true}
 	MainVersion                  = cephv1.CephVersionSpec{Image: mainTestImage, AllowUnsupported: true}
@@ -97,13 +99,19 @@ func ReturnCephVersion() cephv1.CephVersionSpec {
 		return MainVersion
 	case "squid-devel":
 		return SquidDevelVersion
+	case "squid":
+		return SquidVersion
 	case "tentacle-devel":
 		return TentacleDevelVersion
+	case "tentacle":
+		return TentacleVersion
 	case "umbrella-devel":
 		return UmbrellaDevelVersion
+	case "umbrella":
+		return UmbrellaVersion
 	default:
 		// Default to the latest stable version
-		return SquidVersion
+		return TentacleVersion
 	}
 }
 

--- a/tests/integration/ceph_auth_keystone_test.go
+++ b/tests/integration/ceph_auth_keystone_test.go
@@ -93,7 +93,7 @@ func (h *KeystoneAuthSuite) SetupSuite() {
 		ChangeHostName:       true,
 		ConnectionsEncrypted: true,
 		RookVersion:          installer.LocalBuildTag,
-		CephVersion:          installer.SquidVersion,
+		CephVersion:          installer.TentacleVersion,
 		SkipClusterCleanup:   false,
 		SkipCleanupPolicy:    false,
 	}

--- a/tests/integration/ceph_helm_test.go
+++ b/tests/integration/ceph_helm_test.go
@@ -71,7 +71,7 @@ func (h *HelmSuite) SetupSuite() {
 		ChangeHostName:          true,
 		ConnectionsEncrypted:    true,
 		RookVersion:             installer.LocalBuildTag,
-		CephVersion:             installer.SquidVersion,
+		CephVersion:             installer.TentacleVersion,
 	}
 	h.settings.ApplyEnvVars()
 	h.installer, h.k8shelper = StartTestCluster(h.T, h.settings)

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -81,7 +81,7 @@ func (s *MultiClusterDeploySuite) SetupSuite() {
 		Mons:               1,
 		MultipleMgrs:       true,
 		RookVersion:        installer.LocalBuildTag,
-		CephVersion:        installer.SquidVersion,
+		CephVersion:        installer.TentacleVersion,
 		RequireMsgr2:       true,
 		ClusterConcurrency: 2,
 	}
@@ -92,7 +92,7 @@ func (s *MultiClusterDeploySuite) SetupSuite() {
 		Namespace:         "multi-external",
 		OperatorNamespace: s.settings.OperatorNamespace,
 		RookVersion:       s.settings.RookVersion,
-		CephVersion:       installer.SquidVersion,
+		CephVersion:       installer.TentacleVersion,
 	}
 	externalSettings.ApplyEnvVars()
 	s.externalManifests = installer.NewCephManifests(externalSettings)


### PR DESCRIPTION
Several changes to the daily CI tests:
- The daily CI smoke, object, and other suites now run all of the known Ceph versions, including stable Squid, Tentacle, and Umbrella, in addition to devel versions of the same releases.
- Only run the markdown checker on main fork, disabling it on other forks.

Also, a change that affects CI in PRs:
- Integration tests default to stable tentacle version instead of squid

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
