### PR TITLE
osd: reject replacement of an OSD sharing its device

### DIFF
--- a/Documentation/Storage-Configuration/Advanced/ceph-osd-mgmt.md
+++ b/Documentation/Storage-Configuration/Advanced/ceph-osd-mgmt.md
@@ -207,10 +207,17 @@ The replacement runs in five stages, alternating between what you do and what Ro
 - **Matched automatically:** `useAllDevices: true`, a `deviceFilter` that matches by kernel name, or a `/dev/disk/by-path/...` reference when the new disk is in the same physical slot.
 - **Needs a CR update:** a `/dev/disk/by-id/...` or `/dev/disk/by-uuid/...` reference, an explicit device name, or a `by-path` reference when the disk moves to a different slot. These identify the old disk, so edit the CephCluster CR to point at the new one.
 
-**Supported layouts:** all types of OSDs for host-based clusters, including shared-metadata OSDs.
+**Supported:**
 
-!!! warning
-    This procedure replaces a single **data** disk. It does not replace a **metadata device** shared by several OSDs. If the disk that failed is the shared metadata device, this procedure does not apply.
+- Host-based OSDs that own their whole data device.
+- OSDs sharing a metadata (DB) device: the data disk is replaced, the DB volume is reused.
+- Encrypted OSDs.
+
+**Not supported:**
+
+- **PVC-based OSDs** (`storageClassDeviceSets`). Rook rejects the request.
+- **Multiple OSDs on one device** (`osdsPerDevice` greater than `1`). Rook rejects the request and logs a warning. Use [Remove an OSD](#remove-an-osd) for such a disk instead, and let the operator re-create the OSDs.
+- **The shared metadata device itself.** This procedure replaces a single **data** disk; if the failed disk is the metadata device shared by several OSDs, it does not apply.
 
 ### Step 1: Trigger the replacement
 

--- a/design/ceph/osd-replacement.md
+++ b/design/ceph/osd-replacement.md
@@ -153,6 +153,7 @@ Rook's CephCluster controller predicate ([predicate.go#L252-L255](https://github
 2. **Target OSD exists and is not already destroyed.** `ceph osd dump`: the OSD must exist and its `state` must not contain `destroyed`.
 3. **Deployment is host-based.** Label `ceph.rook.io/pvc` must be absent.
 4. **Device references resolve now.** Best-effort check of the OSD's `spec.storage` references, per [Device references may not survive a swap](#device-references-may-not-survive-a-swap).
+5. **One OSD per device.** No other OSD on the same host may report the same physical device set in `ceph osd metadata`, per [Why `osdsPerDevice > 1` is out of scope](#why-osdsperdevice--1-is-out-of-scope).
 
 On the first failed check the controller skips the OSD and emits a Warning event on the CephCluster CR; see [open question 2](#open-questions). On all checks passing, it sets the `ceph.rook.io/do-not-reconcile` label and the `osd.rook.io/replace-in-progress` annotation, both in the same Deployment update so the goroutine never sees one without the other. From here the OSD and its Deployment are ignored by the controller's normal reconcile until the replacement completes or is cancelled, and the OSD health monitor goroutine takes over.
 
@@ -258,7 +259,23 @@ The flow naturally covers OSDs that have no metadata device:
 - **LVM single-disk.** Teardown is `ceph osd destroy` (plain) or `destroy` plus closing the data dm-crypt mapping (encrypted). The data LV is left as the marker. Provisioning uses `lvm prepare --data` without `--block.db`.
 - **`ceph-volume raw` OSDs.** Teardown is `ceph osd destroy`; the BlueStore label on the disk is the marker. Provisioning uses `raw prepare --osd-id <id>`.
 
-Host-based raw OSDs are always plain: `allowRawMode` provisions in lvm mode whenever the OSD is encrypted, has a metadata device, or sets `osdsPerDevice > 1` ([volume.go#L418-L463](https://github.com/rook/rook/blob/59ce48ae88e5ea59df44249b41a887af96a2806c/pkg/daemon/ceph/osd/volume.go#L418-L463)). So an encrypted single host disk is an lvm-mode OSD, and raw-encrypted does not arise. The flow covers all OSD types in a host-based cluster.
+Host-based raw OSDs are always plain: `allowRawMode` provisions in lvm mode whenever the OSD is encrypted, has a metadata device, or sets `osdsPerDevice > 1` ([volume.go#L418-L463](https://github.com/rook/rook/blob/59ce48ae88e5ea59df44249b41a887af96a2806c/pkg/daemon/ceph/osd/volume.go#L418-L463)). So an encrypted single host disk is an lvm-mode OSD, and raw-encrypted does not arise. The flow covers every host-based OSD type that owns its data device.
+
+### Why `osdsPerDevice > 1` is out of scope
+
+Pairing is strictly one destroyed slot to one blank data device, and the prepare invocation passes no
+slot count, so several OSDs on one disk cannot be rebuilt:
+
+- **Whole-disk swap.** The first slot paired consumes the entire disk, keeping the fractional CRUSH
+  weight it had as one of n. Its siblings stay `destroyed` with no device left to claim, and the disk is
+  now an LVM PV so it is never offered as blank again.
+- **One sibling replaced.** The disk still holds the surviving siblings' LVs, so it is never offered as
+  blank at all and the destroyed slot is never paired.
+
+Validation therefore rejects the request when the OSD shares its physical device with another OSD,
+detected from the device set `ceph osd metadata` reports for each OSD on the host. Supporting the
+layout properly means grouping n slots per device and passing `--data-slots n` to `lvm prepare`, which
+ceph-volume accepts — a separate feature, not a constraint of the disk format.
 
 ### Why keep the Deployment instead of deleting it
 

--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -468,6 +468,9 @@ func SetPrimaryAffinity(context *clusterd.Context, clusterInfo *ClusterInfo, osd
 type OSDMetadata struct {
 	Id       int    `json:"id"`
 	HostName string `json:"hostname"`
+	// Devices is the sorted, comma-separated set of physical block devices backing the OSD, resolved
+	// past any LVM/dm layer, e.g. "vdb" or "nvme0n1,vdb" when the DB is on a separate device.
+	Devices string `json:"devices"`
 }
 
 // GetOSDMetadata returns the output of `ceph osd metadata`

--- a/pkg/operator/ceph/cluster/osd/replace.go
+++ b/pkg/operator/ceph/cluster/osd/replace.go
@@ -40,6 +40,7 @@ func (c *Cluster) processOSDReplacements() error {
 
 	var osdTree *cephclient.OsdTree
 	var osdDump *cephclient.OSDDump
+	var osdMetadata []cephclient.OSDMetadata
 	for i := range deployments.Items {
 		d := &deployments.Items[i]
 
@@ -82,17 +83,27 @@ func (c *Cluster) processOSDReplacements() error {
 			continue
 		}
 
-		// Fetch the osd tree only once a replacement needs validating; it carries the "destroyed"
-		// status that `ceph osd dump` does not.
+		// Query Ceph only once a replacement needs validating: the tree carries the "destroyed" status
+		// that `ceph osd dump` does not, and the metadata carries the physical devices behind each OSD.
 		if osdTree == nil {
 			tree, err := cephclient.HostTree(c.context, c.clusterInfo)
 			if err != nil {
-				return errors.Wrap(err, "failed to get osd tree to validate replacement requests")
+				// Without them the request cannot be validated. Skip it rather than reject a request
+				// that may well be valid.
+				log.NamespacedWarning(c.clusterInfo.Namespace, logger,
+					"failed to get osd tree to validate replacement requests; will retry on the next reconcile. %v", err)
+				continue
 			}
-			osdTree = &tree
+			metadata, err := cephclient.GetOSDMetadata(c.context, c.clusterInfo)
+			if err != nil {
+				log.NamespacedWarning(c.clusterInfo.Namespace, logger,
+					"failed to get osd metadata to validate replacement requests; will retry on the next reconcile. %v", err)
+				continue
+			}
+			osdTree, osdMetadata = &tree, *metadata
 		}
 
-		if err := c.validateReplaceOSD(d, replaceValue, osdTree); err != nil {
+		if err := c.validateReplaceOSD(d, replaceValue, osdTree, osdMetadata); err != nil {
 			// Skip the OSD; without the label it keeps reconciling normally.
 			log.NamespacedWarning(c.clusterInfo.Namespace, logger,
 				"skipping OSD replacement request on deployment %q: %v", d.Name, err)
@@ -143,7 +154,7 @@ func (c *Cluster) isMissingFromOSDDump(d *appsv1.Deployment, osdDump *cephclient
 }
 
 // validateReplaceOSD returns an error on the first failed validation check for a replacement request.
-func (c *Cluster) validateReplaceOSD(d *appsv1.Deployment, replaceValue string, osdTree *cephclient.OsdTree) error {
+func (c *Cluster) validateReplaceOSD(d *appsv1.Deployment, replaceValue string, osdTree *cephclient.OsdTree, osdMetadata []cephclient.OSDMetadata) error {
 	// The annotation value must match the deployment's own OSD id, guarding against a copy-paste typo.
 	osdID, err := GetOSDID(d)
 	if err != nil {
@@ -173,6 +184,39 @@ func (c *Cluster) validateReplaceOSD(d *appsv1.Deployment, replaceValue string, 
 	}
 	if !found {
 		return errors.Errorf("OSD %d does not exist in the osd tree", osdID)
+	}
+
+	if err := validateSingleOSDPerDevice(osdID, osdMetadata); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateSingleOSDPerDevice rejects the request when another OSD on the same host reports the same
+// physical device set in `ceph osd metadata`: replacement pairs one destroyed OSD with one whole blank
+// data device (see design/ceph/osd-replacement.md). The set is sorted and comma-separated, so string
+// equality compares sets; a down OSD's metadata is stale, so a renamed device may reject spuriously.
+func validateSingleOSDPerDevice(osdID int, osdMetadata []cephclient.OSDMetadata) error {
+	var target *cephclient.OSDMetadata
+	for i := range osdMetadata {
+		if osdMetadata[i].Id == osdID {
+			target = &osdMetadata[i]
+			break
+		}
+	}
+	// Metadata can be missing or carry no resolved devices/host; don't block the replacement on it.
+	if target == nil || target.Devices == "" || target.HostName == "" {
+		return nil
+	}
+
+	for i := range osdMetadata {
+		other := &osdMetadata[i]
+		if other.Id == osdID || other.HostName != target.HostName || other.Devices != target.Devices {
+			continue
+		}
+		return errors.Errorf("OSD %d and OSD %d on host %q report the same physical device(s) %q; replacement requires an OSD that owns its whole data device (osdsPerDevice > 1 is not supported)",
+			osdID, other.Id, target.HostName, target.Devices)
 	}
 
 	return nil

--- a/pkg/operator/ceph/cluster/osd/replace_test.go
+++ b/pkg/operator/ceph/cluster/osd/replace_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -67,12 +68,37 @@ func osdTreeJSON(osds map[int]string) string {
 	return fmt.Sprintf(`{"nodes":[%s],"stray":[]}`, nodes)
 }
 
+// osdMetadataJSON builds an `osd metadata` response from id -> "hostname|devices" pairs.
+func osdMetadataJSON(osds map[int]string) string {
+	entries := ""
+	for id, hostAndDevices := range osds {
+		host, devices, _ := strings.Cut(hostAndDevices, "|")
+		if entries != "" {
+			entries += ","
+		}
+		entries += fmt.Sprintf(`{"id":%d,"hostname":%q,"devices":%q}`, id, host, devices)
+	}
+	return fmt.Sprintf(`[%s]`, entries)
+}
+
 func newReplaceClusterWithTree(clientset *fake.Clientset, osds map[int]string) *Cluster {
+	// Default metadata: every OSD alone on its own device, so only the tree drives the outcome.
+	metadata := map[int]string{}
+	for id := range osds {
+		metadata[id] = fmt.Sprintf("node-1|disk%d", id)
+	}
+	return newReplaceClusterWithTreeAndMetadata(clientset, osds, metadata)
+}
+
+func newReplaceClusterWithTreeAndMetadata(clientset *fake.Clientset, osds, metadata map[int]string) *Cluster {
 	c := newTestReplaceCluster(clientset)
 	c.context.Executor = &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if len(args) >= 2 && args[0] == "osd" && args[1] == "tree" {
 				return osdTreeJSON(osds), nil
+			}
+			if len(args) >= 2 && args[0] == "osd" && args[1] == "metadata" {
+				return osdMetadataJSON(metadata), nil
 			}
 			return "", nil
 		},
@@ -153,6 +179,20 @@ func TestProcessOSDReplacements(t *testing.T) {
 		dep := osdDeployment(5, map[string]string{cephv1.ReplaceOSDAnnotationKey: "yes-really-replace-osd-5"}, nil)
 		clientset := fake.NewClientset(dep)
 		c := newReplaceClusterWithTree(clientset, map[int]string{7: "up"})
+
+		require.NoError(t, c.processOSDReplacements())
+		assert.NotContains(t, getDep(c, 5).Labels, cephv1.SkipReconcileLabelKey)
+		assert.NotContains(t, getDep(c, 5).Annotations, cephv1.ReplaceInProgressOSDAnnotationKey)
+	})
+
+	t.Run("OSD sharing a device with a sibling is rejected and not fenced", func(t *testing.T) {
+		// osdsPerDevice > 1: osd 5 and osd 6 both sit on vdb, so replacement cannot pair the destroyed
+		// slots one-to-one with blank devices.
+		dep := osdDeployment(5, map[string]string{cephv1.ReplaceOSDAnnotationKey: "yes-really-replace-osd-5"}, nil)
+		clientset := fake.NewClientset(dep)
+		c := newReplaceClusterWithTreeAndMetadata(clientset,
+			map[int]string{5: "up", 6: "up"},
+			map[int]string{5: "node-1|vdb", 6: "node-1|vdb"})
 
 		require.NoError(t, c.processOSDReplacements())
 		assert.NotContains(t, getDep(c, 5).Labels, cephv1.SkipReconcileLabelKey)
@@ -268,6 +308,69 @@ func TestCleanupAbortedReplacement(t *testing.T) {
 		require.NoError(t, c.processOSDReplacements())
 		assert.True(t, depExists(t, c))
 	})
+}
+
+func TestValidateSingleOSDPerDevice(t *testing.T) {
+	md := func(id int, host, devices string) cephclient.OSDMetadata {
+		return cephclient.OSDMetadata{Id: id, HostName: host, Devices: devices}
+	}
+
+	tests := []struct {
+		name     string
+		metadata []cephclient.OSDMetadata
+		rejected bool
+	}{
+		{
+			name:     "one OSD per device",
+			metadata: []cephclient.OSDMetadata{md(5, "node-1", "vdb"), md(6, "node-1", "vdc")},
+		},
+		{
+			// osdsPerDevice > 1: both OSDs are backed by the same disk.
+			name:     "sibling on the same device",
+			metadata: []cephclient.OSDMetadata{md(5, "node-1", "vdb"), md(6, "node-1", "vdb")},
+			rejected: true,
+		},
+		{
+			// The same kernel name on two hosts is two different disks.
+			name:     "same device name on another host",
+			metadata: []cephclient.OSDMetadata{md(5, "node-1", "vdb"), md(6, "node-2", "vdb")},
+		},
+		{
+			// Siblings sharing a DB device also report their own distinct data disk, so this supported
+			// layout must not be mistaken for osdsPerDevice > 1.
+			name:     "shared metadata device",
+			metadata: []cephclient.OSDMetadata{md(5, "node-1", "nvme0n1,vdb"), md(6, "node-1", "nvme0n1,vdc")},
+		},
+		{
+			name:     "shared metadata device and a sibling on the data disk",
+			metadata: []cephclient.OSDMetadata{md(5, "node-1", "nvme0n1,vdb"), md(6, "node-1", "nvme0n1,vdb")},
+			rejected: true,
+		},
+		{
+			// Missing or unresolved metadata must not block the request.
+			name:     "target has no metadata",
+			metadata: []cephclient.OSDMetadata{md(6, "node-1", "vdb")},
+		},
+		{
+			name:     "target reports no devices",
+			metadata: []cephclient.OSDMetadata{md(5, "node-1", ""), md(6, "node-1", "")},
+		},
+		{
+			name:     "target reports no hostname",
+			metadata: []cephclient.OSDMetadata{md(5, "", "vdb"), md(6, "", "vdb")},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateSingleOSDPerDevice(5, test.metadata)
+			if test.rejected {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
 }
 
 func TestReplacementReadyToRecreate(t *testing.T) {


### PR DESCRIPTION
PR to fix non-blocking review isses of osd-replacement #17953 from: https://gist.github.com/jhoblitt/4047ebf57a8736c23696b7e8cb0f2589

OSD replacement pairs one destroyed OSD with one whole blank data device and passes no slot count to ceph-volume, so several OSDs sharing one disk (osdsPerDevice > 1) cannot be rebuilt: the first destroyed slot paired would consume the entire disk and its siblings would stay destroyed with no device left to claim. Validation now rejects the request when another OSD on the same host reports the same physical device set in `ceph osd metadata`, and the docs scope the supported layouts accordingly.


