### PR TITLE
osd: wipe encrypted devices missing ceph_fsid in the LUKS header

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -5378,7 +5378,8 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>WipeDevicesFromOtherClusters wipes the OSD disks belonging to other clusters. This is useful in scenarios where ceph cluster
+<p>WipeDevicesFromOtherClusters wipes the OSD disks belonging to other clusters or incomplete/unprovisioned
+encrypted devices missing ceph_fsid on PVC-backed storage. This is useful in scenarios where ceph cluster
 was reinstalled but OSD disk still contains the metadata from previous ceph cluster.</p>
 </td>
 </tr>

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -15,3 +15,4 @@
 - The toolbox deployments from the Helm chart and the example manifests now reload the keyring and `ceph.conf` automatically after CephX key rotation, mon failover, or a config override change.
 - CephCluster dashboard TLS certificates can now be configured from a same-namespace Kubernetes TLS Secret with `spec.dashboard.sslCertificateRef` when dashboard SSL is enabled. Rook reconciles updates to the referenced Secret and restores the default self-signed certificate when the reference is removed.
 - Object store reconciles now wait for the OSDs to finish upgrading.
+- OSD: `wipeDevicesFromOtherClusters` now also wipes PVC-backed encrypted devices that were formatted with LUKS but failed before completion (missing `ceph_fsid` token), allowing them to be reprovisioned cleanly. Metadata and WAL PVCs as well as host-based volumes are preserved.

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -1712,7 +1712,8 @@ spec:
                       type: object
                     wipeDevicesFromOtherClusters:
                       description: |-
-                        WipeDevicesFromOtherClusters wipes the OSD disks belonging to other clusters. This is useful in scenarios where ceph cluster
+                        WipeDevicesFromOtherClusters wipes the OSD disks belonging to other clusters or incomplete/unprovisioned
+                        encrypted devices missing ceph_fsid on PVC-backed storage. This is useful in scenarios where ceph cluster
                         was reinstalled but OSD disk still contains the metadata from previous ceph cluster.
                       type: boolean
                   type: object

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -1710,7 +1710,8 @@ spec:
                       type: object
                     wipeDevicesFromOtherClusters:
                       description: |-
-                        WipeDevicesFromOtherClusters wipes the OSD disks belonging to other clusters. This is useful in scenarios where ceph cluster
+                        WipeDevicesFromOtherClusters wipes the OSD disks belonging to other clusters or incomplete/unprovisioned
+                        encrypted devices missing ceph_fsid on PVC-backed storage. This is useful in scenarios where ceph cluster
                         was reinstalled but OSD disk still contains the metadata from previous ceph cluster.
                       type: boolean
                   type: object

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -3594,7 +3594,8 @@ type CleanupPolicySpec struct {
 	// +optional
 	AllowUninstallWithVolumes bool `json:"allowUninstallWithVolumes,omitempty"`
 
-	// WipeDevicesFromOtherClusters wipes the OSD disks belonging to other clusters. This is useful in scenarios where ceph cluster
+	// WipeDevicesFromOtherClusters wipes the OSD disks belonging to other clusters or incomplete/unprovisioned
+	// encrypted devices missing ceph_fsid on PVC-backed storage. This is useful in scenarios where ceph cluster
 	// was reinstalled but OSD disk still contains the metadata from previous ceph cluster.
 	// +optional
 	WipeDevicesFromOtherClusters bool `json:"wipeDevicesFromOtherClusters"`

--- a/pkg/daemon/ceph/osd/encryption_test.go
+++ b/pkg/daemon/ceph/osd/encryption_test.go
@@ -67,6 +67,49 @@ Digests:
         Digest:     6d 86 96 05 99 4f a9 48 87 54
                     5c ef 4b 99 3b 9d fa 0b 8f 8a`
 
+// luksDumpNoSubsystem reproduces a LUKS device that was luksFormat'd by Rook but never finished
+// OSD provisioning: it has neither Label nor Subsystem (ceph_fsid) token, since those
+// are only written by setLUKSLabelAndSubsystem() after a successful prepare.
+var luksDumpNoSubsystem = `LUKS header information
+Version:        2
+Epoch:          13
+Metadata area:  12288 bytes
+UUID:           a97525ee-7c30-4f70-89ac-e56d48907cc5
+Label:          (no label)
+Subsystem:      (no subsystem)
+Flags:          (no flags)
+
+Data segments:
+  0: crypt
+        offset: 2097152 [bytes]
+        length: (whole device)
+        cipher: aes-xts-plain64
+        sector: 512 [bytes]
+
+Keyslots:
+  0: luks2
+        Key:        256 bits
+        Priority:   normal
+        Cipher:     aes-xts-plain64
+        PBKDF:      pbkdf2
+        Hash:       sha256
+        Iterations: 583190
+        Salt:       4f 9d 0d 0b 83 41 2f 47 b4 1f 6b 35 df 89 e0 33
+                    c8 bd 27 60 22 a5 f5 02 62 94 a9 92 12 2a 4f c0
+        AF stripes: 4000
+        Area offset:32768 [bytes]
+        Area length:131072 [bytes]
+        Digest ID:  0
+Tokens:
+Digests:
+  0: pbkdf2
+        Hash:       sha256
+        Iterations: 36127
+        Salt:       db 98 33 3a d4 15 b6 6c 48 63 6d 7b 33 b0 7e cd
+                    ef 90 8d 81 46 37 78 b4 82 37 3b 84 e8 e7 d8 1b
+        Digest:     6d 86 96 05 99 4f a9 48 87 54
+                    5c ef 4b 99 3b 9d fa 0b 8f 8a`
+
 func TestCloseEncryptedDevice(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {

--- a/pkg/daemon/ceph/osd/encryption_test.go
+++ b/pkg/daemon/ceph/osd/encryption_test.go
@@ -67,6 +67,49 @@ Digests:
         Digest:     6d 86 96 05 99 4f a9 48 87 54
                     5c ef 4b 99 3b 9d fa 0b 8f 8a`
 
+// luksDumpNoSubsystem reproduces a LUKS device that was luksFormat'd by Rook but never finished
+// OSD provisioning: it has a Label but no Subsystem (ceph_fsid) token, since that token is only
+// written by setLUKSLabelAndSubsystem() after a successful prepare.
+var luksDumpNoSubsystem = `LUKS header information
+Version:        2
+Epoch:          13
+Metadata area:  12288 bytes
+UUID:           a97525ee-7c30-4f70-89ac-e56d48907cc5
+Label:          pvc_name=set1-data-0lmdjp
+Subsystem:      (no subsystem)
+Flags:          (no flags)
+
+Data segments:
+  0: crypt
+        offset: 2097152 [bytes]
+        length: (whole device)
+        cipher: aes-xts-plain64
+        sector: 512 [bytes]
+
+Keyslots:
+  0: luks2
+        Key:        256 bits
+        Priority:   normal
+        Cipher:     aes-xts-plain64
+        PBKDF:      pbkdf2
+        Hash:       sha256
+        Iterations: 583190
+        Salt:       4f 9d 0d 0b 83 41 2f 47 b4 1f 6b 35 df 89 e0 33
+                    c8 bd 27 60 22 a5 f5 02 62 94 a9 92 12 2a 4f c0
+        AF stripes: 4000
+        Area offset:32768 [bytes]
+        Area length:131072 [bytes]
+        Digest ID:  0
+Tokens:
+Digests:
+  0: pbkdf2
+        Hash:       sha256
+        Iterations: 36127
+        Salt:       db 98 33 3a d4 15 b6 6c 48 63 6d 7b 33 b0 7e cd
+                    ef 90 8d 81 46 37 78 b4 82 37 3b 84 e8 e7 d8 1b
+        Digest:     6d 86 96 05 99 4f a9 48 87 54
+                    5c ef 4b 99 3b 9d fa 0b 8f 8a`
+
 func TestCloseEncryptedDevice(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -1070,7 +1070,7 @@ func (a *OsdAgent) WipeDevicesFromOtherClusters(context *clusterd.Context) error
 		// ceph-volume raw list didn't return any existing OSDs. It's possible that /dev/mapper entries of the encrypted disks were removed.
 		// Check for cephFSID in the luks header of the disk and clean the disk if it does not match the cephFSID of the current cluster.
 		logger.Infof("ceph-volume didn't return any existing OSDs. Checking for cephFSID of a different cluster in the luks header of the disk")
-		err := wipeEncryptedDevicesFromOtherClusters(context, a.clusterInfo.FSID)
+		err := a.wipeEncryptedDevicesFromOtherClusters(context)
 		if err != nil {
 			return errors.Wrapf(err, "failed to clean up encrypted disks from other clusters")
 		}
@@ -1113,24 +1113,48 @@ func (a *OsdAgent) WipeDevicesFromOtherClusters(context *clusterd.Context) error
 	return nil
 }
 
-func wipeEncryptedDevicesFromOtherClusters(context *clusterd.Context, currentClusterFSID string) error {
+func (a *OsdAgent) wipeEncryptedDevicesFromOtherClusters(context *clusterd.Context) error {
 	for _, disk := range context.Devices {
 		if disk.Filesystem == "crypto_LUKS" {
 			metadata, err := dumpLUKS(context, disk.Name)
 			if err != nil {
 				logger.Debugf("failed to determine if the encrypted block %q is from our cluster. %v", disk.Name, err)
-				return nil
+				continue
 			}
 
 			ceph_fsid := luksLabelCephFSID.FindString(metadata)
 			if ceph_fsid == "" {
-				logger.Error("ceph_fsid not found in the LUKS header, the encrypted disk is not from a ceph cluster")
-				return nil
+				// Metadata and WAL PVC devices (pvcMetadataTypeDevice / pvcWalTypeDevice) never carry
+				// a ceph_fsid token because setLUKSLabelAndSubsystem() is only applied to the main data device.
+				// Do not wipe them as missing-token devices.
+				if a.pvcBacked && (disk.Type == pvcMetadataTypeDevice || disk.Type == pvcWalTypeDevice) {
+					logger.Debugf("skipping encrypted metadata/wal disk %q (%q) with no ceph_fsid token", disk.Name, disk.RealPath)
+					continue
+				}
+
+				// Only wipe token-less encrypted devices when running on PVC-backed storage.
+				// On host-based clusters, non-Ceph or admin-managed LUKS volumes may lack ceph_fsid and must not be touched.
+				if !a.pvcBacked {
+					logger.Debugf("skipping encrypted disk %q (%q) with no ceph_fsid because host-based wiping is not PVC-backed", disk.Name, disk.RealPath)
+					continue
+				}
+
+				// No ceph_fsid token means this disk was luksFormat'd by Rook but never
+				// finished OSD provisioning (setLUKSLabelAndSubsystem() only writes the token
+				// after a successful prepare). Since this helper runs when the caller wants
+				// foreign/stray disks cleared for reuse, wipe it so it can be reprovisioned.
+				logger.Infof("no ceph_fsid found in the LUKS header of disk %q (%q), wiping it so it can be reprovisioned", disk.Name, disk.RealPath)
+				if err := ZapDevice(context, disk.RealPath); err != nil {
+					return errors.Wrapf(err, "failed to zap encrypted disk %q with no ceph_fsid in its LUKS header", disk.RealPath)
+				}
+				logger.Infof("completed wiping device %q with no ceph_fsid in its LUKS header", disk.RealPath)
+				disk.Filesystem = ""
+				continue
 			}
 
 			// is it an OSD from our cluster?
 			currentDiskCephFSID := strings.SplitAfter(ceph_fsid, "=")[1]
-			if currentDiskCephFSID != currentClusterFSID {
+			if currentDiskCephFSID != a.clusterInfo.FSID {
 				logger.Infof("cleaning encrypted disk %q (%q) that is part of a different ceph cluster %q", disk.Name, disk.RealPath, currentDiskCephFSID)
 				if err := ZapDevice(context, disk.RealPath); err != nil {
 					return errors.Wrapf(err, "failed to zap encrypted disk with different ceph cluster %q", disk.RealPath)

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -1041,8 +1041,19 @@ func wipeEncryptedDevicesFromOtherClusters(context *clusterd.Context, currentClu
 
 			ceph_fsid := luksLabelCephFSID.FindString(metadata)
 			if ceph_fsid == "" {
-				logger.Error("ceph_fsid not found in the LUKS header, the encrypted disk is not from a ceph cluster")
-				return nil
+				// No ceph_fsid token means either this disk was luksFormat'd by Rook but never
+				// finished OSD provisioning (setLUKSLabelAndSubsystem() only writes the token
+				// after a successful prepare), or it isn't a Ceph disk at all. Since this helper
+				// only runs when the caller wants stray/foreign disks cleared for reuse, treat a
+				// missing token the same as a foreign-cluster disk and wipe it so it can be
+				// reprovisioned, instead of leaving it stuck in this state indefinitely.
+				logger.Infof("no ceph_fsid found in the LUKS header of disk %q (%q), wiping it so it can be reprovisioned", disk.Name, disk.RealPath)
+				if err := ZapDevice(context, disk.RealPath); err != nil {
+					return errors.Wrapf(err, "failed to zap encrypted disk %q with no ceph_fsid in its LUKS header", disk.RealPath)
+				}
+				logger.Infof("completed wiping device %q with no ceph_fsid in its LUKS header", disk.RealPath)
+				disk.Filesystem = ""
+				continue
 			}
 
 			// is it an OSD from our cluster?

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -2435,6 +2435,144 @@ func TestWipeDevicesFromOtherClusters(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestWipeDevicesFromOtherClusters_MissingCephFSID reproduces
+// https://github.com/rook/rook/issues/18043: a device that was luksFormat'd by Rook but never
+// finished OSD provisioning has no ceph_fsid token in its LUKS header. On PVC-backed clusters,
+// that must be treated as eligible for wipe so it can be reprovisioned.
+// It also ensures that:
+// 1. Metadata and WAL PVC devices (which never receive a token) are preserved and NOT wiped.
+// 2. Non-PVC (host-based) token-less LUKS devices are preserved and NOT wiped.
+func TestWipeDevicesFromOtherClusters_MissingCephFSID(t *testing.T) {
+	t.Run("PVC data device with missing token is wiped", func(t *testing.T) {
+		agent := &OsdAgent{
+			pvcBacked: true,
+			clusterInfo: &cephclient.ClusterInfo{
+				FSID: "c03d7353-96e5-4a41-98de-830dfff97d06",
+			},
+		}
+		devicePath := "/dev/nvme5n1"
+		var executedCommands []string
+
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			if slices.Contains(args, "raw") && slices.Contains(args, "list") {
+				return `{}`, nil // ceph-volume raw list returns no existing OSDs
+			}
+			return "", errors.Errorf("unknown command %s %s", command, args)
+		}
+		executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+			executedCommands = append(executedCommands, command)
+			if command == cryptsetupBinary && args[0] == "luksDump" {
+				return luksDumpNoSubsystem, nil
+			}
+			if command == "stdbuf" {
+				return "", nil
+			}
+			if command == "umount" {
+				return "not mounted", errors.New("not mounted")
+			}
+			if command == "wipefs" {
+				if args[1] != devicePath {
+					return "", errors.Errorf("device %s should have been zapped, got %s", devicePath, args[1])
+				}
+				return "", nil
+			}
+			if command == "ceph-bluestore-tool" {
+				return "", nil
+			}
+			if command == "dd" {
+				return "", nil
+			}
+			return "", errors.Errorf("unknown command %s %s", command, args)
+		}
+
+		disk := &sys.LocalDisk{Name: "nvme5n1", RealPath: devicePath, Type: pvcDataTypeDevice, Filesystem: "crypto_LUKS"}
+		context := &clusterd.Context{
+			Devices: []*sys.LocalDisk{disk},
+		}
+		context.Executor = executor
+		err := agent.WipeDevicesFromOtherClusters(context)
+		assert.NoError(t, err)
+		assert.Contains(t, executedCommands, "wipefs")
+		assert.Contains(t, executedCommands, "dd")
+		assert.Empty(t, disk.Filesystem)
+	})
+
+	t.Run("PVC metadata and WAL devices with missing token are skipped", func(t *testing.T) {
+		agent := &OsdAgent{
+			pvcBacked: true,
+			clusterInfo: &cephclient.ClusterInfo{
+				FSID: "c03d7353-96e5-4a41-98de-830dfff97d06",
+			},
+		}
+		var executedCommands []string
+
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			if slices.Contains(args, "raw") && slices.Contains(args, "list") {
+				return `{}`, nil
+			}
+			return "", errors.Errorf("unknown command %s %s", command, args)
+		}
+		executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+			executedCommands = append(executedCommands, command)
+			if command == cryptsetupBinary && args[0] == "luksDump" {
+				return luksDumpNoSubsystem, nil
+			}
+			return "", errors.Errorf("unknown command %s %s", command, args)
+		}
+
+		metaDisk := &sys.LocalDisk{Name: "srv-meta", RealPath: "/dev/srv/meta", Type: pvcMetadataTypeDevice, Filesystem: "crypto_LUKS"}
+		walDisk := &sys.LocalDisk{Name: "wal-disk", RealPath: "/dev/wal/wal", Type: pvcWalTypeDevice, Filesystem: "crypto_LUKS"}
+		context := &clusterd.Context{
+			Devices: []*sys.LocalDisk{metaDisk, walDisk},
+		}
+		context.Executor = executor
+		err := agent.WipeDevicesFromOtherClusters(context)
+		assert.NoError(t, err)
+		assert.NotContains(t, executedCommands, "wipefs")
+		assert.NotContains(t, executedCommands, "dd")
+		assert.Equal(t, "crypto_LUKS", metaDisk.Filesystem)
+		assert.Equal(t, "crypto_LUKS", walDisk.Filesystem)
+	})
+
+	t.Run("Host-based cluster token-less devices are skipped", func(t *testing.T) {
+		agent := &OsdAgent{
+			pvcBacked: false,
+			clusterInfo: &cephclient.ClusterInfo{
+				FSID: "c03d7353-96e5-4a41-98de-830dfff97d06",
+			},
+		}
+		var executedCommands []string
+
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			if slices.Contains(args, "raw") && slices.Contains(args, "list") {
+				return `{}`, nil
+			}
+			return "", errors.Errorf("unknown command %s %s", command, args)
+		}
+		executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+			executedCommands = append(executedCommands, command)
+			if command == cryptsetupBinary && args[0] == "luksDump" {
+				return luksDumpNoSubsystem, nil
+			}
+			return "", errors.Errorf("unknown command %s %s", command, args)
+		}
+
+		hostDisk := &sys.LocalDisk{Name: "sda", RealPath: "/dev/sda", Filesystem: "crypto_LUKS"}
+		context := &clusterd.Context{
+			Devices: []*sys.LocalDisk{hostDisk},
+		}
+		context.Executor = executor
+		err := agent.WipeDevicesFromOtherClusters(context)
+		assert.NoError(t, err)
+		assert.NotContains(t, executedCommands, "wipefs")
+		assert.NotContains(t, executedCommands, "dd")
+		assert.Equal(t, "crypto_LUKS", hostDisk.Filesystem)
+	})
+}
+
 func TestFindDeviceClass(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -2332,6 +2332,66 @@ func TestWipeDevicesFromOtherClusters(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestWipeDevicesFromOtherClusters_MissingCephFSID reproduces
+// https://github.com/rook/rook/issues/18043: a device that was luksFormat'd by Rook but never
+// finished OSD provisioning has no ceph_fsid token in its LUKS header. That must be treated as
+// eligible for wipe, the same as a disk from a genuinely different cluster, instead of being left
+// untouched forever.
+func TestWipeDevicesFromOtherClusters_MissingCephFSID(t *testing.T) {
+	agent := &OsdAgent{
+		clusterInfo: &cephclient.ClusterInfo{
+			FSID: "c03d7353-96e5-4a41-98de-830dfff97d06",
+		},
+	}
+	devicePath := "/dev/nvme5n1"
+
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		logger.Infof("%s %v", command, args)
+		if slices.Contains(args, "raw") && slices.Contains(args, "list") {
+			return `{}`, nil // ceph-volume raw list returns no existing OSDs
+		}
+		return "", errors.Errorf("unknown command %s %s", command, args)
+	}
+	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+		logger.Infof("%s %v", command, args)
+
+		if command == cryptsetupBinary && args[0] == "luksDump" {
+			return luksDumpNoSubsystem, nil
+		}
+		// ZapDevice calls: stdbuf (ceph-volume lvm zap), umount, wipefs, ceph-bluestore-tool, dd
+		if command == "stdbuf" {
+			if !slices.Contains(args, "zap") || !slices.Contains(args, devicePath) {
+				return "", errors.Errorf("device %s should have been zapped, got %v", devicePath, args)
+			}
+			return "", nil
+		}
+		if command == "umount" {
+			return "not mounted", errors.New("not mounted")
+		}
+		if command == "wipefs" {
+			if args[1] != devicePath {
+				return "", errors.Errorf("device %s should have been zapped, got %s", devicePath, args[1])
+			}
+			return "", nil
+		}
+		if command == "ceph-bluestore-tool" {
+			return "", nil
+		}
+		if command == "dd" {
+			return "", nil
+		}
+		return "", errors.Errorf("unknown command %s %s", command, args)
+	}
+
+	context := &clusterd.Context{
+		Devices: []*sys.LocalDisk{{RealPath: devicePath, Filesystem: "crypto_LUKS"}},
+	}
+	context.Executor = executor
+	err := agent.WipeDevicesFromOtherClusters(context)
+	assert.NoError(t, err)
+}
+
 func TestFindDeviceClass(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

**Issue resolved by this Pull Request:**
Resolves #18043

The function only handled devices from another cluster, but did not handle devices with no token at all. This second case should also be wiped when wipeDevicesFromOtherClusters=true, instead of being ignored with an error.

AI assisted with root-cause investigation and test scaffolding; reasoning and fix approach reviewed by me.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.