### PR TITLE
osd replacement fix review issues

### DIFF
--- a/Documentation/Storage-Configuration/Advanced/ceph-osd-mgmt.md
+++ b/Documentation/Storage-Configuration/Advanced/ceph-osd-mgmt.md
@@ -275,6 +275,24 @@ kubectl -n rook-ceph get deployment rook-ceph-osd-5
 
 The replacement is complete once OSD `5` is `up` and `in`. Ceph then backfills the data onto the new disk; monitor recovery from the [Ceph dashboard](../Monitoring/ceph-dashboard.md) or the toolbox until all PGs are `active+clean`.
 
+### If the replacement disk fails to provision
+
+If the replacement disk is faulty, provisioning can fail after Ceph has already reserved the OSD ID. The original OSD cannot then be kept in place: once a working disk is in place it is provisioned as a **new** OSD — which may or may not reuse the old ID — and Ceph rebalances data as it does for any new OSD. No data is lost.
+
+Rook deletes the leftover `rook-ceph-osd-5` deployment. The other OSDs sharing the metadata device are unaffected.
+
+The operator log records the cleanup:
+
+```console
+kubectl -n rook-ceph logs deploy/rook-ceph-operator | grep -i "replacement"
+```
+
+Why the disk failed to provision is logged by the OSD prepare job on that node, not by the operator:
+
+```console
+kubectl -n rook-ceph logs job/rook-ceph-osd-prepare-<node>
+```
+
 ## OSD Migration
 
 Ceph does not support changing certain settings on existing OSDs. To support changing these settings on an OSD, the OSD must be destroyed and re-created with the new settings. Rook will automate this by migrating only one OSD at a time. The operator waits for the data to rebalance (PGs to become `active+clean`) before migrating the next OSD. This ensures that there is no data loss. Refer to the [OSD migration](https://github.com/rook/rook/blob/master/design/ceph/osd-migration.md) design doc for more information. 

--- a/design/ceph/osd-replacement.md
+++ b/design/ceph/osd-replacement.md
@@ -210,7 +210,7 @@ Invocation notes:
 
 - **`--osd-id <id>` claims the destroyed slot.** Internally `ceph-volume` calls `ceph osd new <new-fsid> <id>`; the OSD ID, CRUSH bucket, and weight are preserved, only the OSD UUID is new.
 - **Reusing the old DB LV in place is safe.** `ceph-volume` retags and re-mkfs the LV passed via `--block.db`, allocating nothing on the metadata device, so sibling DB LVs are untouched and stale BlueStore or LUKS leftovers are overwritten during prepare. This is why the flow uses `lvm prepare --block.db <vg/lv>` and not `lvm batch`, which always allocates a new DB slot and refuses a surviving sibling LV.
-- **A failed `lvm prepare` can be destructive.** Its rollback runs `ceph osd purge-new`, which removes the destroyed slot and zaps the reused DB LV; recovery is then manual (see [Cancellation and retry](#cancellation-and-retry)). The one known trigger cannot reach prepare, since the availability gate never offers a device pinned by a stale mapping.
+- **A failed `lvm prepare` can be destructive.** See [When provisioning the replacement disk fails](#when-provisioning-the-replacement-disk-fails).
 
 The prepare-job writes the reprovisioned OSD's id and OSDInfo to the per-node status CM `rook-ceph-osd-<node>-status`, exactly as for any OSD it provisions, and never touches the Deployment. That new entry brings the slot back under the controller's create path; nothing in the goroutine runs past `replace-ready-for-swap`.
 
@@ -223,7 +223,7 @@ The replacement is complete once `osd.<id>` is `up` and `in`, at which point the
 Cancellation is done by removing the `osd.rook.io/replace` annotation.
 
 - **Before destroy (during validate or drain).** Clean cancel: no Ceph state has been changed that cannot be reversed. On the next tick the goroutine sees the annotation gone, stops the `safe-to-destroy` wait, marks the OSD back `in` with `ceph osd in <id>`, deletes any in-flight cleanup Job, and clears the `replace-in-progress` annotation and the `do-not-reconcile` label — both in one update, the reverse of how the controller set them — so the updater scales the Deployment back to `replicas=1`. The Job is deleted before the fence is cleared: a lingering `cryptsetup close` would otherwise race the daemon coming back up. The goroutine may clear the label here even though it must never *set* it (see [Why split the work](#why-split-the-work-between-the-controller-and-the-goroutine)). Clearing is safe in a race: if a reconcile does not see the cleared label, it just skips the OSD for one more tick. Setting is not safe: a reconcile that does not see a newly set label would scale the OSD back up and undo the replacement.
-- **After destroy succeeds.** Not honored. The slot is already `destroyed` in the OSDMap. Recovery is to either let the flow complete (provision a new disk into the same slot) or abandon it manually: `ceph osd purge <id>` to retire the slot, `ceph-volume lvm zap --destroy` the surviving DB LV, and delete the held OSD Deployment.
+- **After destroy succeeds.** Not honored. The slot is already `destroyed` in the OSDMap. Recovery is to either let the flow complete (provision a new disk into the same slot) or abandon it manually: `ceph osd purge <id>` to retire the slot and `ceph-volume lvm zap --destroy` the surviving DB LV. The held OSD Deployment does not need deleting by hand: once the purge removes the id from the osdmap, the controller removes it on the next reconcile (see [When provisioning the replacement disk fails](#when-provisioning-the-replacement-disk-fails)).
 
 Retry after a terminal failure (validation rejection): the user removes the `osd.rook.io/replace` annotation and re-adds it. The carve-out fires a fresh reconcile and the controller re-validates.
 
@@ -272,6 +272,23 @@ The simplest design would keep everything in one place. Neither end works alone:
 - **Not all in the controller.** Draining waits on `safe-to-destroy` for hours or days. Running that in the reconcile would tie up the controller and delay its other, more important flows. The goroutine runs on its own 60s loop ([health.go#L70-L91](https://github.com/rook/rook/blob/59ce48ae88e5ea59df44249b41a887af96a2806c/pkg/operator/ceph/cluster/osd/health.go#L70-L91)), independent of the reconcile, so it carries the long teardown without blocking anything and a failure there cannot stall the controller.
 
 The pair of markers is the handoff: the controller owns the OSD until it writes them, the goroutine owns it afterward.
+
+### When provisioning the replacement disk fails
+
+`ceph-volume` claims the OSD id with `ceph osd new <fsid> <id>` **before** it touches the disk, and wraps the whole prepare in its own rollback: on any later failure it runs `ceph osd purge-new` plus `ceph-volume lvm zap --destroy --osd-id <id>`. The zap resolves its targets by the `ceph.osd_id` LV tag and deliberately includes `db` and `wal` LVs, so it takes the surviving DB LV this flow deliberately preserved — that LV carries the tag by design. Upstream will not protect it: from `ceph-volume`'s point of view both the id and the LV are leftovers of a failed new OSD.
+
+Consequences, and what is *not* affected:
+
+- **The destroyed slot is spent.** Its CRUSH bucket and weight are purged, so the rebalance this flow exists to avoid has already started — the one cost the flow was built to prevent, but no worse than not having the flow. Reclaiming the id afterwards would buy nothing, so the swapped-in disk is provisioned by the normal path as a new OSD (which may or may not reuse the old id, since Ceph allocates the lowest free one).
+- **The reused DB LV is destroyed**, and its extents return to the metadata VG's free pool. Sibling DB LVs and the VG itself are untouched, since the zap removes only the LV when others remain in the group.
+- **The data device is left blank**: its VG was created for the failed attempt and was the only LV on it, so the group and label are removed. That is why the device is picked up again as a new OSD.
+- **No data is lost.** The OSD was drained past `safe-to-destroy` before it was destroyed.
+- Failures *before* the id claim (bootstrap keyring missing, `--osd-id` rejected, `lvmPreReq`) leave the slot `destroyed` and are genuinely retried on the next reconcile. Only post-claim failures are terminal.
+
+Neither the prepare-job nor the operator can prevent this — by the time control returns to Rook the slot is already purged. The flow therefore handles it rather than guarding against it:
+
+- The prepare-job logs the per-slot failure and continues, so one bad slot neither blocks its siblings nor the normal provisioning that follows.
+- The controller detects the aborted replacement on a later reconcile and deletes the marker Deployment, which would otherwise sit fenced at `replicas=0` forever. The signal is the OSD id being **absent from the osdmap**: while the replacement is pending, the id is present as a `destroyed` slot; once reprovisioned it is present and not destroyed and the create path owns it; absent means the slot was purged. Absence from the per-node status CM is deliberately *not* used — destroyed OSDs are filtered out of that CM for the whole swap window, so it cannot distinguish "waiting" from "gone".
 
 ### Why the fence label cannot be the ownership marker
 

--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -182,6 +182,20 @@ func (dump *OSDDump) StatusByID(id int64) (int64, int64, error) {
 	return 0, 0, errors.Errorf("not found osd.%d in OSDDump", id)
 }
 
+// Exists reports whether the given OSD id is present in the osdmap.
+func (dump *OSDDump) Exists(id int64) bool {
+	for _, d := range dump.OSDs {
+		idFromDump, err := d.OSD.Int64()
+		if err != nil {
+			continue
+		}
+		if idFromDump == id {
+			return true
+		}
+	}
+	return false
+}
+
 func GetOSDUsage(context *clusterd.Context, clusterInfo *ClusterInfo) (*OSDUsage, error) {
 	args := []string{"osd", "df"}
 	buf, err := NewCephCommand(context, clusterInfo, args).Run()

--- a/pkg/daemon/ceph/osd/replace.go
+++ b/pkg/daemon/ceph/osd/replace.go
@@ -200,10 +200,15 @@ func (a *OsdAgent) preProvisionReplacedOSDs(context *clusterd.Context, available
 
 		// provision selected blank device into destroyed osdID slot:
 		if err := a.provisionReplacedOSD(context, destroyedID, entry); err != nil {
-			// Skip this slot on failure so one bad slot does not block the other slots or the normal
-			// provisioning that runs after this. The destroyed slot stays destroyed and is retried on
-			// the next reconcile.
-			logger.Errorf("failed to provision replacement for destroyed osd.%d on device %q, skipping. %v", destroyedID, blankDevice, err)
+			// Prepare can fail here because the swapped-in device is itself faulty. ceph-volume claims the
+			// OSD id before it writes anything to the disk, so its own rollback purges the reserved slot
+			// and zaps the reused DB LV. Skipping is safe: the DB LV's extents return to the metadata VG
+			// and are reused by the next OSD placed there, the data device is left blank and picked up as
+			// a new OSD, no data is lost since the purged slot rebalances like any removed OSD, and the
+			// leftover downscaled Deployment is cleaned up by the operator. Not returning the error keeps
+			// one bad slot from blocking the other slots or the normal provisioning that runs after this
+			// function.
+			logger.Errorf("failed to provision replacement for destroyed osd.%d on device %q, skipping. the destroyed slot may not have survived the failure. %v", destroyedID, blankDevice, err)
 			continue
 		}
 		logger.Infof("provisioned replacement osd.%d on device %q", destroyedID, blankDevice)

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -283,9 +283,11 @@ func (c *Cluster) Start() error {
 	}
 	log.NamespacedInfo(c.clusterInfo.Namespace, logger, "wait timeout for healthy OSDs during upgrade or restart is %q", c.clusterInfo.OsdUpgradeTimeout)
 
-	// Entry point for OSD replacement. Must run before GetDaemonsToSkipReconcile below so an OSD
-	// labeled in this reconcile is included in the skip-reconcile snapshot.
-	if err := c.validateAndStartOSDReplacement(); err != nil {
+	// Entry point for OSD replacement. Must run before GetDaemonsToSkipReconcile below, so an OSD
+	// labeled in this reconcile lands in the skip-reconcile snapshot; otherwise the updater is not
+	// fenced off it and scales a mid-replacement OSD back to replicas=1. Must also run before
+	// getOSDUpdateInfo, so a Deployment it deletes is absent from the `deployments` snapshot.
+	if err := c.processOSDReplacements(); err != nil {
 		log.NamespacedWarning(c.clusterInfo.Namespace, logger, "failed to process OSD replacement requests. %v", err)
 	}
 

--- a/pkg/operator/ceph/cluster/osd/replace.go
+++ b/pkg/operator/ceph/cluster/osd/replace.go
@@ -29,26 +29,56 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// validateAndStartOSDReplacement acts on annotated OSD deployments for replacements. Validates request and
-// adds do-not-reconcile label to hand over the process to OSD health monitor.
-func (c *Cluster) validateAndStartOSDReplacement() error {
+// processOSDReplacements acts on OSD deployments involved in a replacement: it validates new requests and
+// hands them to the OSD health monitor by labelling them, and it cleans up after a replacement that can no
+// longer complete.
+func (c *Cluster) processOSDReplacements() error {
 	deployments, err := c.getOSDDeployments()
 	if err != nil {
 		return errors.Wrap(err, "failed to list OSD deployments to check for replacement requests")
 	}
 
 	var osdTree *cephclient.OsdTree
+	var osdDump *cephclient.OSDDump
 	for i := range deployments.Items {
 		d := &deployments.Items[i]
 
-		replaceValue, requested := d.Annotations[cephv1.ReplaceOSDAnnotationKey]
-		if !requested {
-			// skip: dont have replace annotation
+		// A deployment waiting for its disk to be swapped needs no validation, but it does need cleaning
+		// up if its OSD is gone from the osdmap
+		if isWaitingForDiskSwap(d) {
+			if osdDump == nil {
+				dump, err := cephclient.GetOSDDump(c.context, c.clusterInfo)
+				if err != nil {
+					// Without the dump the OSD's existence cannot be established. Skip the check rather
+					// than risk deleting the deployment of a replacement still in progress.
+					log.NamespacedWarning(c.clusterInfo.Namespace, logger,
+						"failed to get osd dump to check for aborted replacements; will retry on the next reconcile. %v", err)
+					continue
+				}
+				osdDump = dump
+			}
+			missingFromOSDDump := c.isMissingFromOSDDump(d, osdDump)
+			// deployment is "waiting for swap" AND osd is missing from OSD dump can mean only that replacement has failed and OSD id was deleted during
+			// ceph volume rollback. Cleanup dangling downscaled OSD deployment in this case
+			if missingFromOSDDump {
+				err := k8sutil.DeleteDeployment(c.clusterInfo.Context, c.context.Clientset, d.Namespace, d.Name)
+				if err != nil {
+					log.NamespacedError(c.clusterInfo.Namespace, logger, "cannot cleanup dangling downscaled OSD deployment %q after failed osd-replacement: %v", d.Name, err)
+					continue
+				}
+				log.NamespacedInfo(c.clusterInfo.Namespace, logger, "removed dangling downscaled OSD deployment %q after failed osd-replacement", d.Name)
+			}
 			continue
 		}
 
 		// Already marked: validated, and the goroutine owns it now.
 		if d.Annotations[cephv1.ReplaceInProgressOSDAnnotationKey] == "true" {
+			continue
+		}
+
+		replaceValue, requested := d.Annotations[cephv1.ReplaceOSDAnnotationKey]
+		if !requested {
+			// skip: dont have replace annotation
 			continue
 		}
 
@@ -88,6 +118,28 @@ func (c *Cluster) validateAndStartOSDReplacement() error {
 	}
 
 	return nil
+}
+
+// isWaitingForDiskSwap returns true if the deployment has the cephv1.ReadyForSwapOSDAnnotationKey annotation,
+// meaning that the deployment represents destroyed OSD state awaiting physical disk swap to finish osd-replacement process.
+func isWaitingForDiskSwap(d *appsv1.Deployment) bool {
+	_, readyForSwap := d.Annotations[cephv1.ReadyForSwapOSDAnnotationKey]
+	return readyForSwap
+}
+
+// isMissingFromOSDDump returns true only if osd dump does not contain osd ID from given Deployment.
+// returns false in case of any error or empty OSD Dump
+func (c *Cluster) isMissingFromOSDDump(d *appsv1.Deployment, osdDump *cephclient.OSDDump) bool {
+	osdID, err := GetOSDID(d)
+	if err != nil {
+		log.NamespacedError(c.clusterInfo.Namespace, logger, "unable to get osd ID from Deployment: %v", err)
+		return false
+	}
+
+	if osdDump == nil || len(osdDump.OSDs) == 0 {
+		return false
+	}
+	return !osdDump.Exists(int64(osdID))
 }
 
 // validateReplaceOSD returns an error on the first failed validation check for a replacement request.

--- a/pkg/operator/ceph/cluster/osd/replace_test.go
+++ b/pkg/operator/ceph/cluster/osd/replace_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -95,7 +96,7 @@ func osdDeployment(osdID int, annotations, labels map[string]string) *appsv1.Dep
 	}
 }
 
-func TestValidateAndStartOSDReplacement(t *testing.T) {
+func TestProcessOSDReplacements(t *testing.T) {
 	getDep := func(c *Cluster, osdID int) *appsv1.Deployment {
 		d, err := c.context.Clientset.AppsV1().Deployments("rook-ceph").Get(context.TODO(), fmt.Sprintf(osdAppNameFmt, osdID), metav1.GetOptions{})
 		require.NoError(t, err)
@@ -107,7 +108,7 @@ func TestValidateAndStartOSDReplacement(t *testing.T) {
 		clientset := fake.NewClientset(dep)
 		c := newReplaceClusterWithTree(clientset, map[int]string{5: "up"})
 
-		require.NoError(t, c.validateAndStartOSDReplacement())
+		require.NoError(t, c.processOSDReplacements())
 		got := getDep(c, 5)
 		assert.Equal(t, "true", got.Labels[cephv1.SkipReconcileLabelKey])
 		assert.Equal(t, "true", got.Annotations[cephv1.ReplaceInProgressOSDAnnotationKey])
@@ -119,7 +120,7 @@ func TestValidateAndStartOSDReplacement(t *testing.T) {
 		clientset := fake.NewClientset(dep)
 		c := newReplaceClusterWithTree(clientset, map[int]string{5: "up"})
 
-		require.NoError(t, c.validateAndStartOSDReplacement())
+		require.NoError(t, c.processOSDReplacements())
 		assert.NotContains(t, getDep(c, 5).Labels, cephv1.SkipReconcileLabelKey)
 		assert.NotContains(t, getDep(c, 5).Annotations, cephv1.ReplaceInProgressOSDAnnotationKey)
 	})
@@ -130,7 +131,7 @@ func TestValidateAndStartOSDReplacement(t *testing.T) {
 		clientset := fake.NewClientset(dep)
 		c := newReplaceClusterWithTree(clientset, map[int]string{5: "up"})
 
-		require.NoError(t, c.validateAndStartOSDReplacement())
+		require.NoError(t, c.processOSDReplacements())
 		assert.NotContains(t, getDep(c, 5).Labels, cephv1.SkipReconcileLabelKey)
 		assert.NotContains(t, getDep(c, 5).Annotations, cephv1.ReplaceInProgressOSDAnnotationKey)
 	})
@@ -142,7 +143,7 @@ func TestValidateAndStartOSDReplacement(t *testing.T) {
 		clientset := fake.NewClientset(dep)
 		c := newReplaceClusterWithTree(clientset, map[int]string{5: "destroyed"})
 
-		require.NoError(t, c.validateAndStartOSDReplacement())
+		require.NoError(t, c.processOSDReplacements())
 		got := getDep(c, 5)
 		assert.Equal(t, "true", got.Labels[cephv1.SkipReconcileLabelKey])
 		assert.Equal(t, "true", got.Annotations[cephv1.ReplaceInProgressOSDAnnotationKey])
@@ -153,7 +154,7 @@ func TestValidateAndStartOSDReplacement(t *testing.T) {
 		clientset := fake.NewClientset(dep)
 		c := newReplaceClusterWithTree(clientset, map[int]string{7: "up"})
 
-		require.NoError(t, c.validateAndStartOSDReplacement())
+		require.NoError(t, c.processOSDReplacements())
 		assert.NotContains(t, getDep(c, 5).Labels, cephv1.SkipReconcileLabelKey)
 		assert.NotContains(t, getDep(c, 5).Annotations, cephv1.ReplaceInProgressOSDAnnotationKey)
 	})
@@ -163,7 +164,7 @@ func TestValidateAndStartOSDReplacement(t *testing.T) {
 		clientset := fake.NewClientset(dep)
 		c := newReplaceClusterWithTree(clientset, map[int]string{5: "up"})
 
-		require.NoError(t, c.validateAndStartOSDReplacement())
+		require.NoError(t, c.processOSDReplacements())
 		assert.NotContains(t, getDep(c, 5).Labels, cephv1.SkipReconcileLabelKey)
 	})
 
@@ -175,7 +176,7 @@ func TestValidateAndStartOSDReplacement(t *testing.T) {
 		clientset := fake.NewClientset(dep)
 		c := newTestReplaceCluster(clientset)
 		// no executor: an OSD the goroutine already owns must not trigger an osd tree lookup
-		require.NoError(t, c.validateAndStartOSDReplacement())
+		require.NoError(t, c.processOSDReplacements())
 		assert.Equal(t, "true", getDep(c, 5).Labels[cephv1.SkipReconcileLabelKey])
 	})
 
@@ -188,8 +189,84 @@ func TestValidateAndStartOSDReplacement(t *testing.T) {
 		clientset := fake.NewClientset(dep)
 		c := newReplaceClusterWithTree(clientset, map[int]string{5: "up"})
 
-		require.NoError(t, c.validateAndStartOSDReplacement())
+		require.NoError(t, c.processOSDReplacements())
 		assert.Equal(t, "true", getDep(c, 5).Annotations[cephv1.ReplaceInProgressOSDAnnotationKey])
+	})
+}
+
+// TestCleanupAbortedReplacement covers the cleanup of a replacement that can never complete: the OSD is
+// gone from the osdmap, so no destroyed slot is left to provision the swapped-in disk into. Driven through
+// processOSDReplacements to cover the wiring, since such a deployment is otherwise skipped there.
+func TestCleanupAbortedReplacement(t *testing.T) {
+	osdID := 5
+	waitingForSwapDep := func() *appsv1.Deployment {
+		d := osdDeployment(osdID, map[string]string{
+			cephv1.ReplaceOSDAnnotationKey:           fmt.Sprintf(cephv1.ReplaceOSDAnnotationValueFmt, osdID),
+			cephv1.ReplaceInProgressOSDAnnotationKey: "true",
+			cephv1.ReadyForSwapOSDAnnotationKey:      "true",
+		}, map[string]string{cephv1.SkipReconcileLabelKey: "true"})
+		zero := int32(0)
+		d.Spec.Replicas = &zero
+		return d
+	}
+
+	// The osd tree must never be fetched for an already-marked deployment, so anything but `osd dump` fails.
+	newCluster := func(clientset *fake.Clientset, inByID map[int]int) *Cluster {
+		c := newTestReplaceCluster(clientset)
+		c.context.Executor = &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				if len(args) >= 2 && args[0] == "osd" && args[1] == "dump" {
+					return osdDumpJSON(inByID), nil
+				}
+				return "", fmt.Errorf("unexpected ceph command %v", args)
+			},
+		}
+		return c
+	}
+
+	// Only a NotFound counts as deleted; any other error fails the test rather than reading as a
+	// successful cleanup.
+	depExists := func(t *testing.T, c *Cluster) bool {
+		t.Helper()
+		_, err := c.context.Clientset.AppsV1().Deployments("rook-ceph").Get(context.TODO(), fmt.Sprintf(osdAppNameFmt, osdID), metav1.GetOptions{})
+		if kerrors.IsNotFound(err) {
+			return false
+		}
+		require.NoError(t, err)
+		return true
+	}
+
+	t.Run("osd gone from the osdmap deletes the leftover deployment", func(t *testing.T) {
+		c := newCluster(fake.NewClientset(waitingForSwapDep()), map[int]int{7: 1})
+		require.NoError(t, c.processOSDReplacements())
+		assert.False(t, depExists(t, c))
+	})
+
+	t.Run("osd still in the osdmap is left alone", func(t *testing.T) {
+		// The destroyed slot is still waiting for its disk; deleting it here would drop the marker and
+		// the user's ready-for-swap signal mid-replacement.
+		c := newCluster(fake.NewClientset(waitingForSwapDep()), map[int]int{osdID: 0})
+		require.NoError(t, c.processOSDReplacements())
+		assert.True(t, depExists(t, c))
+	})
+
+	t.Run("empty osd dump is not treated as a missing osd", func(t *testing.T) {
+		c := newCluster(fake.NewClientset(waitingForSwapDep()), map[int]int{})
+		require.NoError(t, c.processOSDReplacements())
+		assert.True(t, depExists(t, c))
+	})
+
+	t.Run("osd dump failure leaves the deployment alone", func(t *testing.T) {
+		// Without the dump the OSD's existence cannot be established, so a replacement that may still
+		// be in progress must keep its deployment rather than risk losing the marker.
+		c := newTestReplaceCluster(fake.NewClientset(waitingForSwapDep()))
+		c.context.Executor = &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				return "", fmt.Errorf("mon is unreachable")
+			},
+		}
+		require.NoError(t, c.processOSDReplacements())
+		assert.True(t, depExists(t, c))
 	})
 }
 


### PR DESCRIPTION
PR to fix review isses of osd-replacement flow from: https://gist.github.com/jhoblitt/4047ebf57a8736c23696b7e8cb0f2589


If osd-replacement fails during provisioning of the new device by the
osd-prepare job (can be the case if the new device is faulty), then
ceph-volume will run its internal rollback logic, which purges the
reserved osd id and its CRUSH position. After the faulty device is
replaced with a working one, rook will reprovision it correctly and
reuse the metadata device slot, but as a new OSD, so data will likely
be rebalanced. Ceph hands out the lowest free id, so the new OSD often
takes the same number back, and then the create path recreates the
deployment by itself. Otherwise, and until a working device arrives,
the downscaled deployment of the destroyed osd is left behind. This
commit handles that case by deleting downscaled ready-for-swap osd
deployments without a corresponding OSD in the osd dump.