### PR TITLE
pool: force update the ec profile during parameter change

### DIFF
--- a/pkg/daemon/ceph/client/erasure-code-profile.go
+++ b/pkg/daemon/ceph/client/erasure-code-profile.go
@@ -106,7 +106,7 @@ func CreateErasureCodeProfile(context *clusterd.Context, clusterInfo *ClusterInf
 		profilePairs = append(profilePairs, fmt.Sprintf("stripe_unit=%d", stripeBytes))
 	}
 
-	args := []string{"osd", "erasure-code-profile", "set", profileName, "--force"}
+	args := []string{"osd", "erasure-code-profile", "set", profileName, "--force", "--yes-i-really-mean-it"}
 	args = append(args, profilePairs...)
 	cmd := NewCephCommand(context, clusterInfo, args)
 	cmd.JsonOutput = false

--- a/pkg/daemon/ceph/client/erasure-code-profile_test.go
+++ b/pkg/daemon/ceph/client/erasure-code-profile_test.go
@@ -71,11 +71,11 @@ func testCreateProfile(t *testing.T, failureDomain, crushRoot, deviceClass strin
 			if args[2] == "set" {
 				assert.Equal(t, "myapp", args[3])
 				assert.Equal(t, "--force", args[4])
-				assert.Equal(t, fmt.Sprintf("k=%d", spec.ErasureCoded.DataChunks), args[5])
-				assert.Equal(t, fmt.Sprintf("m=%d", spec.ErasureCoded.CodingChunks), args[6])
-				assert.Equal(t, "plugin=myplugin", args[7])
-				assert.Equal(t, "technique=t", args[8])
-				nextArg := 9
+				assert.Equal(t, fmt.Sprintf("k=%d", spec.ErasureCoded.DataChunks), args[6])
+				assert.Equal(t, fmt.Sprintf("m=%d", spec.ErasureCoded.CodingChunks), args[7])
+				assert.Equal(t, "plugin=myplugin", args[8])
+				assert.Equal(t, "technique=t", args[9])
+				nextArg := 10
 				if failureDomain != "" {
 					assert.Equal(t, fmt.Sprintf("crush-failure-domain=%s", failureDomain), args[nextArg])
 					nextArg++


### PR DESCRIPTION
if the ec pool profile paramter changes, force update it, so that the pool is created and updated successfully

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

