### PR TITLE
osd: skip migration for OSDs fenced by do-not-reconcile

### DIFF
--- a/pkg/operator/ceph/cluster/osd/migrate_test.go
+++ b/pkg/operator/ceph/cluster/osd/migrate_test.go
@@ -24,10 +24,14 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -173,6 +177,93 @@ func TestMigrationForOSDStore(t *testing.T) {
 	})
 }
 
+func TestStartOSDMigrationSkipsFencedOSDs(t *testing.T) {
+	namespace := "rook-ceph"
+	// PGs report as clean so migration is not blocked on PG health.
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			if args[0] == "status" {
+				return "{}", nil
+			}
+			return "", nil
+		},
+	}
+
+	newCluster := func() (*fake.Clientset, *clusterd.Context, *Cluster) {
+		clientset := fake.NewClientset()
+		ctx := &clusterd.Context{
+			Clientset: clientset,
+			Executor:  executor,
+		}
+		clusterInfo := &cephclient.ClusterInfo{
+			Namespace: namespace,
+			Context:   context.TODO(),
+		}
+		clusterInfo.SetName("mycluster")
+		clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
+
+		c := New(ctx, clusterInfo, cephv1.ClusterSpec{}, "rook/rook:master")
+		c.spec.Storage.Migration.Confirmation = OSDMigrationConfirmation
+		c.spec.Storage.Store.Type = "newStore"
+		return clientset, ctx, c
+	}
+
+	// createPendingOSD creates an OSD running the old store, so it is pending migration.
+	createPendingOSD := func(clientset *fake.Clientset, c *Cluster, nodeName string, osdID int, fenced bool) {
+		d := getDummyDeploymentOnNode(clientset, c, nodeName, osdID)
+		d.Labels[osdStore] = "oldStore"
+		if fenced {
+			// mark the deployment the way validateAndStartOSDReplacement does
+			k8sutil.AddLabelToDeployment(cephv1.SkipReconcileLabelKey, "true", d)
+			k8sutil.AddAnnotationToDeployment(cephv1.ReplaceInProgressOSDAnnotationKey, "true", d)
+		}
+		createDeploymentOrPanic(clientset, d)
+	}
+
+	// derive the fenced set as Cluster.Start does
+	osdsToSkipReconcile := func(ctx *clusterd.Context, c *Cluster) (sets.Set[string], error) {
+		return controller.GetDaemonsToSkipReconcile(context.TODO(), ctx, c.clusterInfo.Namespace, OsdIdLabelKey, AppName)
+	}
+
+	t.Run("a fenced OSD is skipped in favour of another pending OSD", func(t *testing.T) {
+		clientset, ctx, c := newCluster()
+		createPendingOSD(clientset, c, "node1", 1, true)
+		createPendingOSD(clientset, c, "node2", 2, false)
+
+		skip, err := osdsToSkipReconcile(ctx, c)
+		assert.NoError(t, err)
+
+		migrationConfig, err := c.startOSDMigration(skip)
+		assert.NoError(t, err)
+		assert.NotNil(t, migrationConfig)
+
+		assert.NotNil(t, c.migrateOSD)
+		assert.Equal(t, 2, c.migrateOSD.ID)
+		assert.Empty(t, migrationConfig.getOSDIds())
+		_, err = clientset.AppsV1().Deployments(namespace).Get(context.TODO(), "rook-ceph-osd-1", metav1.GetOptions{})
+		assert.NoError(t, err)
+		_, err = clientset.AppsV1().Deployments(namespace).Get(context.TODO(), "rook-ceph-osd-2", metav1.GetOptions{})
+		assert.True(t, kerrors.IsNotFound(err))
+	})
+
+	t.Run("no migration is started when every pending OSD is fenced", func(t *testing.T) {
+		clientset, ctx, c := newCluster()
+		createPendingOSD(clientset, c, "node1", 1, true)
+
+		skip, err := osdsToSkipReconcile(ctx, c)
+		assert.NoError(t, err)
+
+		migrationConfig, err := c.startOSDMigration(skip)
+		assert.NoError(t, err)
+		assert.NotNil(t, migrationConfig)
+
+		assert.Nil(t, c.migrateOSD)
+		assert.Empty(t, migrationConfig.getOSDIds())
+		_, err = clientset.AppsV1().Deployments(namespace).Get(context.TODO(), "rook-ceph-osd-1", metav1.GetOptions{})
+		assert.NoError(t, err)
+	})
+}
+
 func createMigrationConfigmap(osdID, ns string, clientset *fake.Clientset) error {
 	ctx := context.TODO()
 	data := make(map[string]string, 1)
@@ -263,7 +354,7 @@ func TestStartOSDMigration(t *testing.T) {
 		err := createMigrationConfigmap("1", namespace, clientset)
 		assert.NoError(t, err)
 
-		migrationConfig, err := c.startOSDMigration()
+		migrationConfig, err := c.startOSDMigration(nil)
 		// The reconcile must keep flowing (no error) so the interrupted OSD can be recreated
 		// downstream, while still returning the pending OSDs so the caller removes them from
 		// the update queue.

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -294,7 +294,7 @@ func (c *Cluster) Start() error {
 		log.NamespacedWarning(c.clusterInfo.Namespace, logger, "failed to get osds to skip reconcile. %v", err)
 	}
 
-	migrationConfig, err := c.startOSDMigration()
+	migrationConfig, err := c.startOSDMigration(osdsToSkipReconcile)
 	if err != nil {
 		return errors.Wrapf(err, "failed to start OSD migration")
 	}
@@ -384,7 +384,7 @@ func (c *Cluster) deleteOsdBootstrapKeyring() {
 	}
 }
 
-func (c *Cluster) startOSDMigration() (*migrationConfig, error) {
+func (c *Cluster) startOSDMigration(osdsToSkipReconcile sets.Set[string]) (*migrationConfig, error) {
 	if !c.isMigrationRequested() {
 		log.NamespacedDebug(c.clusterInfo.Namespace, logger, "no OSD migration is requested")
 		return nil, nil
@@ -405,6 +405,14 @@ func (c *Cluster) startOSDMigration() (*migrationConfig, error) {
 	migrationConfig, err := c.newMigrationConfig()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get new OSD migration config")
+	}
+
+	// Skip migrating the OSDs with ceph.rook.io/do-not-reconcile label.
+	for osdID := range migrationConfig.osds {
+		if osdsToSkipReconcile.Has(strconv.Itoa(osdID)) {
+			log.NamespacedInfo(c.clusterInfo.Namespace, logger, "skipping migration of OSD.%d labeled with %q", osdID, cephv1.SkipReconcileLabelKey)
+			delete(migrationConfig.osds, osdID)
+		}
 	}
 
 	migrationComplete, err := isLastOSDMigrationComplete(c)


### PR DESCRIPTION
PR to fix non-blocking review isses of osd-replacement #17953 from: https://gist.github.com/jhoblitt/4047ebf57a8736c23696b7e8cb0f2589

Migration was not honoring the `ceph.rook.io/do-not-reconcile` label: it could delete a fenced OSD deployment and interfere with an OSD replacement in progress or with maintenance holding the fence. Fenced OSDs are now excluded from the migration candidates.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
