### PR TITLE
core: ignore Ceph commit IDs during external version validation

### DIFF
--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -250,6 +250,17 @@ func IsSuperior(a, b CephVersion) bool {
 	return false
 }
 
+// IsStrictlySuperior checks if a given version is superior to another one, ignoring any
+// difference in commit ID. Commit IDs are hashes and have no ordering, so unlike IsSuperior
+// this never reports one version as superior to another purely because the two were built
+// from different commits.
+func IsStrictlySuperior(a, b CephVersion) bool {
+	a.CommitID = ""
+	b.CommitID = ""
+
+	return IsSuperior(a, b)
+}
+
 // IsInferior checks if a given version if inferior to another one
 func IsInferior(a, b CephVersion) bool {
 	if a.Major < b.Major {
@@ -295,14 +306,16 @@ func ValidateCephVersionsBetweenLocalAndExternalClusters(localVersion, externalV
 		return nil
 	}
 
-	// Local version must never be higher than the external one
-	if IsSuperior(localVersion, externalVersion) {
+	// Local version must never be higher than the external one. Compare the releases with
+	// IsStrictlySuperior so that two clusters running the same release built from different
+	// commits are not reported as one being higher than the other.
+	if IsStrictlySuperior(localVersion, externalVersion) {
 		return errors.Errorf("local cluster ceph version %q is higher than the external cluster version %q, this must never happen", localVersion.String(), externalVersion.String())
 	}
 
 	// External cluster was updated to a minor version higher, consider updating too!
 	if localVersion.Major == externalVersion.Major {
-		if IsSuperior(externalVersion, localVersion) {
+		if IsStrictlySuperior(externalVersion, localVersion) {
 			logger.Warningf("external cluster ceph version is a minor version higher %q than the local cluster %q, consider upgrading", externalVersion.String(), localVersion.String())
 			return nil
 		}

--- a/pkg/operator/ceph/version/version_test.go
+++ b/pkg/operator/ceph/version/version_test.go
@@ -156,6 +156,36 @@ func TestIsSuperior(t *testing.T) {
 	assert.True(t, IsSuperior(CephVersion{15, 2, 2, 1, ""}, CephVersion{15, 2, 1, 0, ""}))
 }
 
+func TestIsStrictlySuperior(t *testing.T) {
+	// same ordering as IsSuperior when the commit IDs are equal
+	assert.False(t, IsStrictlySuperior(CephVersion{15, 2, 2, 0, ""}, CephVersion{15, 2, 2, 0, ""}))
+	assert.False(t, IsStrictlySuperior(CephVersion{15, 2, 2, 0, ""}, CephVersion{16, 2, 2, 0, ""}))
+	assert.True(t, IsStrictlySuperior(CephVersion{16, 2, 2, 0, ""}, CephVersion{15, 2, 2, 0, ""}))
+	assert.True(t, IsStrictlySuperior(CephVersion{15, 2, 2, 0, ""}, CephVersion{15, 1, 3, 0, ""}))
+	assert.True(t, IsStrictlySuperior(CephVersion{15, 2, 2, 0, ""}, CephVersion{15, 2, 1, 0, ""}))
+	assert.True(t, IsStrictlySuperior(CephVersion{15, 2, 2, 1, ""}, CephVersion{15, 2, 1, 0, ""}))
+
+	// unlike IsSuperior, a differing commit ID alone does not make either version superior
+	a := CephVersion{15, 2, 2, 0, "aaaaaaaaaaaaaaaa"}
+	b := CephVersion{15, 2, 2, 0, "bbbbbbbbbbbbbbbb"}
+	assert.True(t, IsSuperior(a, b))
+	assert.True(t, IsSuperior(b, a))
+	assert.False(t, IsStrictlySuperior(a, b))
+	assert.False(t, IsStrictlySuperior(b, a))
+
+	// the same holds when only one side reports a commit ID
+	assert.False(t, IsStrictlySuperior(CephVersion{15, 2, 2, 0, ""}, a))
+	assert.False(t, IsStrictlySuperior(a, CephVersion{15, 2, 2, 0, ""}))
+
+	// a differing commit ID must not mask a real version difference
+	assert.True(t, IsStrictlySuperior(CephVersion{15, 2, 3, 0, "aaaaaaaaaaaaaaaa"}, b))
+	assert.False(t, IsStrictlySuperior(CephVersion{15, 2, 1, 0, "aaaaaaaaaaaaaaaa"}, b))
+
+	// the caller's versions are not modified
+	assert.Equal(t, "aaaaaaaaaaaaaaaa", a.CommitID)
+	assert.Equal(t, "bbbbbbbbbbbbbbbb", b.CommitID)
+}
+
 func TestIsInferior(t *testing.T) {
 	assert.False(t, IsInferior(CephVersion{15, 2, 2, 0, ""}, CephVersion{15, 2, 2, 0, ""}))
 	assert.False(t, IsInferior(CephVersion{16, 2, 2, 0, ""}, CephVersion{15, 2, 2, 0, ""}))
@@ -196,6 +226,26 @@ func TestValidateCephVersionsBetweenLocalAndExternalClusters(t *testing.T) {
 	externalCephVersion = CephVersion{Major: 15, Minor: 2, Extra: 2}
 	err = ValidateCephVersionsBetweenLocalAndExternalClusters(localCephVersion, externalCephVersion)
 	assert.NoError(t, err)
+
+	// TEST 6: same release on both sides, but the images were built from different commits.
+	// Neither version is higher than the other, so connecting must be allowed.
+	localCephVersion = CephVersion{Major: 17, Minor: 2, Extra: 1, CommitID: "aaaaaaaaaaaaaaaa"}
+	externalCephVersion = CephVersion{Major: 17, Minor: 2, Extra: 1, CommitID: "bbbbbbbbbbbbbbbb"}
+	err = ValidateCephVersionsBetweenLocalAndExternalClusters(localCephVersion, externalCephVersion)
+	assert.NoError(t, err)
+
+	// TEST 7: same release, but only the external cluster reports a commit ID
+	localCephVersion = CephVersion{Major: 17, Minor: 2, Extra: 1}
+	externalCephVersion = CephVersion{Major: 17, Minor: 2, Extra: 1, CommitID: "bbbbbbbbbbbbbbbb"}
+	err = ValidateCephVersionsBetweenLocalAndExternalClusters(localCephVersion, externalCephVersion)
+	assert.NoError(t, err)
+
+	// TEST 8: a commit ID difference must not mask a real version difference. The local
+	// cluster is still higher than the external one, so this must be rejected.
+	localCephVersion = CephVersion{Major: 17, Minor: 2, Extra: 2, CommitID: "aaaaaaaaaaaaaaaa"}
+	externalCephVersion = CephVersion{Major: 17, Minor: 2, Extra: 1, CommitID: "bbbbbbbbbbbbbbbb"}
+	err = ValidateCephVersionsBetweenLocalAndExternalClusters(localCephVersion, externalCephVersion)
+	assert.Error(t, err)
 }
 
 func TestCephVersion_Unsupported(t *testing.T) {


### PR DESCRIPTION
ValidateCephVersionsBetweenLocalAndExternalClusters uses IsSuperior to compare the local and external Ceph versions. IsSuperior treats different commit IDs as making one version superior, even when both clusters run the same Ceph release.

As a result, images built from different commits fail validation with a contradictory error because CephVersion.String does not include the commit ID:

  local cluster ceph version "19.2.3-0 squid" is higher than the external
  cluster version "19.2.3-0 squid", this must never happen

The same false positive occurs when only one version includes a commit ID, because an empty commit ID differs from any non-empty value.

Commit IDs identify builds but do not define release ordering. Clear the commit IDs from the local copies before comparing the versions so validation considers only the Ceph release. The arguments are passed by value, so this does not modify the caller's versions. This also matches the approach already used in keyring/cephx.go before calling IsSuperior.

Leave IsSuperior unchanged because its commit-ID behavior affects other callers and is tracked separately in #18126.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [x] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

