### PR TITLE
external: add watcher to the svg controller for watching csi and clie…

### DIFF
--- a/pkg/operator/ceph/file/subvolumegroup/controller.go
+++ b/pkg/operator/ceph/file/subvolumegroup/controller.go
@@ -32,8 +32,10 @@ import (
 	"github.com/rook/rook/pkg/util/log"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -46,6 +48,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/file"
 	"github.com/rook/rook/pkg/operator/ceph/reporting"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -89,7 +92,7 @@ func Add(mgr manager.Manager, context *clusterd.Context, opManagerContext contex
 	}); err != nil {
 		return fmt.Errorf("failed to index CephFilesystemSubVolumeGroup by %s: %v", cephSVGFileSystemNameIndex, err)
 	}
-	return add(mgr, newReconciler(mgr, context, opManagerContext, opConfig))
+	return add(opManagerContext, mgr, newReconciler(mgr, context, opManagerContext, opConfig))
 }
 
 // newReconciler returns a new reconcile.Reconciler
@@ -103,7 +106,7 @@ func newReconciler(mgr manager.Manager, context *clusterd.Context, opManagerCont
 	}
 }
 
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
+func add(opManagerContext context.Context, mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
 	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})
 	if err != nil {
@@ -129,7 +132,71 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Build handler to map events to CephFilesystemSubVolumeGroup reconcile requests
+	clientProfileHandler, err := opcontroller.ObjectToCRMapper[*cephv1.CephFilesystemSubVolumeGroupList, *csiopv1.ClientProfile](
+		opManagerContext,
+		mgr.GetClient(),
+		&cephv1.CephFilesystemSubVolumeGroupList{},
+		mgr.GetScheme(),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Watch for ClientProfile changes
+	err = c.Watch(
+		source.Kind(
+			mgr.GetCache(),
+			&csiopv1.ClientProfile{TypeMeta: metav1.TypeMeta{Kind: "ClientProfile", APIVersion: fmt.Sprintf("%s/%s", csiopv1.GroupVersion.Group, csiopv1.GroupVersion.Version)}},
+			handler.TypedEnqueueRequestsFromMapFunc(clientProfileHandler),
+			opcontroller.WatchControllerPredicate[*csiopv1.ClientProfile](mgr.GetScheme()),
+		),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Build handler to map Secret events to CephFilesystemSubVolumeGroup reconcile requests
+	secretHandler, err := opcontroller.ObjectToCRMapper[*cephv1.CephFilesystemSubVolumeGroupList, *corev1.Secret](
+		opManagerContext,
+		mgr.GetClient(),
+		&cephv1.CephFilesystemSubVolumeGroupList{},
+		mgr.GetScheme(),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Watch for CSI secret changes (cephfs provisioner/node secrets)
+	err = c.Watch(
+		source.Kind(
+			mgr.GetCache(),
+			&corev1.Secret{TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: corev1.SchemeGroupVersion.String()}},
+			handler.TypedEnqueueRequestsFromMapFunc(secretHandler),
+			predicate.TypedFuncs[*corev1.Secret]{
+				CreateFunc: func(e event.TypedCreateEvent[*corev1.Secret]) bool {
+					return isCSICephFSSecret(e.Object.GetName())
+				},
+				UpdateFunc: func(e event.TypedUpdateEvent[*corev1.Secret]) bool {
+					return isCSICephFSSecret(e.ObjectNew.GetName())
+				},
+				DeleteFunc: func(e event.TypedDeleteEvent[*corev1.Secret]) bool {
+					return isCSICephFSSecret(e.Object.GetName())
+				},
+			},
+		),
+	)
+	if err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// check on for cephfs secrets
+func isCSICephFSSecret(name string) bool {
+	return strings.HasPrefix(name, csi.CsiCephFSProvisionerSecret) ||
+		strings.HasPrefix(name, csi.CsiCephFSNodeSecret)
 }
 
 // Reconcile reads that state of the cluster for a CephFilesystemSubVolumeGroup object and makes changes based on the state read

--- a/pkg/operator/ceph/file/subvolumegroup/controller_test.go
+++ b/pkg/operator/ceph/file/subvolumegroup/controller_test.go
@@ -382,3 +382,26 @@ func Test_formatPinning(t *testing.T) {
 	pinningStatus = formatPinning(*pinning)
 	assert.Equal(t, "random=0.31", pinningStatus)
 }
+
+func TestIsCSICephFSSecret(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"cephfs provisioner secret exact", csi.CsiCephFSProvisionerSecret, true},
+		{"cephfs node secret exact", csi.CsiCephFSNodeSecret, true},
+		{"cephfs provisioner secret with suffix", csi.CsiCephFSProvisionerSecret + "-cluster1", true},
+		{"cephfs node secret with suffix", csi.CsiCephFSNodeSecret + "-cluster1", true},
+		{"rbd node secret", csi.CsiRBDNodeSecret, false},
+		{"rbd provisioner secret", csi.CsiRBDProvisionerSecret, false},
+		{"unrelated secret", "my-app-secret", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isCSICephFSSecret(tt.input))
+		})
+	}
+}


### PR DESCRIPTION
…nt profile

Added a watcher to the SubVolumeGroup controller for watching csi and client profile.

Closes #18030

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
