### PR TITLE
core: add workaround for ctx race after admin cephx rotation

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -319,6 +319,15 @@ func (r *ReconcileCephCluster) Reconcile(context context.Context, request reconc
 }
 
 func (r *ReconcileCephCluster) reconcile(request reconcile.Request) (reconcile.Result, cephv1.CephCluster, error) {
+	if err := r.opManagerContext.Err(); err != nil {
+		log.NamespacedInfo(request.Namespace, logger, "context cancelled before entering reconcile, exiting reconcile")
+		emptyCephCluster := cephv1.CephCluster{ObjectMeta: metav1.ObjectMeta{
+			Namespace: request.Namespace,
+			Name:      request.Name,
+		}}
+		return reconcile.Result{}, emptyCephCluster, nil
+	}
+
 	// Pass the client context to the ClusterController
 	r.clusterController.client = r.client
 

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -113,6 +113,9 @@ func (o *Operator) Run() error {
 			// Stop the operator CRD manager
 			opManagerStop()
 
+			// Short sleep to quickly work around https://github.com/rook/rook/issues/18112
+			time.Sleep(5 * time.Second)
+
 			// Run the operator CRD manager again
 			o.runCRDManager()
 
@@ -140,6 +143,7 @@ func (o *Operator) runCRDManager() {
 
 	// Pass the parent context to the cluster controller so that the monitoring go routines can
 	// consume it to terminate gracefully
+	logger.Info("swapping clusterController context") // debug https://github.com/rook/rook/issues/18112
 	o.clusterController.OpManagerCtx = opManagerContext
 
 	// Run the operator CRD manager


### PR DESCRIPTION
Add a workaround for https://github.com/rook/rook/issues/18112.

This is not a proper fix but is a quick fix that will prevent the race involving operator reload and `ClusterController`'s near-global context.Context from allowing multiple simultaneous CephCluster reconciles of the same cluster object.

There may be other ways in which a CephCluster reconcile could enter this race, but this workaround should reliably resolve the entry after admin cephx key rotation.

Possible entry after this workaround is in place could involve systems where the rook-ceph-operator pod is running on a node with high CPU load which might prevent an ongoing CephCluster reconcile from getting CPU cycles needed to exit following context cancellation before the sleep added in this workaround.


Note: does not resolve 18112, only adds a quick workaround that is safe for backports. An actual fix will be larger and may be hard to bp

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

