### PR TITLE
mon: save mon config in failover path to fix failover mon registering on v1

### DIFF
--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -820,6 +820,13 @@ func (c *Cluster) failoverMon(name string) error {
 	}
 	c.ClusterInfo.InternalMonitors[m.DaemonName] = cephclient.NewMonInfo(m.DaemonName, m.PublicIP, m.Port)
 
+	// Save the new mon's config before starting the deployment so that the mon's
+	// full address (including port) is available in mon_host when the daemon
+	// joins quorum
+	if err := c.saveMonConfig(); err != nil {
+		return errors.Wrap(err, "failed to save mon config before starting failover mon")
+	}
+
 	// Start the deployment
 	newMonMightBeInQuorum = true
 	if err := c.startDeployments(mConf, true, sets.New[string]()); err != nil {


### PR DESCRIPTION
When a mon fails over, the new mon's address does not get saved before its deployment starts. This causes --mkfs to run without the new mon's address in the config, which makes it rely on --public-addr (which has no port) to register itself. Without a port, the new mon gets registered with both msgr1 (port 6789) and msgr2 (port 3300) even when requireMsgr2 is true.

Fixed this issue by calling saveMonConfig before starting the failover mon deployment (similar to the normal mon creation path).

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

