### PR TITLE
mon: create a floating mon service with correct selectors

### DIFF
--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -336,9 +336,9 @@ func (c *Cluster) startMons(targetCount int) error {
 	return nil
 }
 
-// IsFloatingMon returns true if the given mon name is the floating mon defined
+// isFloatingMon returns true if the given mon name is the floating mon defined
 // in the CephCluster spec.
-func IsFloatingMon(c *Cluster, name string) bool {
+func isFloatingMon(c *Cluster, name string) bool {
 	return c.spec.Mon.FloatingMon.Name != "" && name == c.spec.Mon.FloatingMon.Name
 }
 
@@ -963,7 +963,7 @@ func (c *Cluster) assignMons(mons []*monConfig, monsToSkipReconcile sets.Set[str
 	// scheduling for the monitor.
 	for _, mon := range mons {
 		// No need to create canary pod and pvc for floating mon
-		if IsFloatingMon(c, mon.DaemonName) {
+		if isFloatingMon(c, mon.DaemonName) {
 			log.NamespacedDebug(c.Namespace, logger, "skipping scheduling for floating mon %q", mon.DaemonName)
 			continue
 		}
@@ -1132,7 +1132,7 @@ func (c *Cluster) startDeployments(mons []*monConfig, requireAllInQuorum bool, m
 				// and potentially cause more mons to fail. Therefore, we abort if the mon failed to start after upgrade.
 				return errors.Wrapf(err, "failed to upgrade mon %q.", mons[i].DaemonName)
 			}
-			if IsFloatingMon(c, mons[i].DaemonName) {
+			if isFloatingMon(c, mons[i].DaemonName) {
 				// Floating mon failures must not be silently skipped.
 				return errors.Wrapf(err, "failed to start floating mon %q", mons[i].DaemonName)
 			}
@@ -1568,7 +1568,7 @@ func (c *Cluster) updateMon(m *monConfig, d *apps.Deployment) error {
 //     - if HostPath -> leave node selector as is
 //     - if PVC      -> remove node selector, if present
 func (c *Cluster) startMon(m *monConfig, schedule *controller.MonScheduleInfo) error {
-	floating := IsFloatingMon(c, m.DaemonName)
+	floating := isFloatingMon(c, m.DaemonName)
 	log.NamespacedInfo(c.Namespace, logger, "starting mon %q", m.DaemonName)
 
 	// Build the deployment spec. Floating mons use a YAML template that
@@ -1787,7 +1787,7 @@ func (c *Cluster) waitForQuorumWithMons(context *clusterd.Context, clusterInfo *
 		var runningMonNames []string
 		for _, m := range mons {
 			monLabel := AppName
-			if IsFloatingMon(c, m) {
+			if isFloatingMon(c, m) {
 				monLabel = FloatingMonAppName
 			}
 			running, err := k8sutil.PodsRunningWithLabel(clusterInfo.Context, context.Clientset, clusterInfo.Namespace, fmt.Sprintf("app=%s,mon=%s", monLabel, m))

--- a/pkg/operator/ceph/cluster/mon/service_test.go
+++ b/pkg/operator/ceph/cluster/mon/service_test.go
@@ -55,3 +55,27 @@ func TestCreateService(t *testing.T) {
 	// the clusterIP will now be set to the expected value
 	assert.Equal(t, m.PublicIP, service.Spec.ClusterIP)
 }
+
+func TestCreateServiceSelector(t *testing.T) {
+	ctx := context.TODO()
+	clientset := test.New(t, 1)
+	c := New(ctx, &clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, &k8sutil.OwnerInfo{})
+	c.ClusterInfo = client.AdminTestClusterInfo("rook-ceph")
+
+	t.Run("normal mon service has rook-ceph-mon selector", func(t *testing.T) {
+		m := &monConfig{ResourceName: "rook-ceph-mon-a", DaemonName: "a"}
+		service, err := c.createService(m)
+		assert.NoError(t, err)
+		assert.Equal(t, AppName, service.Spec.Selector["app"])
+		assert.Equal(t, "a", service.Spec.Selector["mon"])
+	})
+
+	t.Run("floating mon service has rook-ceph-floating-mon selector", func(t *testing.T) {
+		c.spec.Mon.FloatingMon.Name = "c"
+		m := &monConfig{ResourceName: "rook-ceph-mon-c", DaemonName: "c"}
+		service, err := c.createService(m)
+		assert.NoError(t, err)
+		assert.Equal(t, FloatingMonAppName, service.Spec.Selector["app"])
+		assert.Equal(t, "c", service.Spec.Selector["mon"])
+	})
+}

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -56,6 +56,9 @@ func (c *Cluster) getLabels(monConfig *monConfig, canary, includeNewLabels bool)
 	// Mons have a service for each mon, so the additional pod data is relevant for its services
 	// Use pod labels to keep "mon: id" for legacy
 	labels := controller.CephDaemonAppLabels(AppName, c.Namespace, config.MonType, monConfig.DaemonName, c.ClusterInfo.NamespacedName().Name, "cephclusters.ceph.rook.io", includeNewLabels)
+	if isFloatingMon(c, monConfig.DaemonName) {
+		labels = controller.CephDaemonAppLabels(FloatingMonAppName, c.Namespace, config.MonType, monConfig.DaemonName, c.ClusterInfo.NamespacedName().Name, "cephclusters.ceph.rook.io", includeNewLabels)
+	}
 	// Add "mon_cluster: <namespace>" for legacy
 	labels[monClusterAttr] = c.Namespace
 	if canary {

--- a/pkg/operator/ceph/cluster/monitoring.go
+++ b/pkg/operator/ceph/cluster/monitoring.go
@@ -54,7 +54,7 @@ func (c *ClusterController) configureCephMonitoring(cluster *cluster, clusterInf
 					InternalCancel: internalCancel,
 				})
 
-				// We can't use mon.IsFloatingMon(cluster.mons, daemon) because the mon ID is not available.
+				// We can't use mon.isFloatingMon(cluster.mons, daemon) because the mon ID is not available.
 				if daemon == "mon" && cluster.Spec.Mon.FloatingMon.Name != "" {
 					log.NamespacedInfo(cluster.Namespace, logger, "skip mon health check since floating mon %q is configured", daemon)
 					continue


### PR DESCRIPTION
the floating mon has a new app lablel
app: rook-ceph-floating-mon
It service selector should also create with the correct label seclector that matches with the pod label

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
