### PR TITLE
helm: add cephObjectStoreUsers to the cluster chart

### DIFF
--- a/Documentation/Helm-Charts/ceph-cluster-chart.gotmpl.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.gotmpl.md
@@ -142,6 +142,17 @@ commented out by default; uncomment and adjust them to deploy a multisite config
 | `cephObjectZones[].name` | The name of the CephObjectZone | `zone-a` |
 | `cephObjectZones[].spec` | The CephObjectZone spec, see the [CephObjectZone CRD](../CRDs/Object-Storage/ceph-object-zone-crd.md) documentation. | see values.yaml |
 
+### **Ceph Object Store Users**
+
+The `cephObjectStoreUsers` array in the values file defines a list of S3 users to create in an
+object store. The entries are commented out by default; uncomment and adjust them to create users,
+pointing each at a `cephObjectStores` entry via its `spec.store`.
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `cephObjectStoreUsers[].name` | The name of the CephObjectStoreUser | `my-user` |
+| `cephObjectStoreUsers[].spec` | The CephObjectStoreUser spec, see the [CephObjectStoreUser CRD](../CRDs/Object-Storage/ceph-object-store-user-crd.md) documentation. | see values.yaml |
+
 ### **Existing Clusters**
 
 If you have an existing CephCluster CR that was created without the helm chart and you want the helm

--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -181,6 +181,17 @@ commented out by default; uncomment and adjust them to deploy a multisite config
 | `cephObjectZones[].name` | The name of the CephObjectZone | `zone-a` |
 | `cephObjectZones[].spec` | The CephObjectZone spec, see the [CephObjectZone CRD](../CRDs/Object-Storage/ceph-object-zone-crd.md) documentation. | see values.yaml |
 
+### **Ceph Object Store Users**
+
+The `cephObjectStoreUsers` array in the values file defines a list of S3 users to create in an
+object store. The entries are commented out by default; uncomment and adjust them to create users,
+pointing each at a `cephObjectStores` entry via its `spec.store`.
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `cephObjectStoreUsers[].name` | The name of the CephObjectStoreUser | `my-user` |
+| `cephObjectStoreUsers[].spec` | The CephObjectStoreUser spec, see the [CephObjectStoreUser CRD](../CRDs/Object-Storage/ceph-object-store-user-crd.md) documentation. | see values.yaml |
+
 ### **Existing Clusters**
 
 If you have an existing CephCluster CR that was created without the helm chart and you want the helm

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -8,3 +8,4 @@
 
 - RBD QoS (Quality of Service) support via `VolumeAttributesClass` using the krbd mounter with cgroup v2 `io.max` enforcement. See the [RBD QoS documentation](Documentation/Storage-Configuration/Block-Storage-RBD/rbd-qos.md) for details.
 - Automated OSD replacement. OSD deployment can be annotated to mark it for replacement. Rook will drain and destroy it with preserving its CRUSH position to later reuse it when new device will be available on the same node. All types of OSDs supported for host-based cluster included OSDs sharing metadata device. PVC-based OSDs are not supported. See [OSD replacement design document](./design/ceph/osd-replacement.md) for details.
+- The rook-ceph-cluster Helm chart can create `CephObjectStoreUser` resources via the new `cephObjectStoreUsers` value.

--- a/deploy/charts/rook-ceph-cluster/templates/cephobjectstoreuser.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephobjectstoreuser.yaml
@@ -1,0 +1,11 @@
+{{- $root := . -}}
+{{- range $user := .Values.cephObjectStoreUsers }}
+---
+kind: CephObjectStoreUser
+apiVersion: ceph.rook.io/v1
+metadata:
+  name: {{ $user.name }}
+  namespace: {{ $root.Release.Namespace }} # namespace:cluster
+spec:
+  {{- $user.spec | toYaml | nindent 2 }}
+{{- end }}

--- a/deploy/charts/rook-ceph-cluster/tests/cephobjectstoreuser_test.yaml
+++ b/deploy/charts/rook-ceph-cluster/tests/cephobjectstoreuser_test.yaml
@@ -1,0 +1,81 @@
+suite: cephobjectstoreuser
+templates:
+  - cephobjectstoreuser.yaml
+tests:
+  - it: renders nothing by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a CephObjectStoreUser for each configured user
+    set:
+      cephObjectStoreUsers:
+        - name: user-a
+          spec:
+            store: ceph-objectstore
+        - name: user-b
+          spec:
+            store: other-objectstore
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: CephObjectStoreUser
+      - isAPIVersion:
+          of: ceph.rook.io/v1
+      - equal:
+          path: metadata.name
+          value: user-a
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: user-b
+        documentIndex: 1
+
+  - it: places users in the release namespace
+    release:
+      namespace: rook-ceph
+    set:
+      cephObjectStoreUsers:
+        - name: user-a
+          spec:
+            store: ceph-objectstore
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: rook-ceph
+
+  - it: passes the spec through verbatim
+    set:
+      cephObjectStoreUsers:
+        - name: user-a
+          spec:
+            store: ceph-objectstore
+            displayName: A display name
+            clusterNamespace: other-cluster
+            quotas:
+              maxBuckets: 100
+              maxSize: 10G
+              maxObjects: 10000
+            capabilities:
+              user: "*"
+              bucket: "*"
+    asserts:
+      - equal:
+          path: spec.store
+          value: ceph-objectstore
+      - equal:
+          path: spec.displayName
+          value: A display name
+      - equal:
+          path: spec.clusterNamespace
+          value: other-cluster
+      - equal:
+          path: spec.quotas.maxBuckets
+          value: 100
+      - equal:
+          path: spec.quotas.maxSize
+          value: 10G
+      - equal:
+          path: spec.capabilities.user
+          value: "*"

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -748,6 +748,14 @@ cephObjectStores:
 #      #   - "http://rgw-a.fqdn"
 #      # if the pools need to be removed from backend enable following setting
 #      # preservePoolsOnDelete: false
+## cephObjectStoreUsers create S3 users in a CephObjectStore. They are disabled by default;
+## remove the comments and set desired values to enable them. See
+## https://rook.io/docs/rook/latest/CRDs/Object-Storage/ceph-object-store-user-crd/
+#cephObjectStoreUsers:
+#  - name: my-user
+#    spec:
+#      store: ceph-objectstore
+#      displayName: my display name
 ## cephECBlockPools are disabled by default, please remove the comments and set desired values to enable it
 ## For erasure coded a replicated metadata pool is required.
 ## https://rook.io/docs/rook/latest/CRDs/Shared-Filesystem/ceph-filesystem-crd/#erasure-coded


### PR DESCRIPTION
The rook-ceph-cluster chart can create CephObjectStores, but not the S3 users for them: `CephObjectStoreUser` resources had to be applied out-of-band, unlike the pools, filesystems, stores, and multisite resources the chart already manages.

The chart now renders one `CephObjectStoreUser` per entry in a new `cephObjectStoreUsers` values array, disabled by default so existing releases are unaffected. The values file carries a commented example, the cluster chart doc page documents the array, and a helm-unittest suite covers default-off rendering, per-entry iteration, release-namespace placement, and verbatim spec passthrough.

Raw name-plus-spec passthrough — rather than structured per-field values — deliberately matches the chart's multisite template idiom, so the chart never has to chase CRD schema changes.

AI assistance: Claude wrote the template, tests, docs, and this description.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
