### PR TITLE
core: shell-quote command lines in logs and sh -c strings

### DIFF
--- a/Documentation/Storage-Configuration/Advanced/ceph-osd-mgmt.md
+++ b/Documentation/Storage-Configuration/Advanced/ceph-osd-mgmt.md
@@ -120,7 +120,7 @@ $ ceph osd down osd.<ID>
 ```bash
 kubectl rook-ceph rook purge-osd 0 --force
 
-# 2022-09-14 08:58:28.888431 I | rookcmd: starting Rook v1.10.0-alpha.0.164.gcb73f728c with arguments 'rook ceph osd remove --osd-ids=0 --force-osd-removal=true'
+# 2022-09-14 08:58:28.888431 I | rookcmd: starting Rook v1.10.0-alpha.0.164.gcb73f728c with arguments: rook ceph osd remove --osd-ids=0 --force-osd-removal=true
 # 2022-09-14 08:58:28.889217 I | rookcmd: flag values: --force-osd-removal=true, --help=false, --log-level=INFO, --operator-image=, --osd-ids=0, --preserve-pvc=false, --service-account=
 # 2022-09-14 08:58:28.889582 I | op-mon: parsing mon endpoints: b=10.106.118.240:6789
 # 2022-09-14 08:58:28.898898 I | cephclient: writing config file /var/lib/rook/rook-ceph/rook-ceph.config

--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -348,7 +348,7 @@ func removeOSDs(cmd *cobra.Command, args []string) error {
 
 	// We use strings instead of bool since the flag package has issues with parsing bools, or
 	// perhaps it's the translation between YAML and code... It's unclear but see:
-	// starting Rook v1.7.0-alpha.0.660.gb13faecc8 with arguments '/usr/local/bin/rook ceph osd remove --preserve-pvc false --force-osd-removal false --osd-ids 1'
+	// starting Rook v1.7.0-alpha.0.660.gb13faecc8 with arguments: /usr/local/bin/rook ceph osd remove --preserve-pvc false --force-osd-removal false --osd-ids 1
 	// flag values: --force-osd-removal=true, --help=false, --log-level=DEBUG, --operator-image=,
 	// --osd-ids=1, --preserve-pvc=true, --service-account=
 	//

--- a/cmd/rook/rook/rook.go
+++ b/cmd/rook/rook/rook.go
@@ -108,7 +108,7 @@ func SetLogLevel() {
 // LogStartupInfo log the version number, arguments, and all final flag values (environment variable overrides have already been taken into account)
 func LogStartupInfo(cmdFlags *pflag.FlagSet) {
 	flagValues := flags.GetFlagsAndValues(cmdFlags, "secret|keyring")
-	logger.Infof("starting Rook %s with arguments '%s'", version.Version, strings.Join(os.Args, " "))
+	logger.Infof("starting Rook %s with arguments: %s", version.Version, exec.FormatCommand(os.Args[0], os.Args[1:]...))
 	logger.Infof("flag values: %s", strings.Join(flagValues, ", "))
 }
 

--- a/pkg/daemon/ceph/client/rados.go
+++ b/pkg/daemon/ceph/client/rados.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -183,7 +182,7 @@ func RadosNamespaceHasObjects(context *clusterd.Context, clusterInfo *ClusterInf
 	}
 	command, args := FinalizeCephCommandArgs(RadosTool, clusterInfo, radosArgs, context.ConfigDir)
 	// Pipe through "head -c 1" so only 1 byte is buffered regardless of object count.
-	shellCmd := command + " " + strings.Join(args, " ") + " 2>/dev/null | head -c 1"
+	shellCmd := exec.FormatCommand(command, args...) + " 2>/dev/null | head -c 1"
 	output, err := context.Executor.ExecuteCommandWithTimeout(exec.CephCommandsTimeout, "sh", "-c", shellCmd)
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to check for objects in rados://%s/%s", pool, namespace)

--- a/pkg/daemon/ceph/client/rados_test.go
+++ b/pkg/daemon/ceph/client/rados_test.go
@@ -27,7 +27,45 @@ import (
 	"github.com/rook/rook/pkg/util/exec"
 	"github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestRadosNamespaceHasObjects(t *testing.T) {
+	RunAllCephCommandsInToolboxPod = ""
+
+	capturedShellCmd := func(t *testing.T, pool, namespace string) string {
+		var shellCmd string
+		me := &test.MockExecutor{
+			MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, arg ...string) (string, error) {
+				require.Equal(t, "sh", command)
+				require.Len(t, arg, 2)
+				require.Equal(t, "-c", arg[0])
+				shellCmd = arg[1]
+				return "", nil
+			},
+		}
+		ctx := &clusterd.Context{Executor: me, ConfigDir: "/var/lib/rook"}
+		_, err := RadosNamespaceHasObjects(ctx, AdminTestClusterInfo("rook-ceph"), pool, namespace)
+		require.NoError(t, err)
+		return shellCmd
+	}
+
+	t.Run("ordinary names stay unquoted", func(t *testing.T) {
+		assert.Equal(t,
+			"rados --pool mypool --namespace myns ls "+
+				"--cluster=rook-ceph "+
+				"--conf=/var/lib/rook/rook-ceph/rook-ceph.config "+
+				"--name=client.admin "+
+				"--keyring=/var/lib/rook/rook-ceph/client.admin.keyring "+
+				"2>/dev/null | head -c 1",
+			capturedShellCmd(t, "mypool", "myns"))
+	})
+
+	t.Run("shell metacharacters cannot break out of an argument", func(t *testing.T) {
+		assert.Contains(t, capturedShellCmd(t, "mypool", "myns; rm -rf /"),
+			"--namespace 'myns; rm -rf /' ls")
+	})
+}
 
 func TestRadosRemoveObject(t *testing.T) {
 	newTest := func(mockExec *test.MockExecutor) (*clusterd.Context, *ClusterInfo) {

--- a/pkg/daemon/util/cmdreporter.go
+++ b/pkg/daemon/util/cmdreporter.go
@@ -24,11 +24,11 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strings"
 	"syscall"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	rookexec "github.com/rook/rook/pkg/util/exec"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -166,7 +166,7 @@ func (r *CmdReporter) runCommand() (stdout, stderr string, retcode int, err erro
 	c.Stdout = stdoutTee
 	c.Stderr = stderrTee
 
-	cmdStr := fmt.Sprintf("%s %s", c.Path, strings.Join(c.Args, " "))
+	cmdStr := rookexec.FormatCommand(c.Path, c.Args[1:]...)
 	logger.Infof("running command: %s", cmdStr)
 
 	if err := c.Run(); err != nil {

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -266,7 +266,7 @@ func runCommandWithOutput(cmd *exec.Cmd, combinedOutput bool) (string, error) {
 }
 
 func logCommand(command string, arg ...string) {
-	logger.Debugf("Running command: %s %s", command, strings.Join(arg, " "))
+	logger.Debugf("Running command: %s", FormatCommand(command, arg...))
 }
 
 func assertErrorType(err error) string {

--- a/pkg/util/exec/exec_pod.go
+++ b/pkg/util/exec/exec_pod.go
@@ -151,7 +151,7 @@ func (e *RemotePodCommandExecutor) CopyLocalFileToContainer(ctx context.Context,
 	}
 	defer file.Close()
 	stdOut, stdErr, err := e.ExecWithOptions(ctx, ExecOptions{
-		Command:            []string{"sh", "-c", fmt.Sprintf("cat - > %s", dstPath)},
+		Command:            []string{"sh", "-c", fmt.Sprintf("cat - > %s", quoteArg(dstPath))},
 		Namespace:          namespace,
 		PodName:            pods.Items[0].Name,
 		ContainerName:      containerName,

--- a/pkg/util/exec/format.go
+++ b/pkg/util/exec/format.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import "strings"
+
+// safeArgChars are the non-alphanumeric characters a POSIX shell passes through
+// literally, matching the set used by Python's shlex.quote.
+const safeArgChars = "@%+=:,./-_"
+
+// FormatCommand renders a command and its arguments as a single line that can be
+// pasted into a POSIX shell. Arguments are passed to the kernel as a vector, so
+// joining them with plain spaces loses the boundaries between them: an argument
+// containing whitespace or a shell metacharacter reads back as several arguments,
+// or as several commands.
+func FormatCommand(command string, arg ...string) string {
+	quoted := make([]string, 0, len(arg)+1)
+	quoted = append(quoted, quoteArg(command))
+	for _, a := range arg {
+		quoted = append(quoted, quoteArg(a))
+	}
+
+	return strings.Join(quoted, " ")
+}
+
+// quoteArg single-quotes arg if a shell would not read it back verbatim.
+func quoteArg(arg string) string {
+	if arg == "" {
+		return "''"
+	}
+	if !needsQuoting(arg) {
+		return arg
+	}
+
+	// A single quote cannot be escaped inside single quotes; the quoted run has to
+	// be closed, the quote emitted outside it, and a new run opened.
+	return "'" + strings.ReplaceAll(arg, "'", `'\''`) + "'"
+}
+
+func needsQuoting(arg string) bool {
+	for _, r := range arg {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case strings.ContainsRune(safeArgChars, r):
+		default:
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/util/exec/format_test.go
+++ b/pkg/util/exec/format_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_quoteArg(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{"empty", "", "''"},
+		{"plain word", "radosgw-admin", "radosgw-admin"},
+		{"flag", "--rgw-realm=ceph-objectstore", "--rgw-realm=ceph-objectstore"},
+		{"path", "/var/lib/rook/rook-ceph/rook-ceph.config", "/var/lib/rook/rook-ceph/rook-ceph.config"},
+		{"space", "RGW Admin Ops User", "'RGW Admin Ops User'"},
+		{"semicolon and glob", "buckets=*;users=*", "'buckets=*;users=*'"},
+		{"command substitution", "$(id)", "'$(id)'"},
+		{"backtick", "`id`", "'`id`'"},
+		{"tilde", "~/keyring", "'~/keyring'"},
+		{"pipe", "a|b", "'a|b'"},
+		{"newline", "a\nb", "'a\nb'"},
+		{"single quote", "it's", `'it'\''s'`},
+		{"only a single quote", "'", `''\'''`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, quoteArg(tt.arg))
+		})
+	}
+}
+
+func TestFormatCommand(t *testing.T) {
+	t.Run("no arguments", func(t *testing.T) {
+		assert.Equal(t, "ceph", FormatCommand("ceph"))
+	})
+
+	t.Run("empty argument is not swallowed", func(t *testing.T) {
+		assert.Equal(t, "ceph '' status", FormatCommand("ceph", "", "status"))
+	})
+
+	t.Run("rgw admin ops user", func(t *testing.T) {
+		got := FormatCommand("radosgw-admin",
+			"user", "create",
+			"--uid", "rgw-admin-ops-user",
+			"--display-name", "RGW Admin Ops User",
+			"--caps", "accounts=*;buckets=*;users=*;usage=read;metadata=read;zone=read",
+			"--rgw-realm=ceph-objectstore",
+			"--cluster=rook-ceph",
+			"--conf=/var/lib/rook/rook-ceph/rook-ceph.config",
+			"--name=client.admin",
+			"--keyring=/var/lib/rook/rook-ceph/client.admin.keyring",
+		)
+
+		assert.Equal(t, "radosgw-admin user create "+
+			"--uid rgw-admin-ops-user "+
+			"--display-name 'RGW Admin Ops User' "+
+			"--caps 'accounts=*;buckets=*;users=*;usage=read;metadata=read;zone=read' "+
+			"--rgw-realm=ceph-objectstore "+
+			"--cluster=rook-ceph "+
+			"--conf=/var/lib/rook/rook-ceph/rook-ceph.config "+
+			"--name=client.admin "+
+			"--keyring=/var/lib/rook/rook-ceph/client.admin.keyring", got)
+	})
+}


### PR DESCRIPTION
With debug logging on, I hit an exec log line for `radosgw-admin user create` that I could not copy out of the log and re-run. `--display-name RGW Admin Ops User` and `--caps accounts=*;buckets=*;users=*;usage=read;metadata=read;zone=read` were both logged unquoted, so a shell reads them as four arguments and six commands. Arguments reach the kernel as a vector; joining them with plain spaces loses the boundaries between them.

**What changed**

- New `FormatCommand` in `pkg/util/exec` renders a command and its arguments as a line a POSIX shell reads back as the original vector.
- Applied to the exec debug log, cmd-reporter's log line and error string, and rook's startup argument line. cmd-reporter was also naming the command twice, since `exec.Cmd` already carries argv[0] in `Args`.
- Two call sites build a real `sh -c` string the same lossy way, so they were mis-executing rather than mis-reporting: `RadosNamespaceHasObjects` and `CopyLocalFileToContainer`. Nothing has misbehaved there because rook composes both values itself, but neither function enforces that.

**Notable decisions**

Quoting is minimal — an argument is single-quoted only when it holds a character the shell would not pass through literally, using the same safe set as Python's `shlex.quote`. Quoting every token instead would make rook's flag-heavy command lines much harder to read.

Two other space-joins are deliberately left alone: `CEPH_ARGS` in `pkg/operator/ceph/nvmeof/spec.go` and the CRUSH location in `pkg/operator/ceph/cluster/osd/osd.go`. Those space-separated strings are the values Ceph wants, not rendered argv.

AI assistance: Claude Code located the additional call sites carrying the same defect, wrote the `FormatCommand` helper and its unit tests, and ran an adversarial review pass over the branch.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
