### PR TITLE
test: add do-not-reconcile label smoke test

### DIFF
--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -19,10 +19,12 @@ package integration
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/tests/framework/clients"
@@ -33,7 +35,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // ************************************************
@@ -190,6 +194,135 @@ func (s *SmokeSuite) TestMonFailover() {
 	require.Fail(s.T(), "giving up waiting for a new monitor")
 }
 
+// Smoke Test for the do-not-reconcile label - Fence an OSD deployment with the label and mark the
+// OSD out, then trigger an orchestration and check that the operator skips the OSD and leaves both
+// the label and the OSD state alone
+func (s *SmokeSuite) TestDoNotReconcileLabel() {
+	ctx := context.TODO()
+	logger.Infof("Do Not Reconcile Label Smoke Test")
+
+	// Taking an OSD out is only meaningful from a clean starting point, and checking here keeps a
+	// cluster left unhealthy by an earlier test from being blamed on this one
+	checkIfRookClusterIsHealthy(&s.Suite, s.helper, s.settings.Namespace)
+
+	deploymentClient := s.k8sh.Clientset.AppsV1().Deployments(s.settings.Namespace)
+	osdDeployments, err := deploymentClient.List(ctx, metav1.ListOptions{LabelSelector: "app=rook-ceph-osd"})
+	require.NoError(s.T(), err)
+	require.NotEmpty(s.T(), osdDeployments.Items)
+
+	fenced := osdDeployments.Items[0]
+	osdID := fenced.Labels["ceph-osd-id"]
+	require.NotEmpty(s.T(), osdID)
+	osdNum, err := strconv.ParseInt(osdID, 10, 64)
+	require.NoError(s.T(), err)
+	generation := fenced.Generation
+	replicas := fenced.Spec.Replicas
+	logger.Infof("Fencing OSD %s deployment %q at generation %d", osdID, fenced.Name, generation)
+
+	clusterClient := s.k8sh.RookClientset.CephV1().CephClusters(s.settings.Namespace)
+	cluster, err := clusterClient.Get(ctx, s.settings.ClusterName, metav1.GetOptions{})
+	require.NoError(s.T(), err)
+
+	// Any change to the CephCluster spec makes the operator run a fresh orchestration. This flag is
+	// only read when the upgrade checks are enabled, so with them skipped the toggle starts an
+	// orchestration without changing anything the orchestration does.
+	require.True(s.T(), cluster.Spec.SkipUpgradeChecks)
+	continueUpgrade := cluster.Spec.ContinueUpgradeAfterChecksEvenIfNotHealthy
+	toggleSpec := []byte(fmt.Sprintf(`{"spec":{"continueUpgradeAfterChecksEvenIfNotHealthy":%t}}`, !continueUpgrade))
+	revertSpec := []byte(fmt.Sprintf(`{"spec":{"continueUpgradeAfterChecksEvenIfNotHealthy":%t}}`, continueUpgrade))
+
+	// Cleanup runs LIFO, so it is registered in reverse of the order it has to happen in: put the OSD
+	// back in, unfence the deployment, revert the spec, and only then wait for the cluster to go
+	// clean again so the tests that follow do not start against a recovering cluster. Each step is
+	// registered before the change it undoes, since a request can fail after the apiserver or the
+	// mon has already accepted it.
+	defer checkIfRookClusterIsHealthy(&s.Suite, s.helper, s.settings.Namespace)
+	defer func() {
+		_, err := clusterClient.Patch(ctx, s.settings.ClusterName, types.MergePatchType, revertSpec, metav1.PatchOptions{})
+		assert.NoError(s.T(), err)
+	}()
+
+	addLabel := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:"true"}}}`, cephv1.SkipReconcileLabelKey))
+	removeLabel := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:null}}}`, cephv1.SkipReconcileLabelKey))
+	defer func() {
+		_, err := deploymentClient.Patch(ctx, fenced.Name, types.StrategicMergePatchType, removeLabel, metav1.PatchOptions{})
+		assert.NoError(s.T(), err)
+	}()
+	_, err = deploymentClient.Patch(ctx, fenced.Name, types.StrategicMergePatchType, addLabel, metav1.PatchOptions{})
+	require.NoError(s.T(), err)
+
+	defer func() {
+		logger.Infof("Marking OSD %s back in", osdID)
+		_, err := s.k8sh.ExecToolboxWithRetry(3, s.settings.Namespace, "ceph", []string{"osd", "in", fmt.Sprintf("osd.%s", osdID)})
+		assert.NoError(s.T(), err)
+	}()
+	logger.Infof("Marking OSD %s out", osdID)
+	_, err = s.k8sh.ExecToolboxWithRetry(3, s.settings.Namespace, "ceph", []string{"osd", "out", fmt.Sprintf("osd.%s", osdID)})
+	require.NoError(s.T(), err)
+
+	osdIsOut := false
+	for i := 0; i < utils.RetryLoop; i++ {
+		in, err := s.osdIsIn(osdNum)
+		require.NoError(s.T(), err)
+		if !in {
+			logger.Infof("OSD %s is out", osdID)
+			osdIsOut = true
+			break
+		}
+
+		logger.Infof("Waiting for OSD %s to report out", osdID)
+		time.Sleep(utils.RetryInterval * time.Second)
+	}
+	require.True(s.T(), osdIsOut, "OSD never reported out after being marked out")
+
+	logger.Infof("Triggering an orchestration of cluster %q", s.settings.ClusterName)
+	triggered := time.Now()
+	_, err = clusterClient.Patch(ctx, s.settings.ClusterName, types.MergePatchType, toggleSpec, metav1.PatchOptions{})
+	require.NoError(s.T(), err)
+
+	skipMessage := fmt.Sprintf("Skipping update for OSD %s since labeled with %s", osdID, cephv1.SkipReconcileLabelKey)
+	osdSkipped := false
+	for i := 0; i < utils.RetryLoop; i++ {
+		current, err := deploymentClient.Get(ctx, fenced.Name, metav1.GetOptions{})
+		require.NoError(s.T(), err)
+		// Without the label the operator has no reason to log the skip, so report the missing fence
+		// rather than letting this time out as if the orchestration never ran
+		require.Contains(s.T(), current.Labels, cephv1.SkipReconcileLabelKey, "the do-not-reconcile label was removed from OSD %s", osdID)
+
+		matches, err := s.countOperatorLogMatches(ctx, skipMessage, time.Since(triggered))
+		require.NoError(s.T(), err)
+		if matches > 0 {
+			logger.Infof("Operator skipped the fenced OSD %s", osdID)
+			osdSkipped = true
+			break
+		}
+
+		logger.Infof("Waiting for the operator to skip the fenced OSD %s", osdID)
+		time.Sleep(utils.RetryInterval * time.Second)
+	}
+	require.True(s.T(), osdSkipped, "operator never reported skipping the fenced OSD")
+
+	// The OSD health check runs every 10s in the test cluster, so this window spans several ticks of
+	// anything that might be tempted to unfence the OSD or put it back in behind the operator's back
+	for i := 0; i < 6; i++ {
+		time.Sleep(5 * time.Second)
+		current, err := deploymentClient.Get(ctx, fenced.Name, metav1.GetOptions{})
+		require.NoError(s.T(), err)
+		assert.Contains(s.T(), current.Labels, cephv1.SkipReconcileLabelKey, "the do-not-reconcile label was removed from OSD %s", osdID)
+
+		in, err := s.osdIsIn(osdNum)
+		require.NoError(s.T(), err)
+		assert.False(s.T(), in, "OSD %s was marked back in", osdID)
+	}
+
+	current, err := deploymentClient.Get(ctx, fenced.Name, metav1.GetOptions{})
+	require.NoError(s.T(), err)
+	// The generation advances whenever the deployment spec is written with different content, so an
+	// unchanged generation means the fenced OSD was left as it was found
+	assert.Equal(s.T(), generation, current.Generation)
+	assert.Equal(s.T(), replicas, current.Spec.Replicas)
+}
+
 // Smoke Test for pool Resizing
 func (s *SmokeSuite) TestPoolResize() {
 	ctx := context.TODO()
@@ -327,6 +460,42 @@ func (s *SmokeSuite) TestCreateRBDMirrorClient() {
 
 	err = s.helper.RBDMirrorClient.Delete(s.settings.Namespace, rbdMirrorName)
 	require.NoError(s.T(), err)
+}
+
+func (s *SmokeSuite) osdIsIn(osdID int64) (bool, error) {
+	dump, err := client.GetOSDDump(s.k8sh.MakeContext(), client.AdminTestClusterInfo(s.settings.Namespace))
+	if err != nil {
+		return false, err
+	}
+	_, in, err := dump.StatusByID(osdID)
+	if err != nil {
+		return false, err
+	}
+	return in == 1, nil
+}
+
+func (s *SmokeSuite) countOperatorLogMatches(ctx context.Context, match string, window time.Duration) (int, error) {
+	podClient := s.k8sh.Clientset.CoreV1().Pods(s.settings.OperatorNamespace)
+	pods, err := podClient.List(ctx, metav1.ListOptions{LabelSelector: "app=rook-ceph-operator"})
+	if err != nil {
+		return 0, err
+	}
+	if len(pods.Items) == 0 {
+		return 0, fmt.Errorf("no operator pod found in namespace %q", s.settings.OperatorNamespace)
+	}
+
+	// An elapsed duration keeps the window anchored where the caller wants it even if the node clock
+	// disagrees with the test runner, which an absolute timestamp would not
+	sinceSeconds := int64(window.Seconds()) + 1
+	matches := 0
+	for _, pod := range pods.Items {
+		podLog, err := podClient.GetLogs(pod.Name, &corev1.PodLogOptions{SinceSeconds: &sinceSeconds}).DoRaw(ctx)
+		if err != nil {
+			return 0, err
+		}
+		matches += strings.Count(string(podLog), match)
+	}
+	return matches, nil
 }
 
 func (s *SmokeSuite) getNonCanaryMonDeployments() ([]appsv1.Deployment, error) {

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/tests/framework/clients"
@@ -34,6 +35,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // ************************************************
@@ -194,6 +196,99 @@ func (s *SmokeSuite) TestMonFailover() {
 	require.Fail(s.T(), "giving up waiting for a new monitor")
 }
 
+// Smoke Test for the do-not-reconcile label - Fence an OSD deployment, reconcile the cluster and
+// check that the fenced deployment is left as it was found, then lift the fence and check that the
+// next reconcile rewrites it
+func (s *SmokeSuite) TestDoNotReconcileLabel() {
+	ctx := context.TODO()
+	logger.Infof("Do Not Reconcile Label Smoke Test")
+
+	const (
+		// The operator builds an OSD deployment from scratch whenever it updates one, so a label it
+		// never sets survives exactly as long as the deployment is left alone
+		canaryLabelKey = "smoke-test.rook.io/canary"
+		// Asking for an OSD label through the CephCluster spec is what gives a reconcile real work to
+		// do on the OSD deployments. Left alone they already match what the operator would generate,
+		// and it updates neither the fenced nor the unfenced ones.
+		requestedLabelKey = "smoke-test.rook.io/requested"
+	)
+
+	// Starting from a clean cluster keeps unhealthiness left by an earlier test from being blamed
+	// on this test's deferred health check
+	checkIfRookClusterIsHealthy(&s.Suite, s.helper, s.settings.Namespace)
+
+	deploymentClient := s.k8sh.Clientset.AppsV1().Deployments(s.settings.Namespace)
+	osdDeployments, err := deploymentClient.List(ctx, metav1.ListOptions{LabelSelector: "app=rook-ceph-osd"})
+	require.NoError(s.T(), err)
+	require.NotEmpty(s.T(), osdDeployments.Items)
+
+	fenced := osdDeployments.Items[0]
+	osdID := fenced.Labels["ceph-osd-id"]
+	require.NotEmpty(s.T(), osdID)
+	generation := fenced.Generation
+	replicas := fenced.Spec.Replicas
+	logger.Infof("Fencing OSD %s deployment %q at generation %d", osdID, fenced.Name, generation)
+
+	clusterClient := s.k8sh.RookClientset.CephV1().CephClusters(s.settings.Namespace)
+
+	// Cleanup runs LIFO, so it is registered in reverse of the order it has to happen in: drop the
+	// labels this test put on the deployment, stop asking for the OSD label, and only then wait for
+	// the cluster to settle so the tests that follow do not start against a reconciling cluster.
+	// Each step is registered before the change it undoes, since a request can fail after the
+	// apiserver has already accepted it.
+	defer checkIfRookClusterIsHealthy(&s.Suite, s.helper, s.settings.Namespace)
+	defer func() {
+		dropOSDLabel := []byte(`{"spec":{"labels":{"osd":null}}}`)
+		_, err := clusterClient.Patch(ctx, s.settings.ClusterName, types.MergePatchType, dropOSDLabel, metav1.PatchOptions{})
+		assert.NoError(s.T(), err)
+	}()
+	defer func() {
+		removeLabels := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:null,%q:null}}}`, cephv1.SkipReconcileLabelKey, canaryLabelKey))
+		_, err := deploymentClient.Patch(ctx, fenced.Name, types.StrategicMergePatchType, removeLabels, metav1.PatchOptions{})
+		assert.NoError(s.T(), err)
+	}()
+
+	addLabels := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:"true",%q:"true"}}}`, cephv1.SkipReconcileLabelKey, canaryLabelKey))
+	_, err = deploymentClient.Patch(ctx, fenced.Name, types.StrategicMergePatchType, addLabels, metav1.PatchOptions{})
+	require.NoError(s.T(), err)
+
+	s.reconcileCluster(ctx, fmt.Sprintf(`{"spec":{"labels":{"osd":{%q:"fenced"}}}}`, requestedLabelKey))
+
+	current, err := deploymentClient.Get(ctx, fenced.Name, metav1.GetOptions{})
+	require.NoError(s.T(), err)
+	// A canary that is already gone would make the rewrite check at the end of the test vacuous
+	require.Contains(s.T(), current.Labels, canaryLabelKey, "OSD %s lost the canary label while fenced", osdID)
+	assert.Contains(s.T(), current.Labels, cephv1.SkipReconcileLabelKey, "the do-not-reconcile label was removed from OSD %s", osdID)
+	assert.NotContains(s.T(), current.Labels, requestedLabelKey, "the fenced OSD %s was given the label requested through the cluster spec", osdID)
+	// The generation advances whenever the deployment spec is written with different content, so an
+	// unchanged generation means the fenced OSD was left as it was found
+	assert.Equal(s.T(), generation, current.Generation)
+	assert.Equal(s.T(), replicas, current.Spec.Replicas)
+
+	logger.Infof("Lifting the fence on OSD %s deployment %q", osdID, fenced.Name)
+	unfence := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:null}}}`, cephv1.SkipReconcileLabelKey))
+	_, err = deploymentClient.Patch(ctx, fenced.Name, types.StrategicMergePatchType, unfence, metav1.PatchOptions{})
+	require.NoError(s.T(), err)
+
+	s.reconcileCluster(ctx, fmt.Sprintf(`{"spec":{"labels":{"osd":{%q:"unfenced"}}}}`, requestedLabelKey))
+
+	osdRewritten := false
+	for i := 0; i < utils.RetryLoop; i++ {
+		current, err = deploymentClient.Get(ctx, fenced.Name, metav1.GetOptions{})
+		require.NoError(s.T(), err)
+		if _, ok := current.Labels[canaryLabelKey]; !ok {
+			logger.Infof("The reconcile rewrote the unfenced OSD %s", osdID)
+			osdRewritten = true
+			break
+		}
+
+		logger.Infof("Waiting for the reconcile to rewrite the unfenced OSD %s", osdID)
+		time.Sleep(utils.RetryInterval * time.Second)
+	}
+	require.True(s.T(), osdRewritten, "the unfenced OSD %s kept the canary label", osdID)
+	assert.Contains(s.T(), current.Labels, requestedLabelKey, "the unfenced OSD %s was not given the label requested through the cluster spec", osdID)
+}
+
 // Smoke Test for pool Resizing
 func (s *SmokeSuite) TestPoolResize() {
 	ctx := context.TODO()
@@ -331,6 +426,31 @@ func (s *SmokeSuite) TestCreateRBDMirrorClient() {
 
 	err = s.helper.RBDMirrorClient.Delete(s.settings.Namespace, rbdMirrorName)
 	require.NoError(s.T(), err)
+}
+
+// reconcileCluster patches the CephCluster spec and waits for the operator to finish the
+// orchestration that saw the patch. The patch has to change the spec, since that is what starts an
+// orchestration, and the observed generation is only written once a whole orchestration, OSDs
+// included, has succeeded.
+func (s *SmokeSuite) reconcileCluster(ctx context.Context, specPatch string) {
+	clusterClient := s.k8sh.RookClientset.CephV1().CephClusters(s.settings.Namespace)
+	patched, err := clusterClient.Patch(ctx, s.settings.ClusterName, types.MergePatchType, []byte(specPatch), metav1.PatchOptions{})
+	require.NoError(s.T(), err)
+
+	logger.Infof("Waiting for cluster %q to reconcile generation %d", s.settings.ClusterName, patched.Generation)
+	for i := 0; i < utils.RetryLoop; i++ {
+		cluster, err := clusterClient.Get(ctx, s.settings.ClusterName, metav1.GetOptions{})
+		require.NoError(s.T(), err)
+		if cluster.Status.ObservedGeneration >= patched.Generation {
+			logger.Infof("Cluster %q reconciled generation %d", s.settings.ClusterName, patched.Generation)
+			return
+		}
+
+		logger.Infof("Cluster %q is in phase %q having observed generation %d", s.settings.ClusterName, cluster.Status.Phase, cluster.Status.ObservedGeneration)
+		time.Sleep(utils.RetryInterval * time.Second)
+	}
+
+	require.Failf(s.T(), "giving up waiting for the cluster to reconcile", "generation %d was never observed", patched.Generation)
 }
 
 func (s *SmokeSuite) getNonCanaryMonDeployments() ([]appsv1.Deployment, error) {


### PR DESCRIPTION
This adds an integration test pinning the passive contract of the `ceph.rook.io/do-not-reconcile` label on OSD deployments: during an orchestration the operator skips a labeled OSD deployment, and nothing in Rook strips the label or mutates the fenced deployment. This is the fence relied on for disk maintenance (e.g. kubectl-rook-ceph's maintenance mode), so the fence holding is what makes that workflow safe.

The test uses a canary label the operator never sets, so both outcomes are read from the deployment itself and no operator logs are inspected. It fences an existing OSD deployment, adds the canary alongside the fence, and then asks for an OSD label through `spec.labels.osd` on the CephCluster — a spec change both triggers a reconcile and gives it real work to do on every OSD deployment (an unchanged deployment is never rewritten, so a bare reconcile would not exercise the fence). The fenced deployment comes through that reconcile with the canary and fence intact, without the requested label, and at its starting generation. Lifting the fence and asking again rewrites the deployment from scratch, which applies the requested label and takes the canary with it. Reconcile completion is detected via the CephCluster's `status.observedGeneration`, which is only written after a fully successful orchestration.

This guards against the regression class found during review of rook PR 17953, where a health goroutine stripped the label from any deployment carrying it. That defect was fixed before that PR merged by moving the replacement flow to its own private annotation; this test pins the spec-only label contract the fix settled on.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.

AI assistance: this test was designed and implemented with AI assistance, including verification of the operator's deployment-update and status-reporting paths that the test's observables rely on, and an adversarial review pass on the change before submission.
