### PR TITLE
docs: correct the documented default for bucket notification events

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -223,7 +223,12 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>List of events that should trigger the notification</p>
+<p>List of events that should trigger the notification. The S3 API requires a
+non-empty list, so when this is unset or empty Rook sends s3:ObjectCreated:*
+and s3:ObjectRemoved:* itself rather than deferring to RGW; those are the same
+two families RGW uses as its own default. That fallback covers only those two
+families: to receive the lifecycle, replication or sync events this field also
+accepts, list them here explicitly.</p>
 </td>
 </tr>
 <tr>
@@ -2984,7 +2989,12 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>List of events that should trigger the notification</p>
+<p>List of events that should trigger the notification. The S3 API requires a
+non-empty list, so when this is unset or empty Rook sends s3:ObjectCreated:*
+and s3:ObjectRemoved:* itself rather than deferring to RGW; those are the same
+two families RGW uses as its own default. That fallback covers only those two
+families: to receive the lifecycle, replication or sync events this field also
+accepts, list them here explicitly.</p>
 </td>
 </tr>
 <tr>

--- a/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-notifications.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-notifications.md
@@ -159,8 +159,6 @@ spec:
       - name: project
         value: brown
   # notification apply for any of the events
-  # full list of supported events is here:
-  # https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types
   events: [8]
     - s3:ObjectCreated:Put
     - s3:ObjectCreated:Copy
@@ -173,7 +171,7 @@ spec:
 5. `keyFilter` (optional) are filters based on the object key. There could be up to 3 key filters defined: `prefix`, `suffix` and `regex`
 6. `metadataFilters` (optional) are filters based on the object metadata. All metadata fields defined as filters must exists in the object, with the values defined in the filter. Other metadata fields may exist in the object
 7. `tagFilters` (optional) are filters based on object tags. All tags defined as filters must exists in the object, with the values defined in the filter. Other tags may exist in the object
-8. `events` (optional) is a list of events that should trigger the notifications. By default all events should trigger notifications. Valid Events are:
+8. `events` (optional) is a list of events that should trigger the notifications. The S3 API requires a non-empty list, so when this field is unset or empty Rook sends `s3:ObjectCreated:*` and `s3:ObjectRemoved:*` itself rather than deferring to RGW. Those are the same two families [RGW uses as its own default](https://docs.ceph.com/en/latest/radosgw/notifications/). The lifecycle, replication and sync events are not included in that fallback and must be listed explicitly. Valid Events are:
     * s3:ObjectCreated:*
     * s3:ObjectCreated:Put
     * s3:ObjectCreated:Post
@@ -182,6 +180,37 @@ spec:
     * s3:ObjectRemoved:*
     * s3:ObjectRemoved:Delete
     * s3:ObjectRemoved:DeleteMarkerCreated
+    * s3:ObjectLifecycle:Expiration:Current
+    * s3:ObjectLifecycle:Expiration:NonCurrent
+    * s3:ObjectLifecycle:Expiration:DeleteMarker
+    * s3:ObjectLifecycle:Expiration:AbortMultipartUpload
+    * s3:ObjectLifecycle:Transition:Current
+    * s3:ObjectLifecycle:Transition:NonCurrent
+    * s3:LifecycleExpiration:*
+    * s3:LifecycleExpiration:Delete
+    * s3:LifecycleExpiration:DeleteMarkerCreated
+    * s3:LifecycleTransition
+    * s3:ObjectSynced:*
+    * s3:ObjectSynced:Create
+    * s3:ObjectSynced:Delete
+    * s3:ObjectSynced:DeletionMarkerCreated
+    * s3:Replication:*
+    * s3:Replication:Create
+    * s3:Replication:Delete
+    * s3:Replication:DeletionMarkerCreated
+    * s3:ObjectRestore:*
+    * s3:ObjectRestore:Post
+    * s3:ObjectRestore:Completed
+    * s3:ObjectRestore:Delete
+
+!!! warning
+    The `s3:ObjectRestore:*` events are accepted by the CRD but are not yet
+    implemented in a released Ceph version. RGW rejects a notification
+    containing one with `Unknown Event type`, and the notification is never
+    created. Support was added upstream in
+    [ceph tracker #69203](https://tracker.ceph.com/issues/69203); the Tentacle
+    backport is [#75180](https://tracker.ceph.com/issues/75180). Check those for
+    the release that will carry them.
 
 ### OBC Custom Resource
 

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -972,7 +972,13 @@ spec:
               description: BucketNotificationSpec represent the spec of a Bucket Notification
               properties:
                 events:
-                  description: List of events that should trigger the notification
+                  description: |-
+                    List of events that should trigger the notification. The S3 API requires a
+                    non-empty list, so when this is unset or empty Rook sends s3:ObjectCreated:*
+                    and s3:ObjectRemoved:* itself rather than deferring to RGW; those are the same
+                    two families RGW uses as its own default. That fallback covers only those two
+                    families: to receive the lifecycle, replication or sync events this field also
+                    accepts, list them here explicitly.
                   items:
                     description: |-
                       BucketNotificationEvent represent the event type of the bucket notification

--- a/deploy/examples/bucket-notification.yaml
+++ b/deploy/examples/bucket-notification.yaml
@@ -30,8 +30,9 @@ spec:
       - name: project
         value: brown
   # notification apply for any of the events
-  # full list of supported events is here:
-  # https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types
+  # full list of supported events, including which are not usable on the Ceph
+  # releases Rook supports:
+  # https://rook.io/docs/rook/latest/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-notifications/
   events:
     - s3:ObjectCreated:Put
     - s3:ObjectCreated:Copy

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -973,7 +973,13 @@ spec:
               description: BucketNotificationSpec represent the spec of a Bucket Notification
               properties:
                 events:
-                  description: List of events that should trigger the notification
+                  description: |-
+                    List of events that should trigger the notification. The S3 API requires a
+                    non-empty list, so when this is unset or empty Rook sends s3:ObjectCreated:*
+                    and s3:ObjectRemoved:* itself rather than deferring to RGW; those are the same
+                    two families RGW uses as its own default. That fallback covers only those two
+                    families: to receive the lifecycle, replication or sync events this field also
+                    accepts, list them here explicitly.
                   items:
                     description: |-
                       BucketNotificationEvent represent the event type of the bucket notification

--- a/design/ceph/object/ceph-bucket-notification-crd.md
+++ b/design/ceph/object/ceph-bucket-notification-crd.md
@@ -68,7 +68,7 @@ spec:
     - name: regex
       value: [a-z]*
 
-  events: # applicable values [here](https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types), (default all)
+  events: # applicable values [here](https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/#event-types); if omitted, only object create and remove events are configured
 ```
 The information about bucket notification can passed to OBC/BAR(from [COSI](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1979-object-storage-support)) as labels. It can be set using `kubectl` commands, so the name of bucket notifications need to satisfy the [label syntax](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set). For OBC it will look like the following:
 

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -2892,7 +2892,12 @@ type BucketNotificationSpec struct {
 	// The name of the topic associated with this notification
 	// +kubebuilder:validation:MinLength=1
 	Topic string `json:"topic"`
-	// List of events that should trigger the notification
+	// List of events that should trigger the notification. The S3 API requires a
+	// non-empty list, so when this is unset or empty Rook sends s3:ObjectCreated:*
+	// and s3:ObjectRemoved:* itself rather than deferring to RGW; those are the same
+	// two families RGW uses as its own default. That fallback covers only those two
+	// families: to receive the lifecycle, replication or sync events this field also
+	// accepts, list them here explicitly.
 	// +optional
 	Events []BucketNotificationEvent `json:"events,omitempty"`
 	// Spec of notification filter

--- a/pkg/operator/ceph/object/notification/provisioner.go
+++ b/pkg/operator/ceph/object/notification/provisioner.go
@@ -119,8 +119,10 @@ func createS3Filter(filter *cephv1.NotificationFilterSpec) *s3types.Notification
 }
 
 func createS3Events(events []cephv1.BucketNotificationEvent) []s3types.Event {
-	// in the AWS S3 library "Events" is a required field
-	// but in our CR it is optional, indicating notifications on all events
+	// in the AWS S3 library "Events" is a required field, but in our CR it is
+	// optional. An empty list falls back to object create and remove events only,
+	// mirroring what RGW applies when a notification carries no Event element
+	// (see rgw_pubsub_s3_notification::decode_xml).
 	if len(events) == 0 {
 		return []s3types.Event{
 			s3types.Event("s3:ObjectCreated:*"),

--- a/pkg/operator/ceph/object/notification/provisioner_test.go
+++ b/pkg/operator/ceph/object/notification/provisioner_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package notification
+
+import (
+	"testing"
+
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+// The fallback is documented in the CRD description for
+// CephBucketNotification.spec.events and in the bucket notification guide.
+// Both are user-facing, so pin the set rather than let it drift silently.
+func TestCreateS3EventsFallback(t *testing.T) {
+	expected := []s3types.Event{
+		s3types.Event("s3:ObjectCreated:*"),
+		s3types.Event("s3:ObjectRemoved:*"),
+	}
+
+	t.Run("nil list falls back", func(t *testing.T) {
+		assert.Equal(t, expected, createS3Events(nil))
+	})
+
+	t.Run("empty list falls back", func(t *testing.T) {
+		assert.Equal(t, expected, createS3Events([]cephv1.BucketNotificationEvent{}))
+	})
+
+	t.Run("explicit events are passed through unchanged", func(t *testing.T) {
+		events := []cephv1.BucketNotificationEvent{
+			"s3:ObjectLifecycle:Expiration:Current",
+			"s3:Replication:Create",
+		}
+		assert.Equal(t, []s3types.Event{
+			s3types.Event("s3:ObjectLifecycle:Expiration:Current"),
+			s3types.Event("s3:Replication:Create"),
+		}, createS3Events(events))
+	})
+}


### PR DESCRIPTION
`CephBucketNotification.spec.events` is optional, and the guide, the field's
description and the code's own comment all said that leaving it unset triggers
notifications on all events. It does not: with an unset or empty list Rook
configures exactly `s3:ObjectCreated:*` and `s3:ObjectRemoved:*`, so the
lifecycle, replication and sync events the field accepts never fire. A user who
omits `events` because the docs say that means everything gets no lifecycle or
replication notifications at all, and nothing indicates it.

**What changed**

- The field's godoc, the notification guide and the code comment now describe
  the real fallback, and note that it mirrors what RGW itself applies to a
  notification carrying no `Event` element.
- The guide's list of valid events was still the original eight while the CRD
  enum had grown to thirty; it is brought up to the enum.
- A unit test pins the fallback set, which nothing in CI did before.
- No behavior changes.

**Notable decisions**

- This documents the current behavior rather than widening the fallback. Rook's
  two-event fallback is not a local shortcut — RGW applies the same two types,
  under the same "all events" comment, in
  `rgw_pubsub_s3_notification::decode_xml`. Widening it here would give a Rook
  CR a subscription no other S3 client gets against the same RGW; that argument
  belongs upstream.
- The regenerated list carries a warning on the four `s3:ObjectRestore:*`
  values. They are in the CRD enum but are implemented only on Ceph main, and
  RGW rejects a notification containing one with `Unknown Event type` rather
  than ignoring it, so listing them without a warning would have been worse
  than the stale list it replaces.

**Open question for reviewers:** the enum accepting values no supported Ceph
implements is a gap this PR documents rather than closes. Narrowing the enum is
a validation tightening against stored CRs, and Ceph main will make those four
values real, so it did not seem like a call to make here — but if you would
rather see the enum track `rgw::notify::from_string`, that is a reasonable
follow-up. The same shape of gap exists in the other direction
(`s3:ObjectLifecycle:*` wildcards are accepted by RGW and rejected by the enum)
and for `CephBucketTopic` AMQP `ackLevel`, filed as #18132.

**AI assistance**: Claude Code found the discrepancy while auditing CR fields
whose values never take effect, verified the behavior against the Rook and Ceph
sources, and drafted the wording and the test.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary (under the `Documentation` folder).
- [x] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
