### PR TITLE
multus: add ipv6 check in hostTemplateConfig curl

### DIFF
--- a/pkg/daemon/multus/templates.go
+++ b/pkg/daemon/multus/templates.go
@@ -116,6 +116,15 @@ func (vt *ValidationTest) generateWebServerTemplateConfig(placement PlacementCon
 	}
 }
 
+// addressForCurlHostPort wraps IPv6 literals in [] to support :<port> addition
+func addressForCurlHostPort(addr string) string {
+	// it's an IPv6 address and needs square brackets around it to support :<port> addition
+	if strings.Contains(addr, ":") {
+		return "[" + addr + "]"
+	}
+	return addr
+}
+
 func (vt *ValidationTest) generateHostCheckerTemplateConfig(
 	serverPublicAddr string,
 	nodeType string,
@@ -123,7 +132,7 @@ func (vt *ValidationTest) generateHostCheckerTemplateConfig(
 ) hostCheckerTemplateConfig {
 	return hostCheckerTemplateConfig{
 		NodeType:             nodeType,
-		PublicNetworkAddress: serverPublicAddr,
+		PublicNetworkAddress: addressForCurlHostPort(serverPublicAddr),
 		NginxImage:           vt.NginxImage,
 		Placement:            placement,
 	}
@@ -144,10 +153,7 @@ func (vt *ValidationTest) generateClientTemplateConfig(
 		netNamesAndAddresses["cluster"] = serverClusterAddr
 	}
 	for name, addr := range netNamesAndAddresses {
-		if strings.Contains(addr, ":") {
-			// it's an IPv6 address and needs square brackets around it to support :<port> addition
-			netNamesAndAddresses[name] = "[" + addr + "]"
-		}
+		netNamesAndAddresses[name] = addressForCurlHostPort(addr)
 	}
 	return clientTemplateConfig{
 		NodeType:                 nodeType,


### PR DESCRIPTION
currently, only clientTemplateConfig had ipv6 supported curl arg, hostTemplateConfig was missing this change. Adding the change for hostTemplateConfig.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

