### PR TITLE
docs: mark inert CR fields as not implemented

### DIFF
--- a/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
@@ -123,7 +123,6 @@ spec:
         - member
         - service
       implicitTenants: "swift"
-      revocationInterval: 1200
       serviceUserSecretName: usersecret
       tokenCacheSize: 1000
       url: https://keystone.example-namespace.svc/
@@ -140,7 +139,7 @@ The following options can be configured in the `keystone`-section:
 
 * `acceptedRoles`: The OpenStack Keystone [roles](https://docs.openstack.org/keystone/latest/admin/cli-manage-projects-users-and-roles.html#roles-and-role-assignments) accepted by RGW when authenticating against Keystone.
 * `implicitTenants`: Indicates whether to use implicit tenants. This can be `true`, `false`, `swift` and `s3`. For more details see the Ceph RadosGW documentation on [multitenancy](https://docs.ceph.com/en/latest/radosgw/multitenancy/).
-* `revocationInterval`: The number of seconds between token revocation checks.
+* `revocationInterval`: Unimplemented, and retained for backward compatibility. RGW no longer performs Keystone token revocation checks at all.
 * `serviceUserSecretName`: the name of the user secret containing the credentials for the admin user to use by rgw when communicating with Keystone. See [Object Store with Keystone and Swift](../../Storage-Configuration/Object-Storage-RGW/ceph-object-swift.md) for more details on what the secret must contain.
 * `tokenCacheSize`: specifies the maximum number of entries in each Keystone token cache.
 * `url`: The url of the Keystone API endpoint to use.

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -7096,7 +7096,7 @@ time.Duration
 </td>
 <td>
 <em>(Optional)</em>
-<p>DEPRECATED: PGHealthCheckTimeout is no longer implemented</p>
+<p>Deprecated: PGHealthCheckTimeout is no longer implemented and has no effect.</p>
 </td>
 </tr>
 <tr>
@@ -7121,7 +7121,8 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This enables management of machinedisruptionbudgets.</p>
+<p>Deprecated: ManageMachineDisruptionBudgets is no longer implemented and has no
+effect. The machine disruption budget controller has been removed.</p>
 </td>
 </tr>
 <tr>
@@ -7133,7 +7134,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. Namespace to look for MDBs by the machineDisruptionBudgetController</p>
+<p>Deprecated: MachineDisruptionBudgetNamespace is no longer implemented and has no
+effect. The machine disruption budget controller has been removed.</p>
 </td>
 </tr>
 </tbody>
@@ -9422,7 +9424,10 @@ int
 </td>
 <td>
 <em>(Optional)</em>
-<p>The number of seconds between token revocation checks.</p>
+<p>The number of seconds between token revocation checks.
+NOT IMPLEMENTED: this setting has no effect, and never has in any Rook
+release that offers it. RGW stopped performing Keystone token revocation
+checks after Nautilus, which predates the oldest Ceph release Rook supports.</p>
 </td>
 </tr>
 </tbody>
@@ -11601,7 +11606,10 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Filters based on the object&rsquo;s metadata</p>
+<p>Filters based on the object&rsquo;s metadata.
+NOT IMPLEMENTED: this setting has no effect. RGW supports metadata and tag
+filters, but Rook sends only keyFilters to the bucket notification
+configuration.</p>
 </td>
 </tr>
 <tr>
@@ -11615,7 +11623,10 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Filters based on the object&rsquo;s tags</p>
+<p>Filters based on the object&rsquo;s tags.
+NOT IMPLEMENTED: this setting has no effect. RGW supports metadata and tag
+filters, but Rook sends only keyFilters to the bucket notification
+configuration.</p>
 </td>
 </tr>
 </tbody>
@@ -11972,7 +11983,10 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>Whether the RADOS namespaces should be preserved on deletion of the object store</p>
+<p>Whether the RADOS namespaces should be preserved on deletion of the object store.
+NOT IMPLEMENTED: this setting has no effect. Rook does not delete the RADOS
+namespaces of a shared-pool object store, so their data is retained regardless of
+this setting. See <a href="https://github.com/rook/rook/issues/13921">https://github.com/rook/rook/issues/13921</a>.</p>
 </td>
 </tr>
 <tr>
@@ -15111,7 +15125,9 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>PersistentVolumeClaims to use as storage</p>
+<p>PersistentVolumeClaims to use as storage.
+NOT IMPLEMENTED: this setting has no effect. Use
+storageClassDeviceSets[].volumeClaimTemplates to back OSDs with PVCs.</p>
 </td>
 </tr>
 </tbody>
@@ -15746,7 +15762,8 @@ map[string]string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Provider-specific device configuration</p>
+<p>Provider-specific device configuration.
+NOT IMPLEMENTED: this setting has no effect.</p>
 </td>
 </tr>
 <tr>

--- a/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-notifications.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-notifications.md
@@ -150,18 +150,10 @@ spec:
       # match objects with keys with only lowercase characters
       - name: regex
         value: "[a-z]*\\.*"
-    metadataFilters: [6]
-      - name: x-amz-meta-color
-        value: blue
-      - name: x-amz-meta-user-type
-        value: free
-    tagFilters: [7]
-      - name: project
-        value: brown
   # notification apply for any of the events
   # full list of supported events is here:
   # https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types
-  events: [8]
+  events: [6]
     - s3:ObjectCreated:Put
     - s3:ObjectCreated:Copy
 ```
@@ -171,9 +163,7 @@ spec:
 3. `topic` to which the notifications should be sent
 4. `filter` (optional) holds a list of filtering rules of different types. Only objects that match all the filters will trigger notification sending
 5. `keyFilter` (optional) are filters based on the object key. There could be up to 3 key filters defined: `prefix`, `suffix` and `regex`
-6. `metadataFilters` (optional) are filters based on the object metadata. All metadata fields defined as filters must exists in the object, with the values defined in the filter. Other metadata fields may exist in the object
-7. `tagFilters` (optional) are filters based on object tags. All tags defined as filters must exists in the object, with the values defined in the filter. Other tags may exist in the object
-8. `events` (optional) is a list of events that should trigger the notifications. By default all events should trigger notifications. Valid Events are:
+6. `events` (optional) is a list of events that should trigger the notifications. By default all events should trigger notifications. Valid Events are:
     * s3:ObjectCreated:*
     * s3:ObjectCreated:Put
     * s3:ObjectCreated:Post
@@ -182,6 +172,13 @@ spec:
     * s3:ObjectRemoved:*
     * s3:ObjectRemoved:Delete
     * s3:ObjectRemoved:DeleteMarkerCreated
+
+!!! note
+    `metadataFilters` and `tagFilters` are accepted by the API but **not
+    implemented**: they have no effect. RGW supports both filter types, but
+    Rook sends only `keyFilters` to the bucket notification configuration, so a
+    notification is not narrowed by object metadata or object tags. Tracked in
+    [#18360](https://github.com/rook/rook/issues/18360).
 
 ### OBC Custom Resource
 

--- a/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-swift.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-swift.md
@@ -69,7 +69,6 @@ spec:
         - member
         - service
       implicitTenants: "swift"
-      revocationInterval: 1200
       serviceUserSecretName: usersecret
       tokenCacheSize: 1000
       url: https://keystone.rook-ceph.svc/

--- a/Documentation/Storage-Configuration/Object-Storage-RGW/object-storage.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/object-storage.md
@@ -168,12 +168,17 @@ spec:
   sharedPools:
     metadataPoolName: rgw-meta-pool
     dataPoolName: rgw-data-pool
-    preserveRadosNamespaceDataOnDelete: true
   gateway:
     # sslCertificateRef:
     port: 80
     instances: 1
 ```
+
+!!! note
+    `preserveRadosNamespaceDataOnDelete` is accepted by the API but **not
+    implemented**: it has no effect. Rook does not delete the RADOS namespaces of
+    a shared-pool object store, so their data is retained when the object store is
+    deleted regardless of this setting. Admins must clean up manually if desired.
 
 Create the object store:
 

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -1034,7 +1034,11 @@ spec:
                         type: object
                       type: array
                     metadataFilters:
-                      description: Filters based on the object's metadata
+                      description: |-
+                        Filters based on the object's metadata.
+                        NOT IMPLEMENTED: this setting has no effect. RGW supports metadata and tag
+                        filters, but Rook sends only keyFilters to the bucket notification
+                        configuration.
                       items:
                         description: NotificationFilterRule represents a single rule in the Notification Filter spec
                         properties:
@@ -1051,7 +1055,11 @@ spec:
                         type: object
                       type: array
                     tagFilters:
-                      description: Filters based on the object's tags
+                      description: |-
+                        Filters based on the object's tags.
+                        NOT IMPLEMENTED: this setting has no effect. RGW supports metadata and tag
+                        filters, but Rook sends only keyFilters to the bucket notification
+                        configuration.
                       items:
                         description: NotificationFilterRule represents a single rule in the Notification Filter spec
                         properties:
@@ -1807,10 +1815,14 @@ spec:
                   nullable: true
                   properties:
                     machineDisruptionBudgetNamespace:
-                      description: Deprecated. Namespace to look for MDBs by the machineDisruptionBudgetController
+                      description: |-
+                        Deprecated: MachineDisruptionBudgetNamespace is no longer implemented and has no
+                        effect. The machine disruption budget controller has been removed.
                       type: string
                     manageMachineDisruptionBudgets:
-                      description: Deprecated. This enables management of machinedisruptionbudgets.
+                      description: |-
+                        Deprecated: ManageMachineDisruptionBudgets is no longer implemented and has no
+                        effect. The machine disruption budget controller has been removed.
                       type: boolean
                     managePodBudgets:
                       description: This enables management of poddisruptionbudgets
@@ -1823,7 +1835,7 @@ spec:
                       format: int64
                       type: integer
                     pgHealthCheckTimeout:
-                      description: 'DEPRECATED: PGHealthCheckTimeout is no longer implemented'
+                      description: 'Deprecated: PGHealthCheckTimeout is no longer implemented and has no effect.'
                       format: int64
                       type: integer
                     pgHealthyRegex:
@@ -4304,7 +4316,10 @@ spec:
                             description: Whether to consume all the storage devices found on a machine
                             type: boolean
                           volumeClaimTemplates:
-                            description: PersistentVolumeClaims to use as storage
+                            description: |-
+                              PersistentVolumeClaims to use as storage.
+                              NOT IMPLEMENTED: this setting has no effect. Use
+                              storageClassDeviceSets[].volumeClaimTemplates to back OSDs with PVCs.
                             items:
                               description: VolumeClaimTemplate is a simplified version of K8s corev1's PVC. It has no type meta or status.
                               properties:
@@ -4544,7 +4559,9 @@ spec:
                           config:
                             additionalProperties:
                               type: string
-                            description: Provider-specific device configuration
+                            description: |-
+                              Provider-specific device configuration.
+                              NOT IMPLEMENTED: this setting has no effect.
                             nullable: true
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
@@ -5904,7 +5921,10 @@ spec:
                     useAllNodes:
                       type: boolean
                     volumeClaimTemplates:
-                      description: PersistentVolumeClaims to use as storage
+                      description: |-
+                        PersistentVolumeClaims to use as storage.
+                        NOT IMPLEMENTED: this setting has no effect. Use
+                        storageClassDeviceSets[].volumeClaimTemplates to back OSDs with PVCs.
                       items:
                         description: VolumeClaimTemplate is a simplified version of K8s corev1's PVC. It has no type meta or status.
                         properties:
@@ -13343,7 +13363,11 @@ spec:
                           description: Create new users in their own tenants of the same name. Possible values are true, false, swift and s3. The latter have the effect of splitting the identity space such that only the indicated protocol will use implicit tenants.
                           type: string
                         revocationInterval:
-                          description: The number of seconds between token revocation checks.
+                          description: |-
+                            The number of seconds between token revocation checks.
+                            NOT IMPLEMENTED: this setting has no effect, and never has in any Rook
+                            release that offers it. RGW stopped performing Keystone token revocation
+                            checks after Nautilus, which predates the oldest Ceph release Rook supports.
                           nullable: true
                           type: integer
                         serviceUserSecretName:
@@ -15580,7 +15604,11 @@ spec:
                         type: object
                       type: array
                     preserveRadosNamespaceDataOnDelete:
-                      description: Whether the RADOS namespaces should be preserved on deletion of the object store
+                      description: |-
+                        Whether the RADOS namespaces should be preserved on deletion of the object store.
+                        NOT IMPLEMENTED: this setting has no effect. Rook does not delete the RADOS
+                        namespaces of a shared-pool object store, so their data is retained regardless of
+                        this setting. See https://github.com/rook/rook/issues/13921.
                       type: boolean
                   type: object
                 zone:
@@ -16782,7 +16810,11 @@ spec:
                         type: object
                       type: array
                     preserveRadosNamespaceDataOnDelete:
-                      description: Whether the RADOS namespaces should be preserved on deletion of the object store
+                      description: |-
+                        Whether the RADOS namespaces should be preserved on deletion of the object store.
+                        NOT IMPLEMENTED: this setting has no effect. Rook does not delete the RADOS
+                        namespaces of a shared-pool object store, so their data is retained regardless of
+                        this setting. See https://github.com/rook/rook/issues/13921.
                       type: boolean
                   type: object
                 zoneGroup:

--- a/deploy/examples/bucket-notification.yaml
+++ b/deploy/examples/bucket-notification.yaml
@@ -17,18 +17,6 @@ spec:
       # match objects with keys with only lowercase characters
       - name: regex
         value: "[a-z]*\\.*"
-    metadataFilters:
-      # match objects that have the below metadata fields and values
-      # (other metadata fields may exist for the object)
-      - name: x-amz-meta-color
-        value: blue
-      - name: x-amz-meta-user-type
-        value: free
-    tagFilters:
-      # match objects that have the below tags
-      # (other tags may exist for the object)
-      - name: project
-        value: brown
   # notification apply for any of the events
   # full list of supported events is here:
   # https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -1035,7 +1035,11 @@ spec:
                         type: object
                       type: array
                     metadataFilters:
-                      description: Filters based on the object's metadata
+                      description: |-
+                        Filters based on the object's metadata.
+                        NOT IMPLEMENTED: this setting has no effect. RGW supports metadata and tag
+                        filters, but Rook sends only keyFilters to the bucket notification
+                        configuration.
                       items:
                         description: NotificationFilterRule represents a single rule in the Notification Filter spec
                         properties:
@@ -1052,7 +1056,11 @@ spec:
                         type: object
                       type: array
                     tagFilters:
-                      description: Filters based on the object's tags
+                      description: |-
+                        Filters based on the object's tags.
+                        NOT IMPLEMENTED: this setting has no effect. RGW supports metadata and tag
+                        filters, but Rook sends only keyFilters to the bucket notification
+                        configuration.
                       items:
                         description: NotificationFilterRule represents a single rule in the Notification Filter spec
                         properties:
@@ -1805,10 +1813,14 @@ spec:
                   nullable: true
                   properties:
                     machineDisruptionBudgetNamespace:
-                      description: Deprecated. Namespace to look for MDBs by the machineDisruptionBudgetController
+                      description: |-
+                        Deprecated: MachineDisruptionBudgetNamespace is no longer implemented and has no
+                        effect. The machine disruption budget controller has been removed.
                       type: string
                     manageMachineDisruptionBudgets:
-                      description: Deprecated. This enables management of machinedisruptionbudgets.
+                      description: |-
+                        Deprecated: ManageMachineDisruptionBudgets is no longer implemented and has no
+                        effect. The machine disruption budget controller has been removed.
                       type: boolean
                     managePodBudgets:
                       description: This enables management of poddisruptionbudgets
@@ -1821,7 +1833,7 @@ spec:
                       format: int64
                       type: integer
                     pgHealthCheckTimeout:
-                      description: 'DEPRECATED: PGHealthCheckTimeout is no longer implemented'
+                      description: 'Deprecated: PGHealthCheckTimeout is no longer implemented and has no effect.'
                       format: int64
                       type: integer
                     pgHealthyRegex:
@@ -4302,7 +4314,10 @@ spec:
                             description: Whether to consume all the storage devices found on a machine
                             type: boolean
                           volumeClaimTemplates:
-                            description: PersistentVolumeClaims to use as storage
+                            description: |-
+                              PersistentVolumeClaims to use as storage.
+                              NOT IMPLEMENTED: this setting has no effect. Use
+                              storageClassDeviceSets[].volumeClaimTemplates to back OSDs with PVCs.
                             items:
                               description: VolumeClaimTemplate is a simplified version of K8s corev1's PVC. It has no type meta or status.
                               properties:
@@ -4542,7 +4557,9 @@ spec:
                           config:
                             additionalProperties:
                               type: string
-                            description: Provider-specific device configuration
+                            description: |-
+                              Provider-specific device configuration.
+                              NOT IMPLEMENTED: this setting has no effect.
                             nullable: true
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
@@ -5902,7 +5919,10 @@ spec:
                     useAllNodes:
                       type: boolean
                     volumeClaimTemplates:
-                      description: PersistentVolumeClaims to use as storage
+                      description: |-
+                        PersistentVolumeClaims to use as storage.
+                        NOT IMPLEMENTED: this setting has no effect. Use
+                        storageClassDeviceSets[].volumeClaimTemplates to back OSDs with PVCs.
                       items:
                         description: VolumeClaimTemplate is a simplified version of K8s corev1's PVC. It has no type meta or status.
                         properties:
@@ -13332,7 +13352,11 @@ spec:
                           description: Create new users in their own tenants of the same name. Possible values are true, false, swift and s3. The latter have the effect of splitting the identity space such that only the indicated protocol will use implicit tenants.
                           type: string
                         revocationInterval:
-                          description: The number of seconds between token revocation checks.
+                          description: |-
+                            The number of seconds between token revocation checks.
+                            NOT IMPLEMENTED: this setting has no effect, and never has in any Rook
+                            release that offers it. RGW stopped performing Keystone token revocation
+                            checks after Nautilus, which predates the oldest Ceph release Rook supports.
                           nullable: true
                           type: integer
                         serviceUserSecretName:
@@ -15569,7 +15593,11 @@ spec:
                         type: object
                       type: array
                     preserveRadosNamespaceDataOnDelete:
-                      description: Whether the RADOS namespaces should be preserved on deletion of the object store
+                      description: |-
+                        Whether the RADOS namespaces should be preserved on deletion of the object store.
+                        NOT IMPLEMENTED: this setting has no effect. Rook does not delete the RADOS
+                        namespaces of a shared-pool object store, so their data is retained regardless of
+                        this setting. See https://github.com/rook/rook/issues/13921.
                       type: boolean
                   type: object
                 zone:
@@ -16768,7 +16796,11 @@ spec:
                         type: object
                       type: array
                     preserveRadosNamespaceDataOnDelete:
-                      description: Whether the RADOS namespaces should be preserved on deletion of the object store
+                      description: |-
+                        Whether the RADOS namespaces should be preserved on deletion of the object store.
+                        NOT IMPLEMENTED: this setting has no effect. Rook does not delete the RADOS
+                        namespaces of a shared-pool object store, so their data is retained regardless of
+                        this setting. See https://github.com/rook/rook/issues/13921.
                       type: boolean
                   type: object
                 zoneGroup:

--- a/deploy/examples/object-a.yaml
+++ b/deploy/examples/object-a.yaml
@@ -18,7 +18,6 @@ spec:
   sharedPools:
     metadataPoolName: rgw-meta-pool
     dataPoolName: rgw-data-pool
-    preserveRadosNamespaceDataOnDelete: true
   # The gateway service configuration
   gateway:
     # A reference to the secret in the rook namespace where the ssl certificate is stored

--- a/deploy/examples/object-b.yaml
+++ b/deploy/examples/object-b.yaml
@@ -18,7 +18,6 @@ spec:
   sharedPools:
     metadataPoolName: rgw-meta-pool
     dataPoolName: rgw-data-pool
-    preserveRadosNamespaceDataOnDelete: true
   # The gateway service configuration
   gateway:
     # A reference to the secret in the rook namespace where the ssl certificate is stored

--- a/deploy/examples/object-multisite-realm-test.yaml
+++ b/deploy/examples/object-multisite-realm-test.yaml
@@ -38,4 +38,3 @@ spec:
       - name: placement-b
         metadataPoolName: rgw-meta-pool
         dataPoolName: rgw-data-pool
-    preserveRadosNamespaceDataOnDelete: true

--- a/design/ceph/object/store.md
+++ b/design/ceph/object/store.md
@@ -82,14 +82,13 @@ spec:
 
 #### Pools shared by multiple CephObjectStore
 
-If user want to use existing pools for metadata and data, the pools must be created before the object store is created. This will be useful if multiple objectstore can share same pools. The detail of pools need to shared in `sharedPools` settings in object-store CRD. Now the object stores can consume same pool isolated with different namespaces. Usually RGW server itself create different [namespaces](https://docs.ceph.com/en/latest/radosgw/layout/#appendix-compendium) on the pools. User can create via [Pool CRD](/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md), this is need to present before the object store is created. Similar to `preservePoolsOnDelete` setting, `preserveRadosNamespaceDataOnDelete` is used to preserve the data in the rados namespace when the object store is deleted. It is set to 'false' by default.
+If user want to use existing pools for metadata and data, the pools must be created before the object store is created. This will be useful if multiple objectstore can share same pools. The detail of pools need to shared in `sharedPools` settings in object-store CRD. Now the object stores can consume same pool isolated with different namespaces. Usually RGW server itself create different [namespaces](https://docs.ceph.com/en/latest/radosgw/layout/#appendix-compendium) on the pools. User can create via [Pool CRD](/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md), this is need to present before the object store is created. Similar to the `preservePoolsOnDelete` setting, `preserveRadosNamespaceDataOnDelete` was intended to preserve the data in the rados namespace when the object store is deleted. It is not implemented and has no effect: Rook does not delete the RADOS namespaces of a shared-pool object store, so their data is retained either way. RADOS has no namespace-scoped purge -- `rados purge` operates on a whole pool -- so honoring `false` would require an unbounded, non-atomic per-object delete.
 
 ```yaml
 spec:
   sharedPools:
     metadataPoolName: rgw-meta-pool
     dataPoolName: rgw-data-pool
-    preserveRadosNamespaceDataOnDelete: true
 ```
 
 To create the pools that will be shared by multiple object stores, create the following CephBlockPool CRs:

--- a/design/ceph/object/swift-and-keystone-integration.md
+++ b/design/ceph/object/swift-and-keystone-integration.md
@@ -75,7 +75,6 @@ auth:
     acceptedRoles: ["_member_", "service", "admin"] [1, 2]
     implicitTenants: swift                          [1]
     tokenCacheSize: 1000                            [1]
-    revocationInterval: 1200                        [1]
     serviceUserSecretName: rgw-service-user         [3, 2]
 ```
 Annotations:

--- a/design/ceph/object/zone.md
+++ b/design/ceph/object/zone.md
@@ -22,7 +22,7 @@ If endpoint(s) are not specified the endpoint will be set to the Kubernetes serv
 
 This example `ceph-object-zone.yaml`, names a zone `my-zone`.
 ```yaml
-apiVersion: ceph.rook.io/v1alpha1
+apiVersion: ceph.rook.io/v1
 kind: CephObjectZone
 metadata:
   name: zone-a
@@ -148,7 +148,7 @@ The following variables can be configured in the ceph-object-zone resource.
 - `preservePoolsOnDelete`: If it is set to 'true' the pools used to support the zone will remain when the CephObjectZone is deleted. This is a security measure to avoid accidental loss of data. It is set to 'true' by default. If not specified it is also deemed as 'true'.
 
 ```yaml
-apiVersion: ceph.rook.io/v1alpha1
+apiVersion: ceph.rook.io/v1
 kind: CephObjectZone
 metadata:
   name: zone-b
@@ -194,18 +194,17 @@ Just like deleting the zone itself, removing the pools must be done by hand thro
       codingChunks: 2
 ```
 
-The [radosNamespaces](/design/ceph/object/store.md/#pools-shared-by-multiple-cephobjectstore) feature is supported for the ceph-object-zone CRD as well. The following example shows how to configure a `radosnamespace` in the zone spec.
+The [sharedPools](/design/ceph/object/store.md/#pools-shared-by-multiple-cephobjectstore) feature is supported for the ceph-object-zone CRD as well. The following example shows how to configure shared pools in the zone spec.
 
 ```yaml
-apiVersion: ceph.rook.io/v1alpha1
+apiVersion: ceph.rook.io/v1
 kind: CephObjectZone
 metadata:
   name: zone-b
   namespace: rook-ceph
 spec:
   zoneGroup: zone-group-b
-  radosNamespaces:
+  sharedPools:
     metadataPoolName: rgw-meta-pool
     dataPoolName: rgw-data-pool
-    preserveRadosNamespaceDataOnDelete: true
 ```

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1959,7 +1959,10 @@ type ObjectSharedPoolsSpec struct {
 	// +optional
 	DataPoolName string `json:"dataPoolName,omitempty"`
 
-	// Whether the RADOS namespaces should be preserved on deletion of the object store
+	// Whether the RADOS namespaces should be preserved on deletion of the object store.
+	// NOT IMPLEMENTED: this setting has no effect. Rook does not delete the RADOS
+	// namespaces of a shared-pool object store, so their data is retained regardless of
+	// this setting. See https://github.com/rook/rook/issues/13921.
 	// +optional
 	PreserveRadosNamespaceDataOnDelete bool `json:"preserveRadosNamespaceDataOnDelete"`
 
@@ -2290,6 +2293,9 @@ type KeystoneSpec struct {
 	// +nullable
 	TokenCacheSize *int `json:"tokenCacheSize,omitempty"`
 	// The number of seconds between token revocation checks.
+	// NOT IMPLEMENTED: this setting has no effect, and never has in any Rook
+	// release that offers it. RGW stopped performing Keystone token revocation
+	// checks after Nautilus, which predates the oldest Ceph release Rook supports.
 	// +optional
 	// +nullable
 	RevocationInterval *int `json:"revocationInterval,omitempty"`
@@ -2929,10 +2935,16 @@ type NotificationFilterSpec struct {
 	// Filters based on the object's key
 	// +optional
 	KeyFilters []NotificationKeyFilterRule `json:"keyFilters,omitempty"`
-	// Filters based on the object's metadata
+	// Filters based on the object's metadata.
+	// NOT IMPLEMENTED: this setting has no effect. RGW supports metadata and tag
+	// filters, but Rook sends only keyFilters to the bucket notification
+	// configuration.
 	// +optional
 	MetadataFilters []NotificationFilterRule `json:"metadataFilters,omitempty"`
-	// Filters based on the object's tags
+	// Filters based on the object's tags.
+	// NOT IMPLEMENTED: this setting has no effect. RGW supports metadata and tag
+	// filters, but Rook sends only keyFilters to the bucket notification
+	// configuration.
 	// +optional
 	TagFilters []NotificationFilterRule `json:"tagFilters,omitempty"`
 }
@@ -3491,7 +3503,7 @@ type DisruptionManagementSpec struct {
 	// +optional
 	OSDMaintenanceTimeout time.Duration `json:"osdMaintenanceTimeout,omitempty"`
 
-	// DEPRECATED: PGHealthCheckTimeout is no longer implemented
+	// Deprecated: PGHealthCheckTimeout is no longer implemented and has no effect.
 	// +optional
 	PGHealthCheckTimeout time.Duration `json:"pgHealthCheckTimeout,omitempty"`
 
@@ -3500,11 +3512,13 @@ type DisruptionManagementSpec struct {
 	// +optional
 	PGHealthyRegex string `json:"pgHealthyRegex,omitempty"`
 
-	// Deprecated. This enables management of machinedisruptionbudgets.
+	// Deprecated: ManageMachineDisruptionBudgets is no longer implemented and has no
+	// effect. The machine disruption budget controller has been removed.
 	// +optional
 	ManageMachineDisruptionBudgets bool `json:"manageMachineDisruptionBudgets,omitempty"`
 
-	// Deprecated. Namespace to look for MDBs by the machineDisruptionBudgetController
+	// Deprecated: MachineDisruptionBudgetNamespace is no longer implemented and has no
+	// effect. The machine disruption budget controller has been removed.
 	// +optional
 	MachineDisruptionBudgetNamespace string `json:"machineDisruptionBudgetNamespace,omitempty"`
 }
@@ -3902,7 +3916,9 @@ type Selection struct {
 	// +nullable
 	// +optional
 	Devices []Device `json:"devices,omitempty"`
-	// PersistentVolumeClaims to use as storage
+	// PersistentVolumeClaims to use as storage.
+	// NOT IMPLEMENTED: this setting has no effect. Use
+	// storageClassDeviceSets[].volumeClaimTemplates to back OSDs with PVCs.
 	// +optional
 	VolumeClaimTemplates []VolumeClaimTemplate `json:"volumeClaimTemplates,omitempty"`
 }
@@ -3967,7 +3983,8 @@ type StorageClassDeviceSet struct {
 	// +nullable
 	// +optional
 	PreparePlacement *Placement `json:"preparePlacement,omitempty"` // Placement constraints for the device preparation
-	// Provider-specific device configuration
+	// Provider-specific device configuration.
+	// NOT IMPLEMENTED: this setting has no effect.
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +nullable
 	// +optional

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -525,7 +525,6 @@ spec:
         - member
         - service
       implicitTenants: "true"
-      revocationInterval: 1200
       serviceUserSecretName: usersecret
       tokenCacheSize: 1000
       url: https://keystone.{{ .Manifests.Settings.Namespace }}.svc/


### PR DESCRIPTION
While auditing what happens to the underlying Ceph state when a field is deleted
from a CR, I found a set of spec fields that Rook accepts but never reads.
Several are documented as working features and set to `true` in shipped example
manifests, so a user configures one, Rook ignores it, and nothing in the CRD
description or the docs says so.

**What changed**

- API doc comments now mark the inert fields: `NOT IMPLEMENTED` for those the
  Ceph operator has never acted on, `DEPRECATED` for the machine disruption
  budget fields, whose controller was removed.
- The user guides, design notes, shipped examples and one integration-test
  manifest that presented these settings as working are corrected.
- No behavior changes; no field is added to or removed from the API.

**Notable decisions**

- Two marker forms rather than one. `metadataFilters`, `tagFilters` and
  `preserveRadosNamespaceDataOnDelete` were never implemented, so calling them
  deprecated would wrongly imply they once worked and are being withdrawn.
- `CephNFS` `spec.rados.pool` and `.namespace` are left as they are. They are
  overwritten during reconcile, but the deletion path reads the user's values
  once before that overwrite, so "has no effect" would be the wrong marker.

Three follow-ups this deliberately does not take on. The operator's
`--enable-machine-disruption-budget` flag, its unused backing variable and the
stale `machine.openshift.io` RBAC grant are the same removed controller's
residue, but they are not CR fields. `design/ceph/object/zone.md` names the
shared-pools block `radosNamespaces` and declares `apiVersion:
ceph.rook.io/v1alpha1`, neither of which exists — the same silently-pruned-config
problem, but a different field than the ones documented here. And Rook has
precedent for warning at reconcile time about a setting it will ignore
(`pkg/operator/ceph/file/controller.go:476-481`), which would reach users who
already have these fields set in a live CR; this change is documentation only.

Refs https://github.com/rook/rook/issues/13921 — the RADOS namespace cleanup
request that `preserveRadosNamespaceDataOnDelete` was meant to control. This
change documents that gap rather than closing it.

**AI assistance**: Claude Code ran the audit that identified the inert fields,
verified each against the reconcile code and against Ceph sources, and drafted
the comment and documentation wording.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
