### PR TITLE
osd: update osd mclock value based on benchmark

### DIFF
--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -157,6 +157,8 @@ data:
   # DISCOVER_AGENT_POD_LABELS: "key1=value1,key2=value2"
   # Disable automatic orchestration when new devices are discovered
   ROOK_DISABLE_DEVICE_HOTPLUG: "false"
+  # Disable automatic OSD mclock capacity update
+  ROOK_DISABLE_OSD_BENCHMARK: "false"
   # The duration between discovering devices in the rook-discover daemonset.
   ROOK_DISCOVER_DEVICES_INTERVAL: "60m"
   # DISCOVER_DAEMON_RESOURCES: |

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -74,6 +74,8 @@ data:
   # DISCOVER_AGENT_POD_LABELS: "key1=value1,key2=value2"
   # Disable automatic orchestration when new devices are discovered
   ROOK_DISABLE_DEVICE_HOTPLUG: "false"
+  # Disable automatic OSD mclock capacity update
+  ROOK_DISABLE_OSD_BENCHMARK: "false"
   # The duration between discovering devices in the rook-discover daemonset.
   ROOK_DISCOVER_DEVICES_INTERVAL: "60m"
   # DISCOVER_DAEMON_RESOURCES: |

--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -470,7 +470,9 @@ type OSDMetadata struct {
 	HostName string `json:"hostname"`
 	// Devices is the sorted, comma-separated set of physical block devices backing the OSD, resolved
 	// past any LVM/dm layer, e.g. "vdb" or "nvme0n1,vdb" when the DB is on a separate device.
-	Devices string `json:"devices"`
+	Devices                 string `json:"devices"`
+	BluestoreBdevType       string `json:"bluestore_bdev_type"`
+	BluestoreBdevRotational string `json:"bluestore_bdev_rotational"`
 }
 
 // GetOSDMetadata returns the output of `ceph osd metadata`
@@ -485,6 +487,49 @@ func GetOSDMetadata(context *clusterd.Context, clusterInfo *ClusterInfo) (*[]OSD
 		return nil, errors.Wrap(err, "failed to unmarshal osd metadata response")
 	}
 	return &osdMetadata, nil
+}
+
+// GetOSDMetadataByID returns metadata for a single OSD.
+func GetOSDMetadataByID(context *clusterd.Context, clusterInfo *ClusterInfo, osdID int) (*OSDMetadata, error) {
+	args := []string{"osd", "metadata", strconv.Itoa(osdID)}
+	buf, err := NewCephCommand(context, clusterInfo, args).Run()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get metadata by id for osd.%d", osdID)
+	}
+	var meta OSDMetadata
+	if err := json.Unmarshal(buf, &meta); err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal metadata for osd.%d", osdID)
+	}
+	return &meta, nil
+}
+
+// OSDBenchResult is the JSON output of `ceph tell osd.N bench`.
+type OSDBenchResult struct {
+	IOPS json.Number `json:"iops"`
+}
+
+// OSDBench runs a 4KiB random write bench on the OSD with Ceph recommended defaults.
+func OSDBench(context *clusterd.Context, clusterInfo *ClusterInfo, osdID int) (*OSDBenchResult, error) {
+	args := []string{"tell", fmt.Sprintf("osd.%d", osdID), "bench", "12288000", "4096", "4194304", "100"}
+	buf, err := NewCephCommand(context, clusterInfo, args).Run()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to run ceph tell osd.%d bench", osdID)
+	}
+	var result OSDBenchResult
+	if err := json.Unmarshal(buf, &result); err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal bench result for osd.%d", osdID)
+	}
+	return &result, nil
+}
+
+// OSDCacheDrop runs `ceph tell osd.N cache drop`.
+func OSDCacheDrop(context *clusterd.Context, clusterInfo *ClusterInfo, osdID int) error {
+	args := []string{"tell", fmt.Sprintf("osd.%d", osdID), "cache", "drop"}
+	_, err := NewCephCommand(context, clusterInfo, args).Run()
+	if err != nil {
+		return errors.Wrapf(err, "failed to drop cache for osd.%d", osdID)
+	}
+	return nil
 }
 
 // Blocklist blocklists the client address for predefined duration

--- a/pkg/operator/ceph/cluster/osd/mclock.go
+++ b/pkg/operator/ceph/cluster/osd/mclock.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"sync"
+
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/config"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util/log"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	mclockIopsHDD          = "osd_mclock_max_capacity_iops_hdd"
+	mclockIopsSSD          = "osd_mclock_max_capacity_iops_ssd"
+	disableOSDBenchmarkEnv = "ROOK_DISABLE_OSD_BENCHMARK"
+)
+
+var mclockCapacityUpdated sync.Map
+
+// ensureMclockCapacityForOSDs sets osd_mclock_max_capacity_iops_[hdd|ssd] from an OSD bench.
+func (c *Cluster) ensureMclockCapacityForOSDs() {
+	if k8sutil.GetOperatorSetting(disableOSDBenchmarkEnv, "false") == "true" {
+		return
+	}
+
+	osdDump, err := cephclient.GetOSDDump(c.context, c.clusterInfo)
+	if err != nil {
+		log.NamespacedError(c.clusterInfo.Namespace, logger, "failed to get osd dump for mclock capacity update: %v", err)
+		return
+	}
+
+	monStore := config.GetMonStore(c.context, c.clusterInfo)
+	for _, osd := range osdDump.OSDs {
+		osdID, ok := osdIDIsUp(osd.Up, osd.OSD)
+		if !ok {
+			continue
+		}
+
+		// namespace/osdID is used as the key to store the updated mclock capacity
+		// this is used to avoid updating the mclock capacity multiple times for the same osd
+		updatedKey := c.clusterInfo.Namespace + "/" + strconv.Itoa(osdID)
+		if _, ok := mclockCapacityUpdated.Load(updatedKey); ok {
+			continue
+		}
+
+		if err := c.updateMclockCapacity(osdID, monStore, updatedKey); err != nil {
+			log.NamespacedError(c.clusterInfo.Namespace, logger, "failed to update mclock capacity for osd.%d: %v", osdID, err)
+		}
+	}
+}
+
+func (c *Cluster) updateMclockCapacity(osdID int, monStore *config.MonStore, updatedKey string) error {
+	meta, err := cephclient.GetOSDMetadataByID(c.context, c.clusterInfo, osdID)
+	if err != nil {
+		return err
+	}
+	option := mclockIopsSSD
+	if meta.BluestoreBdevRotational == "1" || meta.BluestoreBdevType == "hdd" {
+		option = mclockIopsHDD
+	}
+
+	who := fmt.Sprintf("osd.%d", osdID)
+	currentValue, err := monStore.Get(who, option)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get current iops for osd.%d", osdID)
+	}
+
+	currentIOPS, err := strconv.ParseFloat(currentValue, 64)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse current iops for osd.%d", osdID)
+	}
+
+	if err := cephclient.OSDCacheDrop(c.context, c.clusterInfo, osdID); err != nil {
+		return err
+	}
+
+	result, err := cephclient.OSDBench(c.context, c.clusterInfo, osdID)
+	if err != nil {
+		return err
+	}
+
+	resultIOPS, err := result.IOPS.Float64()
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse bench iops for osd.%d", osdID)
+	}
+
+	if resultIOPS <= currentIOPS {
+		mclockCapacityUpdated.Store(updatedKey, struct{}{})
+		return nil
+	}
+
+	resultIOPSValue := strconv.Itoa(int(math.Round(resultIOPS)))
+	if err := monStore.Set(who, option, resultIOPSValue); err != nil {
+		return err
+	}
+
+	mclockCapacityUpdated.Store(updatedKey, struct{}{})
+	log.NamespacedInfo(c.clusterInfo.Namespace, logger, "set %s=%s for osd.%d from osd bench", option, resultIOPSValue, osdID)
+	return nil
+}
+
+func osdIDIsUp(up, osd json.Number) (int, bool) {
+	upVal, err := up.Int64()
+	if err != nil || upVal != 1 {
+		return 0, false
+	}
+	id, err := osd.Int64()
+	if err != nil {
+		return 0, false
+	}
+	return int(id), true
+}

--- a/pkg/operator/ceph/cluster/osd/mclock_test.go
+++ b/pkg/operator/ceph/cluster/osd/mclock_test.go
@@ -1,0 +1,430 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	opconfig "github.com/rook/rook/pkg/operator/ceph/config"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+)
+
+const mclockTestNamespace = "rook-ceph"
+
+func resetMclockCapacityUpdated() {
+	mclockCapacityUpdated = sync.Map{}
+}
+
+func mclockDone(osdID int) bool {
+	_, ok := mclockCapacityUpdated.Load(mclockTestNamespace + "/" + fmt.Sprint(osdID))
+	return ok
+}
+
+func newMclockCluster(executor *exectest.MockExecutor) *Cluster {
+	clusterInfo := client.AdminTestClusterInfo(mclockTestNamespace)
+	clusterInfo.Context = context.TODO()
+	return &Cluster{
+		context:     &clusterd.Context{Executor: executor},
+		clusterInfo: clusterInfo,
+	}
+}
+
+func mclockExecutor(mock func(args ...string) (string, error)) *exectest.MockExecutor {
+	run := func(command string, args ...string) (string, error) {
+		return mock(args...)
+	}
+	return &exectest.MockExecutor{
+		MockExecuteCommandWithOutput: run,
+		MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
+			return run(command, args...)
+		},
+	}
+}
+
+func TestOsdIDIsUp(t *testing.T) {
+	id, ok := osdIDIsUp("1", "2")
+	assert.True(t, ok)
+	assert.Equal(t, 2, id)
+
+	id, ok = osdIDIsUp("0", "0")
+	assert.False(t, ok)
+	assert.Equal(t, 0, id)
+
+	id, ok = osdIDIsUp("x", "0")
+	assert.False(t, ok)
+
+	id, ok = osdIDIsUp("1", "x")
+	assert.False(t, ok)
+}
+
+func TestUpdateMclockCapacity(t *testing.T) {
+	key := mclockTestNamespace + "/0"
+	monStore := func(c *Cluster) *opconfig.MonStore {
+		return opconfig.GetMonStore(c.context, c.clusterInfo)
+	}
+
+	t.Run("sets hdd capacity when bench is higher", func(t *testing.T) {
+		resetMclockCapacityUpdated()
+		var setOption, setValue string
+		c := newMclockCluster(mclockExecutor(func(args ...string) (string, error) {
+			switch {
+			case len(args) >= 2 && args[0] == "osd" && args[1] == "metadata":
+				return `{"bluestore_bdev_type":"hdd","bluestore_bdev_rotational":"1"}`, nil
+			case len(args) >= 4 && args[0] == "config" && args[1] == "get":
+				return "315", nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "cache":
+				return "", nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "bench":
+				return `{"iops":8735.34}`, nil
+			case len(args) >= 5 && args[0] == "config" && args[1] == "set":
+				setOption, setValue = args[3], args[4]
+				return "", nil
+			}
+			return "", fmt.Errorf("unexpected args %v", args)
+		}))
+
+		err := c.updateMclockCapacity(0, monStore(c), key)
+		assert.NoError(t, err)
+		assert.Equal(t, mclockIopsHDD, setOption)
+		assert.Equal(t, "8735", setValue)
+		assert.True(t, mclockDone(0))
+	})
+
+	t.Run("sets ssd capacity for non-rotational device", func(t *testing.T) {
+		resetMclockCapacityUpdated()
+		var setOption string
+		c := newMclockCluster(mclockExecutor(func(args ...string) (string, error) {
+			switch {
+			case len(args) >= 3 && args[0] == "osd" && args[1] == "metadata":
+				return `{"bluestore_bdev_type":"ssd","bluestore_bdev_rotational":"0"}`, nil
+			case len(args) >= 4 && args[0] == "config" && args[1] == "get":
+				return "1000", nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "cache":
+				return "", nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "bench":
+				return `{"iops":21500.6}`, nil
+			case len(args) >= 5 && args[0] == "config" && args[1] == "set":
+				setOption = args[3]
+				return "", nil
+			}
+			return "", fmt.Errorf("unexpected args %v", args)
+		}))
+
+		err := c.updateMclockCapacity(1, monStore(c), mclockTestNamespace+"/1")
+		assert.NoError(t, err)
+		assert.Equal(t, mclockIopsSSD, setOption)
+		assert.True(t, mclockDone(1))
+	})
+
+	t.Run("metadata lookup fails", func(t *testing.T) {
+		resetMclockCapacityUpdated()
+		c := newMclockCluster(mclockExecutor(func(args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == "osd" && args[1] == "metadata" {
+				return "", fmt.Errorf("metadata failed")
+			}
+			return "", fmt.Errorf("unexpected args %v", args)
+		}))
+		err := c.updateMclockCapacity(0, monStore(c), key)
+		assert.Error(t, err)
+		assert.False(t, mclockDone(0))
+	})
+
+	t.Run("config get fails", func(t *testing.T) {
+		resetMclockCapacityUpdated()
+		c := newMclockCluster(mclockExecutor(func(args ...string) (string, error) {
+			switch {
+			case len(args) >= 2 && args[0] == "osd" && args[1] == "metadata":
+				return `{"bluestore_bdev_rotational":"1"}`, nil
+			case len(args) >= 4 && args[0] == "config" && args[1] == "get":
+				return "", fmt.Errorf("config get failed")
+			}
+			return "", fmt.Errorf("unexpected args %v", args)
+		}))
+		err := c.updateMclockCapacity(0, monStore(c), key)
+		assert.ErrorContains(t, err, "failed to get current iops")
+		assert.False(t, mclockDone(0))
+	})
+
+	t.Run("current iops is not numeric", func(t *testing.T) {
+		resetMclockCapacityUpdated()
+		c := newMclockCluster(mclockExecutor(func(args ...string) (string, error) {
+			switch {
+			case len(args) >= 2 && args[0] == "osd" && args[1] == "metadata":
+				return `{"bluestore_bdev_rotational":"1"}`, nil
+			case len(args) >= 4 && args[0] == "config" && args[1] == "get":
+				return "not-a-number", nil
+			}
+			return "", fmt.Errorf("unexpected args %v", args)
+		}))
+		err := c.updateMclockCapacity(0, monStore(c), key)
+		assert.ErrorContains(t, err, "failed to parse current iops")
+		assert.False(t, mclockDone(0))
+	})
+
+	t.Run("cache drop fails", func(t *testing.T) {
+		resetMclockCapacityUpdated()
+		c := newMclockCluster(mclockExecutor(func(args ...string) (string, error) {
+			switch {
+			case len(args) >= 2 && args[0] == "osd" && args[1] == "metadata":
+				return `{"bluestore_bdev_rotational":"1"}`, nil
+			case len(args) >= 4 && args[0] == "config" && args[1] == "get":
+				return "315", nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "cache":
+				return "", fmt.Errorf("cache drop failed")
+			}
+			return "", fmt.Errorf("unexpected args %v", args)
+		}))
+		err := c.updateMclockCapacity(0, monStore(c), key)
+		assert.ErrorContains(t, err, "cache drop")
+		assert.False(t, mclockDone(0))
+	})
+
+	t.Run("bench fails", func(t *testing.T) {
+		resetMclockCapacityUpdated()
+		c := newMclockCluster(mclockExecutor(func(args ...string) (string, error) {
+			switch {
+			case len(args) >= 2 && args[0] == "osd" && args[1] == "metadata":
+				return `{"bluestore_bdev_rotational":"1"}`, nil
+			case len(args) >= 4 && args[0] == "config" && args[1] == "get":
+				return "315", nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "cache":
+				return "", nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "bench":
+				return "", fmt.Errorf("bench failed")
+			}
+			return "", fmt.Errorf("unexpected args %v", args)
+		}))
+		err := c.updateMclockCapacity(0, monStore(c), key)
+		assert.ErrorContains(t, err, "bench")
+		assert.False(t, mclockDone(0))
+	})
+
+	t.Run("bench iops is not numeric", func(t *testing.T) {
+		resetMclockCapacityUpdated()
+		c := newMclockCluster(mclockExecutor(func(args ...string) (string, error) {
+			switch {
+			case len(args) >= 2 && args[0] == "osd" && args[1] == "metadata":
+				return `{"bluestore_bdev_rotational":"1"}`, nil
+			case len(args) >= 4 && args[0] == "config" && args[1] == "get":
+				return "315", nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "cache":
+				return "", nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "bench":
+				return `{"iops":"bad"}`, nil
+			}
+			return "", fmt.Errorf("unexpected args %v", args)
+		}))
+		err := c.updateMclockCapacity(0, monStore(c), key)
+		assert.ErrorContains(t, err, "bench result")
+		assert.False(t, mclockDone(0))
+	})
+
+	t.Run("config set fails", func(t *testing.T) {
+		resetMclockCapacityUpdated()
+		c := newMclockCluster(mclockExecutor(func(args ...string) (string, error) {
+			switch {
+			case len(args) >= 2 && args[0] == "osd" && args[1] == "metadata":
+				return `{"bluestore_bdev_rotational":"1"}`, nil
+			case len(args) >= 4 && args[0] == "config" && args[1] == "get":
+				return "315", nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "cache":
+				return "", nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "bench":
+				return `{"iops":8735}`, nil
+			case len(args) >= 5 && args[0] == "config" && args[1] == "set":
+				return "", fmt.Errorf("config set failed")
+			}
+			return "", fmt.Errorf("unexpected args %v", args)
+		}))
+		err := c.updateMclockCapacity(0, monStore(c), key)
+		assert.Error(t, err)
+		assert.False(t, mclockDone(0))
+	})
+
+	t.Run("bench lower than current skips config set", func(t *testing.T) {
+		resetMclockCapacityUpdated()
+		configSet := false
+		c := newMclockCluster(mclockExecutor(func(args ...string) (string, error) {
+			switch {
+			case len(args) >= 2 && args[0] == "osd" && args[1] == "metadata":
+				return `{"bluestore_bdev_rotational":"1"}`, nil
+			case len(args) >= 4 && args[0] == "config" && args[1] == "get":
+				return "9000", nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "cache":
+				return "", nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "bench":
+				return `{"iops":8000}`, nil
+			case len(args) >= 5 && args[0] == "config" && args[1] == "set":
+				configSet = true
+				return "", nil
+			}
+			return "", fmt.Errorf("unexpected args %v", args)
+		}))
+		err := c.updateMclockCapacity(0, monStore(c), key)
+		assert.NoError(t, err)
+		assert.False(t, configSet)
+		assert.True(t, mclockDone(0))
+	})
+
+	t.Run("bench equal to current skips config set", func(t *testing.T) {
+		resetMclockCapacityUpdated()
+		configSet := false
+		c := newMclockCluster(mclockExecutor(func(args ...string) (string, error) {
+			switch {
+			case len(args) >= 2 && args[0] == "osd" && args[1] == "metadata":
+				return `{"bluestore_bdev_rotational":"1"}`, nil
+			case len(args) >= 4 && args[0] == "config" && args[1] == "get":
+				return "8735", nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "cache":
+				return "", nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "bench":
+				return `{"iops":8735}`, nil
+			case len(args) >= 5 && args[0] == "config" && args[1] == "set":
+				configSet = true
+				return "", nil
+			}
+			return "", fmt.Errorf("unexpected args %v", args)
+		}))
+		err := c.updateMclockCapacity(0, monStore(c), key)
+		assert.NoError(t, err)
+		assert.False(t, configSet)
+		assert.True(t, mclockDone(0))
+	})
+}
+
+func TestEnsureMclockCapacityForOSDs(t *testing.T) {
+	t.Run("sets capacity for up osds", func(t *testing.T) {
+		resetMclockCapacityUpdated()
+		var setValue string
+		c := newMclockCluster(mclockExecutor(func(args ...string) (string, error) {
+			switch {
+			case len(args) >= 2 && args[0] == "osd" && args[1] == "dump":
+				return `{"osds":[{"osd":"0","up":"1","in":"1"}]}`, nil
+			case len(args) >= 2 && args[0] == "osd" && args[1] == "metadata":
+				return `{"bluestore_bdev_rotational":"1"}`, nil
+			case len(args) >= 4 && args[0] == "config" && args[1] == "get":
+				return "315", nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "cache":
+				return "", nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "bench":
+				return `{"iops":8735}`, nil
+			case len(args) >= 5 && args[0] == "config" && args[1] == "set":
+				setValue = args[4]
+				return "", nil
+			}
+			return "", fmt.Errorf("unexpected args %v", args)
+		}))
+		c.ensureMclockCapacityForOSDs()
+		assert.Equal(t, "8735", setValue)
+		assert.True(t, mclockDone(0))
+	})
+
+	t.Run("disabled by operator setting", func(t *testing.T) {
+		resetMclockCapacityUpdated()
+		t.Setenv(disableOSDBenchmarkEnv, "true")
+		defer os.Unsetenv(disableOSDBenchmarkEnv)
+
+		benchCalls := 0
+		c := newMclockCluster(mclockExecutor(func(args ...string) (string, error) {
+			if len(args) >= 3 && args[0] == "tell" && args[2] == "bench" {
+				benchCalls++
+			}
+			return "", fmt.Errorf("unexpected args %v", args)
+		}))
+		c.ensureMclockCapacityForOSDs()
+		assert.Equal(t, 0, benchCalls)
+	})
+
+	t.Run("osd dump failure is a no-op", func(t *testing.T) {
+		resetMclockCapacityUpdated()
+		c := newMclockCluster(mclockExecutor(func(args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == "osd" && args[1] == "dump" {
+				return "", fmt.Errorf("dump failed")
+			}
+			return "", fmt.Errorf("unexpected args %v", args)
+		}))
+		c.ensureMclockCapacityForOSDs()
+		assert.False(t, mclockDone(0))
+	})
+
+	t.Run("skips osd that is not up", func(t *testing.T) {
+		resetMclockCapacityUpdated()
+		benchCalls := 0
+		c := newMclockCluster(mclockExecutor(func(args ...string) (string, error) {
+			switch {
+			case len(args) >= 2 && args[0] == "osd" && args[1] == "dump":
+				return `{"osds":[{"osd":"0","up":"0","in":"1"}]}`, nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "bench":
+				benchCalls++
+			}
+			return "", fmt.Errorf("unexpected args %v", args)
+		}))
+		c.ensureMclockCapacityForOSDs()
+		assert.Equal(t, 0, benchCalls)
+	})
+
+	t.Run("does not re-bench osd already marked done", func(t *testing.T) {
+		resetMclockCapacityUpdated()
+		mclockCapacityUpdated.Store(mclockTestNamespace+"/0", struct{}{})
+		benchCalls := 0
+		c := newMclockCluster(mclockExecutor(func(args ...string) (string, error) {
+			switch {
+			case len(args) >= 2 && args[0] == "osd" && args[1] == "dump":
+				return `{"osds":[{"osd":"0","up":"1","in":"1"}]}`, nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "bench":
+				benchCalls++
+			}
+			return "", fmt.Errorf("unexpected args %v", args)
+		}))
+		c.ensureMclockCapacityForOSDs()
+		assert.Equal(t, 0, benchCalls)
+	})
+
+	t.Run("continues when one osd fails", func(t *testing.T) {
+		resetMclockCapacityUpdated()
+		c := newMclockCluster(mclockExecutor(func(args ...string) (string, error) {
+			switch {
+			case len(args) >= 2 && args[0] == "osd" && args[1] == "dump":
+				return `{"osds":[{"osd":"0","up":"1","in":"1"},{"osd":"1","up":"1","in":"1"}]}`, nil
+			case len(args) >= 3 && args[0] == "osd" && args[1] == "metadata" && args[2] == "0":
+				return "", fmt.Errorf("metadata failed for osd.0")
+			case len(args) >= 3 && args[0] == "osd" && args[1] == "metadata":
+				return `{"bluestore_bdev_rotational":"1"}`, nil
+			case len(args) >= 4 && args[0] == "config" && args[1] == "get":
+				return "315", nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "cache":
+				return "", nil
+			case len(args) >= 3 && args[0] == "tell" && args[2] == "bench":
+				return `{"iops":8735}`, nil
+			case len(args) >= 5 && args[0] == "config" && args[1] == "set":
+				return "", nil
+			}
+			return "", fmt.Errorf("unexpected args %v", args)
+		}))
+		c.ensureMclockCapacityForOSDs()
+		assert.False(t, mclockDone(0))
+		assert.True(t, mclockDone(1))
+	})
+}

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -482,6 +482,8 @@ func (c *Cluster) postReconcileUpdateOSDProperties(desiredOSDs map[int]*OSDInfo)
 		}
 	}
 
+	c.ensureMclockCapacityForOSDs()
+
 	return nil
 }
 


### PR DESCRIPTION
for some disk ceph reset the mclock value to default lower value as sometime very fast devices have high mclock number which ceph thinks as wrong value so,it revert it to default lower value. And, also sometimes a hdd can be detected as a ssd which will lead to wrong mclock value. This commit run the ceph benchmark to fetch the right mclock value and set apply it to each osds.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

