### PR TITLE
object: accept routable as an AMQP topic ack level

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -2739,7 +2739,9 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>The ack level required for this topic (none/broker/routeable)</p>
+<p>The ack level required for this topic (none/broker/routable). The misspelled value
+&ldquo;routeable&rdquo; is deprecated, is sent to the RGW as &ldquo;routable&rdquo;, and will be removed in a
+future release.</p>
 </td>
 </tr>
 </tbody>

--- a/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-notifications.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-notifications.md
@@ -109,6 +109,7 @@ stringData:
     + `none`: message is considered "delivered" if sent to broker
     + `broker`: message is considered "delivered" if acked by broker (default)
     + `routable`: message is considered "delivered" if broker can route to a consumer
+    + `routeable`: deprecated misspelling of `routable`. Rook sends it to the RGW as `routable`, and support for the misspelling will be removed in a future release
 14. `exchange` in the AMQP broker that would route the notifications. Different topics pointing to the same endpoint must use the same exchange
 15. `kafka` (optional) hold the spec for a Kafka endpoint. The format of the URI would be: `kafka://[<user>:<password>@]<fqdn>[:<port]`
     + port defaults to: 9092

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -1168,10 +1168,14 @@ spec:
                       properties:
                         ackLevel:
                           default: broker
-                          description: The ack level required for this topic (none/broker/routeable)
+                          description: |-
+                            The ack level required for this topic (none/broker/routable). The misspelled value
+                            "routeable" is deprecated, is sent to the RGW as "routable", and will be removed in a
+                            future release.
                           enum:
                             - none
                             - broker
+                            - routable
                             - routeable
                           type: string
                         disableVerifySSL:

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -1168,10 +1168,14 @@ spec:
                       properties:
                         ackLevel:
                           default: broker
-                          description: The ack level required for this topic (none/broker/routeable)
+                          description: |-
+                            The ack level required for this topic (none/broker/routable). The misspelled value
+                            "routeable" is deprecated, is sent to the RGW as "routable", and will be removed in a
+                            future release.
                           enum:
                             - none
                             - broker
+                            - routable
                             - routeable
                           type: string
                         disableVerifySSL:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -2774,8 +2774,10 @@ type AMQPEndpointSpec struct {
 	// Indicate whether the server certificate is validated by the client or not
 	// +optional
 	DisableVerifySSL bool `json:"disableVerifySSL,omitempty"`
-	// The ack level required for this topic (none/broker/routeable)
-	// +kubebuilder:validation:Enum=none;broker;routeable
+	// The ack level required for this topic (none/broker/routable). The misspelled value
+	// "routeable" is deprecated, is sent to the RGW as "routable", and will be removed in a
+	// future release.
+	// +kubebuilder:validation:Enum=none;broker;routable;routeable
 	// +kubebuilder:default=broker
 	// +optional
 	AckLevel string `json:"ackLevel,omitempty"`

--- a/pkg/operator/ceph/object/topic/provisioner.go
+++ b/pkg/operator/ceph/object/topic/provisioner.go
@@ -122,6 +122,22 @@ func createSNSClient(p provisioner, objectStoreName types.NamespacedName) (*sns.
 	return snsClient, nil
 }
 
+const (
+	amqpAckLevelRoutable = "routable"
+	// misspelling of amqpAckLevelRoutable, accepted by the CRD since the AMQP endpoint spec was
+	// introduced and always rejected by the RGW
+	amqpAckLevelRouteable = "routeable"
+)
+
+func amqpAckLevel(nsName types.NamespacedName, ackLevel string) string {
+	if ackLevel == amqpAckLevelRouteable {
+		log.NamedWarning(nsName, logger, "CephBucketTopic %q .spec.endpoint.amqp.ackLevel %q is a deprecated misspelling of %q and is sent to the RGW as %q. update the CephBucketTopic, support for the misspelling will be removed in a future release", nsName, amqpAckLevelRouteable, amqpAckLevelRoutable, amqpAckLevelRoutable)
+		return amqpAckLevelRoutable
+	}
+
+	return ackLevel
+}
+
 func createTopicAttributes(p provisioner, topic *cephv1.CephBucketTopic) (map[string]string, *map[types.UID]*corev1.Secret, error) {
 	attr := make(map[string]string)
 	nsName := controller.NsName(topic.Namespace, topic.Name)
@@ -133,7 +149,7 @@ func createTopicAttributes(p provisioner, topic *cephv1.CephBucketTopic) (map[st
 		log.NamedInfo(nsName, logger, "creating CephBucketTopic %q with endpoint %q", nsName, topic.Spec.Endpoint.AMQP.URI)
 		attr["push-endpoint"] = topic.Spec.Endpoint.AMQP.URI
 		attr["amqp-exchange"] = topic.Spec.Endpoint.AMQP.Exchange
-		attr["amqp-ack-level"] = topic.Spec.Endpoint.AMQP.AckLevel
+		attr["amqp-ack-level"] = amqpAckLevel(nsName, topic.Spec.Endpoint.AMQP.AckLevel)
 		attr["verify-ssl"] = strconv.FormatBool(!topic.Spec.Endpoint.AMQP.DisableVerifySSL)
 	}
 	if topic.Spec.Endpoint.HTTP != nil {

--- a/pkg/operator/ceph/object/topic/provisioner_test.go
+++ b/pkg/operator/ceph/object/topic/provisioner_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestTopicAttributesCreation(t *testing.T) {
@@ -107,6 +108,43 @@ func TestTopicAttributesCreation(t *testing.T) {
 		assert.Equal(t, expectedAttrs, attrs)
 	})
 
+	t.Run("test AMQP attributes with deprecated ack level", func(t *testing.T) {
+		uri := "amqp://my-rabbitmq-service:5672/vhost1"
+		exchange := "ex1"
+		expectedAttrs := map[string]string{
+			"OpaqueData":     emptyString,
+			"persistent":     falseString,
+			"push-endpoint":  uri,
+			"verify-ssl":     trueString,
+			"amqp-exchange":  exchange,
+			"amqp-ack-level": "routable",
+		}
+		bucketTopic := &cephv1.CephBucketTopic{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind: "CephBucketTopic",
+			},
+			Spec: cephv1.BucketTopicSpec{
+				ObjectStoreName:      store,
+				ObjectStoreNamespace: namespace,
+				Endpoint: cephv1.TopicEndpointSpec{
+					AMQP: &cephv1.AMQPEndpointSpec{
+						URI:      uri,
+						AckLevel: "routeable",
+						Exchange: exchange,
+					},
+				},
+			},
+		}
+
+		attrs, _, err := createTopicAttributes(provisioner{}, bucketTopic)
+		require.NoError(t, err)
+		assert.Equal(t, expectedAttrs, attrs)
+	})
+
 	t.Run("test Kafka attributes", func(t *testing.T) {
 		uri := "kafka://my-kafka-service:9092"
 		ackLevel := "broker"
@@ -146,4 +184,24 @@ func TestTopicAttributesCreation(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, expectedAttrs, attrs)
 	})
+}
+
+func TestAMQPAckLevel(t *testing.T) {
+	nsName := types.NamespacedName{Name: name, Namespace: namespace}
+
+	for _, tc := range []struct {
+		name     string
+		ackLevel string
+		expected string
+	}{
+		{"unset", "", ""},
+		{"none", "none", "none"},
+		{"broker", "broker", "broker"},
+		{"routable", "routable", "routable"},
+		{"deprecated routeable", "routeable", "routable"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, amqpAckLevel(nsName, tc.ackLevel))
+		})
+	}
 }


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #18132

`CephBucketTopic.spec.endpoint.amqp.ackLevel` offers `routeable`, which the RGW rejects, and forbids `routable`, which the RGW accepts. The misspelling is not caught when the topic is created — the RGW stores the attribute verbatim and raises `AMQP: invalid amqp-ack-level: routeable` only when a notification is pushed — so the topic reports Ready and notifications fail later. The AMQP `routable` ack level has been unreachable through Rook since the field was introduced.

**What changed**

- `ackLevel` accepts `routable`, and it reaches the RGW as the `amqp-ack-level` topic attribute.
- `routeable` is still accepted, is translated to `routable` before it reaches the RGW, and the operator logs a deprecation warning naming the CephBucketTopic.
- The bucket notification guide and the CRD field description record the deprecation and the planned removal.

**Notable decisions**

The misspelling stays in the enum rather than being dropped. No working configuration is preserved either way, since no Ceph release has ever accepted `routeable` — but removing an enum value tightens CRD validation, which is not a change to make in a patch release, and this is intended for backport. Existing broken topics need no user action: the reconcile that follows an operator upgrade re-creates the topic with the corrected attribute.

Not verified against a live AMQP broker. That the RGW accepts `routable` and rejects `routeable` rests on `get_ack_level` in `src/rgw/driver/rados/rgw_pubsub_push.cc`, which is identical on reef, squid and main.

AI assistance: Claude Code drafted the code, tests, and documentation from the issue report, and ran the unit test and lint gates locally.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary (under the `Documentation` folder).
- [x] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
