### PR TITLE
build: harden the release helper scripts

### DIFF
--- a/build/release/set-release-ver.sh
+++ b/build/release/set-release-ver.sh
@@ -5,9 +5,23 @@ set -euo pipefail
 # release version (TO_TAG) instead the old one (FROM_TAG) in preparation for a release.
 # The script will usually be run on a release branch.
 
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <new release version>  # e.g., v1.17.2" >&2
+  exit 1
+fi
 TO_TAG="$1"
 
-FROM_TAG=$(grep "docker.io/rook/ceph" deploy/examples/images.txt | awk -F : '{ print $2 }')
+if [[ ! "$TO_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$ ]]; then
+  echo "error: '$TO_TAG' is not a release version (vX.Y.Z with an optional -alpha/-beta/-rc.N suffix)" >&2
+  exit 1
+fi
+
+FROM_TAG=$(grep "docker.io/rook/ceph" deploy/examples/images.txt | awk -F : '{ print $2 }') || true
+
+if [[ -z "$FROM_TAG" ]]; then
+  echo "error: could not determine the current version from deploy/examples/images.txt" >&2
+  exit 1
+fi
 
 echo "Updating from $FROM_TAG to $TO_TAG..."
 

--- a/tests/scripts/gen_release_notes.sh
+++ b/tests/scripts/gen_release_notes.sh
@@ -3,9 +3,10 @@ set -e
 
 function help() {
   print="
-  To run this command,
-  1. verify you are selecting right branch from GitHub UI dropdown menu
-  2. enter the tag you want to create
+  To run this command, set:
+  1. GITHUB_USER and GITHUB_TOKEN for the GitHub API
+  2. FROM_BRANCH to the tag of the release being published (e.g., v1.12.9)
+  3. TO_TAG to the previous release tag (e.g., v1.12.8)
   "
   echo "$print"
   exit 1
@@ -16,6 +17,18 @@ if [ -z "${GITHUB_USER}" ] || [ -z "${GITHUB_TOKEN}" ]; then
   help
 fi
 
+if [ -z "${FROM_BRANCH}" ] || [ -z "${TO_TAG}" ]; then
+  echo "requires both FROM_BRANCH and TO_TAG to be set as env variables"
+  help
+fi
+
+for tag in "${FROM_BRANCH}" "${TO_TAG}"; do
+  if ! git rev-parse --verify --quiet "${tag}^{commit}" >/dev/null; then
+    echo "'${tag}' is not a known git revision"
+    help
+  fi
+done
+
 pr_list=$(git log --pretty="%s" --merges --left-only "${FROM_BRANCH}"..."${TO_TAG}" | grep pull | awk '/Merge pull request/ {print $4}' | cut -c 2-)
 
 # for releases notes
@@ -23,10 +36,6 @@ function release_notes() {
   for pr in $pr_list; do
   # get PR title
   backport_pr=$(curl -s -u "${GITHUB_USER}":"${GITHUB_TOKEN}" "https://api.github.com/repos/rook/rook/pulls/${pr}" | jq '.title')
-  # with upstream/release-1.6 v1.6.8, it was giving extra PR numbers, so removing after PR for changing tag is merged.
-  if [[ "$backport_pr" =~ ./*"build: Update build version to $TO_TAG"* ]]; then
-    break
-  fi
   # check if it is manual backport PR or not, for mergify backport PR it will contain "(backport"
   if [[ "$backport_pr" =~ .*"(backport".* ]]; then
     # find the PR number after the #


### PR DESCRIPTION
Preparing releases relies on two helper scripts whose failure modes have bitten before: a malformed version argument shipped across the v1.20.0-beta.0 bump manifests, and `gen_release_notes.sh` silently prints nothing when its inputs are unset or mistyped.

What changed:

- `set-release-ver.sh` validates its usage and the version argument format, and reports a clear error when the current version cannot be read from `deploy/examples/images.txt`.
- `gen_release_notes.sh` fails fast with usage help when `FROM_BRANCH`/`TO_TAG` are unset or do not resolve to git revisions, its dead stop condition (matching a bump PR title convention last used in 2021) is removed, and the help text describes the script's actual inputs.

Per review feedback, the script does not try to guess the intended branch, and the version-bump PR remains in the notes output for manual pruning.

AI assistance: this PR was researched, implemented, and verified with an AI agent (Claude Code), including replaying the scripts against real release history.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
