### PR TITLE
core: don't prepend /dev to a device path that already has it

### DIFF
--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -130,15 +130,22 @@ func ListDevices(executor exec.Executor) ([]string, error) {
 	return strings.Split(devices, "\n"), nil
 }
 
+// resolveDevicePath returns an absolute path for a device. Callers pass either
+// a bare kernel name ("sdb") or an absolute path, which may be a device node
+// ("/dev/sdb") or a mount point for a PVC-backed block device
+// ("/mnt/<pvc-name>"). Only a bare kernel name needs the /dev prefix; adding it
+// unconditionally would produce "/dev//dev/sdb".
+func resolveDevicePath(device string) string {
+	if len(strings.Split(device, "/")) == 1 {
+		return fmt.Sprintf("/dev/%s", device)
+	}
+
+	return device
+}
+
 // GetDevicePartitions gets partitions on a given device
 func GetDevicePartitions(device string, executor exec.Executor) (partitions []Partition, unusedSpace uint64, err error) {
-	var devicePath string
-	splitDevicePath := strings.Split(device, "/")
-	if len(splitDevicePath) == 1 {
-		devicePath = fmt.Sprintf("/dev/%s", device) // device path for OSD on devices.
-	} else {
-		devicePath = device // use the exact device path (like /mnt/<pvc-name>) in case of PVC block device
-	}
+	devicePath := resolveDevicePath(device)
 
 	output, err := executor.ExecuteCommandWithOutput("lsblk", devicePath,
 		"--bytes", "--pairs", "--output", "NAME,SIZE,TYPE,PKNAME")
@@ -197,14 +204,7 @@ func GetDevicePartitions(device string, executor exec.Executor) (partitions []Pa
 
 // GetDeviceProperties gets device properties
 func GetDeviceProperties(device string, executor exec.Executor) (map[string]string, error) {
-	// As we are mounting the block mode PVs on /mnt we use the entire path,
-	// e.g., if the device path is /mnt/example-pvc then it's taken completely
-	// else if it's just vdb then the following is used
-	devicePath := strings.Split(device, "/")
-	if len(devicePath) == 1 {
-		device = fmt.Sprintf("/dev/%s", device)
-	}
-	return GetDevicePropertiesFromPath(device, executor)
+	return GetDevicePropertiesFromPath(resolveDevicePath(device), executor)
 }
 
 // GetDevicePropertiesFromPath gets a device property from a path
@@ -235,14 +235,7 @@ func IsLV(devicePath string, executor exec.Executor) (bool, error) {
 
 // GetUdevInfo gets udev information
 func GetUdevInfo(device string, executor exec.Executor) (map[string]string, error) {
-	// The caller may pass either a kernel name ("sdb") or a full device path
-	// ("/dev/sdb"), so only add the /dev prefix when it is missing. Adding it
-	// unconditionally produces "/dev//dev/sdb", which udevadm rejects.
-	devicePath := strings.Split(device, "/")
-	if len(devicePath) == 1 {
-		device = fmt.Sprintf("/dev/%s", device)
-	}
-	output, err := executor.ExecuteCommandWithOutput("udevadm", "info", "--query=property", device)
+	output, err := executor.ExecuteCommandWithOutput("udevadm", "info", "--query=property", resolveDevicePath(device))
 	if err != nil {
 		return nil, err
 	}
@@ -253,10 +246,7 @@ func GetUdevInfo(device string, executor exec.Executor) (map[string]string, erro
 
 // GetDeviceFilesystems get the file systems available
 func GetDeviceFilesystems(device string, executor exec.Executor) (string, error) {
-	devicePath := strings.Split(device, "/")
-	if len(devicePath) == 1 {
-		device = fmt.Sprintf("/dev/%s", device)
-	}
+	device = resolveDevicePath(device)
 	output, err := executor.ExecuteCommandWithOutput("udevadm", "info", "--query=property", device)
 	if err != nil {
 		return "", err
@@ -271,10 +261,7 @@ func GetDiskUUID(device string, executor exec.Executor) (string, error) {
 		return "", errors.Wrap(err, "sgdisk not found")
 	}
 
-	devicePath := strings.Split(device, "/")
-	if len(devicePath) == 1 {
-		device = fmt.Sprintf("/dev/%s", device)
-	}
+	device = resolveDevicePath(device)
 
 	output, err := executor.ExecuteCommandWithOutput(sgdiskCmd, "--print", device)
 	if err != nil {

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -235,7 +235,14 @@ func IsLV(devicePath string, executor exec.Executor) (bool, error) {
 
 // GetUdevInfo gets udev information
 func GetUdevInfo(device string, executor exec.Executor) (map[string]string, error) {
-	output, err := executor.ExecuteCommandWithOutput("udevadm", "info", "--query=property", fmt.Sprintf("/dev/%s", device))
+	// The caller may pass either a kernel name ("sdb") or a full device path
+	// ("/dev/sdb"), so only add the /dev prefix when it is missing. Adding it
+	// unconditionally produces "/dev//dev/sdb", which udevadm rejects.
+	devicePath := strings.Split(device, "/")
+	if len(devicePath) == 1 {
+		device = fmt.Sprintf("/dev/%s", device)
+	}
+	output, err := executor.ExecuteCommandWithOutput("udevadm", "info", "--query=property", device)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/sys/device_test.go
+++ b/pkg/util/sys/device_test.go
@@ -176,6 +176,41 @@ NAME="ceph--89fa04fa--b93a--4874--9364--c95be3ec01c6-osd--data--70847bdb--2ec1--
 	assert.Equal(t, 0, len(partitions))
 }
 
+func TestGetUdevInfo(t *testing.T) {
+	// GetUdevInfo is called both with a kernel name ("sdb") and with a full
+	// device path ("/dev/sdb"). Both must reach udevadm as "/dev/sdb"; a full
+	// path must not become "/dev//dev/sdb", which udevadm rejects.
+	// The argument is asserted exactly rather than with Contains, because a
+	// doubled prefix still contains the device name.
+	tests := []struct {
+		name     string
+		device   string
+		expected string
+	}{
+		{"kernel name", "sdb", "/dev/sdb"},
+		{"full path", "/dev/sdb", "/dev/sdb"},
+		{"by-id path", "/dev/disk/by-id/scsi-36001405d27e5d898829468b90ce4ef8c", "/dev/disk/by-id/scsi-36001405d27e5d898829468b90ce4ef8c"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var gotDevice string
+			executor := &exectest.MockExecutor{
+				MockExecuteCommandWithOutput: func(command string, arg ...string) (string, error) {
+					assert.Equal(t, "udevadm", command)
+					gotDevice = arg[len(arg)-1]
+					return udevOutput, nil
+				},
+			}
+
+			info, err := GetUdevInfo(test.device, executor)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, gotDevice)
+			assert.Equal(t, "ext2", info["ID_FS_TYPE"])
+		})
+	}
+}
+
 func TestParseUdevInfo(t *testing.T) {
 	m := parseUdevInfo(udevOutput)
 	assert.Equal(t, m["ID_FS_TYPE"], "ext2")


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #18079

`GetUdevInfo` unconditionally formatted its argument as `/dev/%s`, but it is
called both with a bare kernel name (`sdb`) and with a full device path
(`/dev/sdb`). In the second case `udevadm` runs against `/dev//dev/sdb` and
fails, so `GetUdevInfo` returns an error and `DevLinks` is never populated.

This guards the prefix the same way the neighbouring `GetDeviceFilesystems`,
`GetDiskUUID` and `GetDeviceProperties` already do — `GetUdevInfo` was the only
one of the four missing it — so both call styles reach `udevadm` unchanged.

The failure is only logged at warning level, so it degrades silently. Because
`findDeviceClass` consults DEVLINKS only when `devLinks != ""`, that branch
cannot match while `DevLinks` is empty, which affects a per-device
`deviceClass` set on a `/dev/disk/by-id/...` entry in the CephCluster CR.

**Testing**

Added `TestGetUdevInfo`, covering a kernel name, a full path and a by-id path.
It asserts the exact argument passed to `udevadm` rather than using
`strings.Contains`, because a doubled prefix still contains the device name —
which is why the existing mocks could not catch this (`volume_test.go` returns
a fixed value for any `udevadm` call, and `daemon_test.go` matches with
`strings.Contains(args[2], "sdc")`).

Verified the new test fails without the fix:

```
--- FAIL: TestGetUdevInfo/full_path
      expected: "/dev/sdb"
      actual  : "/dev//dev/sdb"
--- FAIL: TestGetUdevInfo/by-id_path
      expected: "/dev/disk/by-id/scsi-36001405d27e5d898829468b90ce4ef8c"
      actual  : "/dev//dev/disk/by-id/scsi-36001405d27e5d898829468b90ce4ef8c"
```

and passes with it. The `kernel name` case passes either way, confirming
existing behaviour is unchanged. `pkg/util/sys`, `pkg/clusterd` and
`pkg/daemon/ceph/osd` all pass; `gofmt` and `go vet` are clean.

I originally hit this on my own cluster — a single-node k3s with Rook v1.19.8
and a Hetzner Cloud Volume named by its `/dev/disk/by-id/` path — where the
malformed path appears in the osd-prepare log.

No API, CRD or RBAC surface is touched, so no codegen is affected. No release
note added as there is no user-visible behaviour change beyond the lookup now
succeeding; happy to add one if maintainers prefer.

*AI disclosure: Claude Code assisted with tracing the call path through
`PopulateDeviceUdevInfo` and `findDeviceClass`, drafting the unit test, and
checking the git history for prior art. I reproduced the bug on my own cluster
and verified the test's fail-then-pass behaviour myself.*

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
