### PR TITLE
build: validate the release version before tagging and publishing

### DIFF
--- a/.github/workflows/push-build.yaml
+++ b/.github/workflows/push-build.yaml
@@ -29,6 +29,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: validate release version
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: build/release/validate-tag.sh "$TAG_NAME"
+
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26"

--- a/build/release/README.md
+++ b/build/release/README.md
@@ -109,6 +109,8 @@ To publish a new patch release build, follow these steps:
     git reset --hard upstream/$BRANCH_NAME
     # set to the new release
     TAG_NAME=<release version> # e.g., v1.12.9
+    # verify the checkout matches the version being tagged
+    build/release/validate-tag.sh "$TAG_NAME"
     git tag -a "$TAG_NAME" -m "$TAG_NAME release tag"
     git push upstream "$TAG_NAME"
     ```

--- a/build/release/validate-tag.sh
+++ b/build/release/validate-tag.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verifies that the checked out tree matches the release version being tagged, so that a
+# mismatched tag cannot publish artifacts that reference a different version. Run it before
+# pushing a release tag; the release build runs it again before publishing anything.
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <release version>  # e.g., v1.17.2" >&2
+  exit 1
+fi
+TAG="$1"
+
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$ ]]; then
+  echo "error: '$TAG' is not a release version (vX.Y.Z with an optional -alpha/-beta/-rc.N suffix)" >&2
+  exit 1
+fi
+
+cd "$(git rev-parse --show-toplevel)"
+
+# The alpha tag marks the creation of a release branch and is tagged before the version
+# update PR, so the tree is not expected to match it.
+if [[ "$TAG" == *"-alpha."* ]]; then
+  echo "$TAG is an alpha tag; skipping the release version check."
+  exit 0
+fi
+
+if [[ -n "$(git status --porcelain --untracked-files=no)" ]]; then
+  echo "error: the working tree has local modifications, which would taint the version reported by 'git describe'." >&2
+  exit 1
+fi
+
+IMAGE_TAG=$(grep "docker.io/rook/ceph" deploy/examples/images.txt | awk -F : '{ print $2 }') || true
+if [[ -z "$IMAGE_TAG" ]]; then
+  echo "error: could not find the docker.io/rook/ceph image in deploy/examples/images.txt" >&2
+  exit 1
+fi
+if [[ "$IMAGE_TAG" != "$TAG" ]]; then
+  echo "error: deploy/examples/images.txt has docker.io/rook/ceph:${IMAGE_TAG}, expected ${TAG}." >&2
+  echo "Merge the version update PR (see set-release-ver.sh) to the release branch before tagging ${TAG}." >&2
+  exit 1
+fi
+
+CHART_TAG=$(awk '/repository: docker\.io\/rook\/ceph/{f=1; next} f && /^[[:space:]]*tag:/{print $2; exit}' deploy/charts/rook-ceph/values.yaml)
+if [[ -z "$CHART_TAG" ]]; then
+  echo "error: could not find the docker.io/rook/ceph image tag in deploy/charts/rook-ceph/values.yaml" >&2
+  exit 1
+fi
+if [[ "$CHART_TAG" != "$TAG" ]]; then
+  echo "error: deploy/charts/rook-ceph/values.yaml sets the rook image tag to '${CHART_TAG}', expected ${TAG}." >&2
+  exit 1
+fi
+
+echo "OK: the tree matches release version ${TAG}."


### PR DESCRIPTION
Nothing verified that the commit being tagged for a release actually carries the intended version: tagging a release branch before the version-update PR merges publishes images and manifests that reference the previous version. This has happened: the tree at `v1.20.0-beta.0` referenced `docker.io/rook/ceph:v1.20-beta.0` — an image tag that was never published — so its manifests and chart pointed at a nonexistent image.

- `build/release/validate-tag.sh` verifies the checkout matches the release version being tagged: a clean tree (a dirty tree taints the `git describe`-derived build version), `deploy/examples/images.txt` carrying exactly `docker.io/rook/ceph:<tag>`, and the operator chart's rook image tag matching. `*-alpha.*` tags are exempt since the alpha only marks the creation of a release branch, before the first version update.
- `push-build.yaml` runs the validation immediately after checkout for `v*` tag refs, before any registry login, build, or publish step, so a mismatched tag fails before any artifact ships.
- The tagging steps in `build/release/README.md` now run the script before `git tag`.

AI assistance: this PR was researched, implemented, and verified with an AI agent (Claude Code), including replaying the validation against real historical release trees.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
