### PR TITLE
core: fix godoc comments that contradict their functions

### DIFF
--- a/pkg/daemon/ceph/client/filesystem_mirror.go
+++ b/pkg/daemon/ceph/client/filesystem_mirror.go
@@ -32,7 +32,7 @@ type BootstrapPeerToken struct {
 	Token string `json:"token"`
 }
 
-// RemoveFilesystemMirrorPeer add a mirror peer in the cephfs-mirror configuration
+// RemoveFilesystemMirrorPeer removes a mirror peer from the cephfs-mirror configuration
 func RemoveFilesystemMirrorPeer(context *clusterd.Context, clusterInfo *ClusterInfo, peerUUID string) error {
 	logger.Infof("removing cephfs-mirror peer %q", peerUUID)
 
@@ -68,7 +68,7 @@ func EnableFilesystemSnapshotMirror(context *clusterd.Context, clusterInfo *Clus
 	return nil
 }
 
-// DisableFilesystemSnapshotMirror enables filesystem snapshot mirroring
+// DisableFilesystemSnapshotMirror disables filesystem snapshot mirroring
 func DisableFilesystemSnapshotMirror(context *clusterd.Context, clusterInfo *ClusterInfo, filesystem string) error {
 	logger.Infof("disabling ceph filesystem snapshot mirror for filesystem %q", filesystem)
 

--- a/pkg/daemon/ceph/client/mgr.go
+++ b/pkg/daemon/ceph/client/mgr.go
@@ -115,7 +115,7 @@ func enableModule(context *clusterd.Context, clusterInfo *ClusterInfo, name stri
 	return nil
 }
 
-// enableDisableBalancerModule enables the ceph balancer module
+// enableDisableBalancerModule enables or disables the ceph balancer module, depending on action
 func enableDisableBalancerModule(context *clusterd.Context, clusterInfo *ClusterInfo, action string) error {
 	args := []string{"balancer", action}
 	_, err := NewCephCommand(context, clusterInfo, args).Run()

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -439,7 +439,7 @@ spec:
     activeStandby: true`
 }
 
-// GetFilesystem returns the manifest to create a Rook Ceph NFS resource with the given config.
+// GetNFS returns the manifest to create a Rook Ceph NFS resource with the given config.
 func (m *CephManifestsMaster) GetNFS(name string, count int) string {
 	return `apiVersion: ceph.rook.io/v1
 kind: CephNFS
@@ -454,7 +454,7 @@ spec:
     active: ` + strconv.Itoa(count)
 }
 
-// GetFilesystem returns the manifest to create a Rook Ceph NFS resource with the given config.
+// GetNFSPool returns the manifest to create the CephBlockPool backing the .nfs pool.
 func (m *CephManifestsMaster) GetNFSPool() string {
 	return `apiVersion: ceph.rook.io/v1
 kind: CephBlockPool

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -1346,7 +1346,7 @@ func (k8sh *K8sHelper) GetRGWServiceURL(storeName string, namespace string) (str
 	return k8sh.getExternalRGWServiceURL(storeName, namespace)
 }
 
-// GetRGWServiceURL returns URL of ceph RGW service in the cluster
+// getInternalRGWServiceURL returns the in-cluster URL of the ceph RGW service
 func (k8sh *K8sHelper) getInternalRGWServiceURL(storeName string, namespace string) (string, error) {
 	name := "rook-ceph-rgw-" + storeName
 	svc, err := k8sh.GetService(name, namespace)
@@ -1359,7 +1359,7 @@ func (k8sh *K8sHelper) getInternalRGWServiceURL(storeName string, namespace stri
 	return endpoint, nil
 }
 
-// GetRGWServiceURL returns URL of ceph RGW service in the cluster
+// getExternalRGWServiceURL returns the node-port URL of the ceph RGW service
 func (k8sh *K8sHelper) getExternalRGWServiceURL(storeName string, namespace string) (string, error) {
 	hostip, err := k8sh.GetPodHostIP("rook-ceph-rgw", namespace)
 	if err != nil {


### PR DESCRIPTION
Seven godoc comments described behavior their function does not have. In pkg/daemon/ceph/client, RemoveFilesystemMirrorPeer was documented as adding a peer although it runs "peer_remove", DisableFilesystemSnapshotMirror was documented as enabling mirroring although it runs "mirror disable", and enableDisableBalancerModule was documented as only enabling although it does either depending on its action argument.
In tests/framework, four comments carried a different function's name. Both RGW URL helpers in k8s_helper.go were documented as GetRGWServiceURL, which is their exported caller rather than either helper, and GetNFS and GetNFSPool in ceph_manifests.go were both documented as GetFilesystem. GetNFSPool also described an NFS resource when it returns a CephBlockPool for the .nfs pool. Each comment appears to have been copied from the neighboring function it was based on. Only comments change, so behavior is unaffected.




**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

