### PR TITLE
ci: fix mod.check validation error message

### DIFF
--- a/tests/scripts/validate_modified_files.sh
+++ b/tests/scripts/validate_modified_files.sh
@@ -5,7 +5,7 @@ set -ex
 # VARIABLES #
 #############
 CODEGEN_ERR="found codegen files! please run 'make codegen' and update your PR"
-MOD_ERR="changes found by mod.check. You may need to run make clean"
+MOD_ERR="changes found by 'make mod.check'. please run 'make mod.check' locally and update your PR"
 CRD_ERR="changes found by 'make crds'. please run 'make crds' locally and update your PR"
 BUILD_ERR="changes found by make build', please commit your go.sum or other changed files"
 HELM_ERR="changes found by 'make gen-rbac'. please run 'make gen-rbac' locally and update your PR"


### PR DESCRIPTION
## Summary
- Correct the `modcheck` failure message in `validate_modified_files.sh` to advise running `make mod.check` and committing the result, instead of the incorrect `make clean` guidance.
- Aligns the message with the other validation errors in the same script (`crds`, `docs`, etc.).