### PR TITLE
rbdmirror: honor TMPDIR for the bootstrap peer token file

### DIFF
--- a/pkg/daemon/ceph/client/mirror.go
+++ b/pkg/daemon/ceph/client/mirror.go
@@ -67,7 +67,7 @@ func ImportRBDMirrorBootstrapPeer(context *clusterd.Context, clusterInfo *Cluste
 
 	// Token file
 	tokenFilePattern := fmt.Sprintf("rbd-mirror-token-%s", poolName)
-	tokenFilePath, err := os.CreateTemp("/tmp", tokenFilePattern)
+	tokenFilePath, err := os.CreateTemp("", tokenFilePattern)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create temporary token file for pool %q", poolName)
 	}


### PR DESCRIPTION
Rook's unit tests fail in any environment that does not permit writes to `/tmp`. Running `make test` inside a filesystem sandbox that advertises a writable temp directory through `TMPDIR` but keeps `/tmp` itself read-only fails three packages — `pkg/daemon/ceph/client`, `pkg/operator/ceph/cluster/rbd`, and `pkg/operator/ceph/pool` — all of them on the paths that exercise `ImportRBDMirrorBootstrapPeer`:

```
failed to create temporary token file for pool "my-pool":
open /tmp/rbd-mirror-token-my-pool2719219208: read-only file system
```

**What changed**

`ImportRBDMirrorBootstrapPeer` created the peer bootstrap token file with `os.CreateTemp("/tmp", ...)`. It now passes an empty directory, so `os.CreateTemp` falls back to `os.TempDir()` and honors `TMPDIR`.

**Notable decisions**

`os.TempDir()` returns `/tmp` when `TMPDIR` is unset, so behavior in the operator container is unchanged — this only allows a caller to relocate temporary storage.

**AI assistance:** Claude Code diagnosed the failing tests, located the call site, and drafted the fix and this description.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
