### PR TITLE
rgw: force unboard account with purge data job

### DIFF
--- a/pkg/operator/ceph/object/account.go
+++ b/pkg/operator/ceph/object/account.go
@@ -19,12 +19,18 @@ package object
 import (
 	"context"
 	"fmt"
-	"syscall"
+	"strings"
 
 	"github.com/ceph/go-ceph/rgw/admin"
 	"github.com/pkg/errors"
-	"github.com/rook/rook/pkg/util/exec"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util/log"
+	batch "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -90,29 +96,149 @@ func DeleteAccount(nsName types.NamespacedName, ctx context.Context, adminOpsCon
 	return nil
 }
 
-// ForceDeleteAccount removes an RGW account, even if it has associated users or buckets.
-func ForceDeleteAccount(nsName types.NamespacedName, adminOpsContext *AdminOpsContext, accountID string) error {
+// ForceDeleteAccount removes an RGW account by creating a Kubernetes Job that runs
+// "radosgw-admin account rm --purge-data". A Job is used because purging large
+// amounts of data can far exceed the operator's 15-second command timeout.
+// The Job retries on failure until the purge completes or the account no longer exists.
+func ForceDeleteAccount(uid types.UID, nsName types.NamespacedName, adminOpsContext *AdminOpsContext, accountID string, cephClusterSpec *cephv1.ClusterSpec) (bool, error) {
 	if accountID == "" {
-		return errors.New("account ID cannot be empty")
+		return false, errors.New("account ID cannot be empty")
 	}
-
-	// run the cli cmd using --purge-data flag
 	if adminOpsContext == nil {
-		return errors.New("adminOpsContext cannot be nil")
-	}
-	// Rook should use admin ops API for this, but `--purge-data` isn't integrated yet. Swap this implementation when it is.
-	account := fmt.Sprintf("--account-id=%s", accountID)
-	_, err := runAdminCommand(&adminOpsContext.Context, false, "account", "rm", "--purge-data", account)
-	if err != nil {
-		// If account doesn't exist, consider it successful (idempotent)
-		if code, ok := exec.ExitStatus(err); ok && code == int(syscall.ENOENT) {
-			log.NamedInfo(nsName, logger, "account %q not found, considering force-deletion successful", accountID)
-			return nil
-		}
-		return errors.Wrapf(err, "failed to force delete account %q using CLI", accountID)
+		return false, errors.New("adminOpsContext cannot be nil")
 	}
 
-	return nil
+	clusterInfo := adminOpsContext.clusterInfo
+	job := makeAccountPurgeJob(uid, nsName, adminOpsContext, accountID, clusterInfo, cephClusterSpec)
+
+	if err := clusterInfo.OwnerInfo.SetControllerReference(job); err != nil {
+		return false, errors.Wrapf(err, "failed to set owner reference on purge job for account %q", accountID)
+	}
+
+	log.NamedInfo(nsName, logger, "creating purge-data job %q for account %q", job.Name, accountID)
+	if err := k8sutil.RunJob(clusterInfo.Context, adminOpsContext.Context.Context.Clientset, job); err != nil {
+		return false, errors.Wrapf(err, "failed to create purge-data job for account %q", accountID)
+	}
+
+	// check for the job to complete with a re-qeueue loop, to not block other reconcile operations
+	jobComplete, err := k8sutil.CheckIfJobIsCompleted(clusterInfo.Context, adminOpsContext.Context.Context.Clientset, job)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to check if purge-data job %q for account %q is completed", job.Name, accountID)
+	}
+	if !jobComplete {
+		log.NamedInfo(nsName, logger, "purge-data job %q for account %q is still running, requeuing reconcile", job.Name, accountID)
+		return true, nil
+	}
+
+	// if the job completed successfully, the account should be gone, but check to be sure
+	_, err = GetAccount(clusterInfo.Context, adminOpsContext, accountID)
+	if err != nil {
+		if errors.Is(err, admin.ErrNoSuchKey) {
+			log.NamedInfo(nsName, logger, "account %q successfully purged", accountID)
+			// delete the job now that the account is gone
+			if err := k8sutil.DeleteBatchJob(clusterInfo.Context, adminOpsContext.Context.Context.Clientset, job.Namespace, job.Name, true); err != nil {
+				return false, errors.Wrapf(err, "failed to delete purge-data job %q for account %q", job.Name, accountID)
+			}
+			// this function will take exit from here
+			return false, nil
+		}
+	}
+
+	// do not delete the job if the account still exists, so we can check the job logs for errors
+	return false, errors.Wrapf(err, "failed to verify account %q was purged", accountID)
+}
+
+func makeAccountPurgeJob(uid types.UID, nsName types.NamespacedName, adminOpsContext *AdminOpsContext, accountID string, clusterInfo *cephclient.ClusterInfo, cephClusterSpec *cephv1.ClusterSpec) *batch.Job {
+	// Build the radosgw-admin command args
+	args := []string{
+		"account", "rm",
+		"--purge-data",
+		fmt.Sprintf("--account-id=%s", accountID),
+	}
+
+	// Add multisite flags when applicable
+	if adminOpsContext.Name != "" && clusterInfo.CephCred.Username == cephclient.AdminUsername {
+		args = append(args,
+			fmt.Sprintf("--rgw-realm=%s", adminOpsContext.Realm),
+			fmt.Sprintf("--rgw-zonegroup=%s", adminOpsContext.ZoneGroup),
+			fmt.Sprintf("--rgw-zone=%s", adminOpsContext.Zone),
+		)
+	}
+	keyringFile := fmt.Sprintf("%s.keyring", clusterInfo.CephCred.Username)
+	keyringFilePath := fmt.Sprintf("%s/%s/%s", cephClusterSpec.DataDirHostPath, nsName.Namespace, keyringFile)
+	configFile := fmt.Sprintf("%s.config", clusterInfo.Namespace)
+	configFilePath := fmt.Sprintf("%s/%s/%s", cephClusterSpec.DataDirHostPath, nsName.Namespace, configFile)
+
+	args = append(args,
+		fmt.Sprintf("--keyring=%s", keyringFilePath),
+		fmt.Sprintf("--conf=%s", configFilePath),
+		fmt.Sprintf("--name=%s", clusterInfo.CephCred.Username),
+	)
+
+	// Wrap in a shell to treat ENOENT (exit code 2) as success
+	shellCmd := fmt.Sprintf(`
+		radosgw-admin %s;
+		rc=$?;
+		if [ $rc -eq 0 ]; then
+    		echo 'account purge succeeded';
+  		elif [ $rc -eq 2 ]; then
+    		echo 'account not found, nothing to purge';
+    		exit 0;
+  		else
+    		echo "account purge failed with exit code $rc";
+  		fi;
+  		exit $rc
+		`, strings.Join(args, " "),
+	)
+
+	volumes := []corev1.Volume{{Name: "account-cleanup", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: cephClusterSpec.DataDirHostPath}}}}
+	volumeMounts := []corev1.VolumeMount{{Name: "account-cleanup", MountPath: cephClusterSpec.DataDirHostPath}}
+	jobName := k8sutil.TruncateNodeNameForJob("rgw-account-purge-%s", fmt.Sprintf("%s-%s-%s", nsName.Name, nsName.Namespace, uid))
+
+	labels := map[string]string{
+		k8sutil.AppAttr:     "rgw-account-purge",
+		k8sutil.ClusterAttr: clusterInfo.Namespace,
+	}
+	timeToLive := int32(86400) // 24 hours
+
+	job := getJobTemplate(jobName, nsName.Namespace, labels, volumes, volumeMounts, shellCmd, cephClusterSpec, timeToLive)
+
+	k8sutil.AddRookVersionLabelToJob(job)
+	return job
+}
+
+func getJobTemplate(jobName, namespace string, labels map[string]string, volumes []corev1.Volume, volumeMounts []corev1.VolumeMount, shellCmd string, cephClusterSpec *cephv1.ClusterSpec, timeToLive int32) *batch.Job {
+	return &batch.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: batch.JobSpec{
+			TTLSecondsAfterFinished: &timeToLive,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "rgw-account-purge",
+							Image:           cephClusterSpec.CephVersion.Image,
+							ImagePullPolicy: opcontroller.GetContainerImagePullPolicy(cephClusterSpec.CephVersion.ImagePullPolicy),
+							Command:         []string{"/bin/sh", "-c"},
+							Args:            []string{shellCmd},
+							VolumeMounts:    volumeMounts,
+							SecurityContext: opcontroller.PrivilegedContext(true),
+						},
+					},
+					Volumes:            volumes,
+					RestartPolicy:      corev1.RestartPolicyOnFailure,
+					ServiceAccountName: k8sutil.DefaultServiceAccount,
+				},
+			},
+		},
+	}
 }
 
 // CreateAccountRootUser creates a root user for the given RGW account using the admin ops API.

--- a/pkg/operator/ceph/object/account/controller.go
+++ b/pkg/operator/ceph/object/account/controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"time"
 
 	"github.com/ceph/go-ceph/rgw/admin"
 	"github.com/coreos/pkg/capnslog"
@@ -228,11 +229,13 @@ func (r *ReconcileObjectStoreAccount) reconcile(request reconcile.Request) (reco
 		log.NamedDebug(request.NamespacedName, logger, "deleting object store account")
 		r.recorder.Eventf(cephObjectStoreAccount, nil, corev1.EventTypeNormal, string(cephv1.ReconcileStarted), string(cephv1.ReconcileStarted), "deleting CephObjectStoreAccount %q", cephObjectStoreAccount.Name)
 
-		err := r.deleteAccount(cephObjectStoreAccount)
+		requeue, err := r.deleteAccount(cephObjectStoreAccount)
 		if err != nil {
 			return reconcile.Result{}, *cephObjectStoreAccount, errors.Wrapf(err, "failed to delete ceph object store account %q", cephObjectStoreAccount.Name)
 		}
-
+		if requeue {
+			return reconcile.Result{Requeue: true, RequeueAfter: 2 * time.Minute}, *cephObjectStoreAccount, nil
+		}
 		// Remove finalizer
 		err = opcontroller.RemoveFinalizer(r.opManagerContext, r.client, cephObjectStoreAccount)
 		if err != nil {
@@ -418,12 +421,12 @@ func (r *ReconcileObjectStoreAccount) persistAccountIDToStatus(cephObjectStoreAc
 	return nil
 }
 
-func (r *ReconcileObjectStoreAccount) deleteAccount(cephObjectStoreAccount *cephv1.CephObjectStoreAccount) error {
+func (r *ReconcileObjectStoreAccount) deleteAccount(cephObjectStoreAccount *cephv1.CephObjectStoreAccount) (bool, error) {
 	nsName := types.NamespacedName{Namespace: cephObjectStoreAccount.Namespace, Name: cephObjectStoreAccount.Name}
 	accountID := getAccountID(cephObjectStoreAccount)
 	if accountID == "" {
 		log.NamedInfo(nsName, logger, "no account ID found, skipping deletion")
-		return nil
+		return false, nil
 	}
 
 	// Only delete the account if we have ownership proof (status contains the account ID).
@@ -433,7 +436,7 @@ func (r *ReconcileObjectStoreAccount) deleteAccount(cephObjectStoreAccount *ceph
 	hasOwnershipProof := cephObjectStoreAccount.Status != nil && cephObjectStoreAccount.Status.AccountID == accountID
 	if !hasOwnershipProof {
 		log.NamedInfo(nsName, logger, "account %q was never successfully managed by this CR, skipping deletion to avoid removing a foreign account", accountID)
-		return nil
+		return false, nil
 	}
 
 	// Always attempt to delete the root user to ensure cleanup
@@ -442,7 +445,7 @@ func (r *ReconcileObjectStoreAccount) deleteAccount(cephObjectStoreAccount *ceph
 	err := object.DeleteAccountRootUser(r.opManagerContext, r.objContext, rootUserID)
 	if err != nil {
 		if !errors.Is(err, admin.ErrNoSuchUser) {
-			return errors.Wrapf(err, "failed to delete root user %q for account %q", rootUserID, accountID)
+			return false, errors.Wrapf(err, "failed to delete root user %q for account %q", rootUserID, accountID)
 		}
 		log.NamedInfo(nsName, logger, "root user %q not found, considering deletion successful", rootUserID)
 	} else {
@@ -454,20 +457,23 @@ func (r *ReconcileObjectStoreAccount) deleteAccount(cephObjectStoreAccount *ceph
 	// if `rook.io/force-deletion` annotation is set to true, we will force delete the account even if it contains S3 resources
 	if opcontroller.ForceDeleteRequested(cephObjectStoreAccount.Annotations) {
 		log.NamedInfo(nsName, logger, "force-deletion annotation set to true, forcing deletion of account %q", accountID)
-		err = object.ForceDeleteAccount(nsName, r.objContext, accountID)
+		requeue, err := object.ForceDeleteAccount(cephObjectStoreAccount.UID, nsName, r.objContext, accountID, r.cephClusterSpec)
 		if err != nil {
-			return errors.Wrapf(err, "failed to force delete account %q", accountID)
+			return requeue, errors.Wrapf(err, "failed to force delete account %q", accountID)
+		}
+		if requeue {
+			return requeue, nil
 		}
 	} else {
 		log.NamedInfo(nsName, logger, "force-deletion annotation not set for account %q, manual cleanup may be required if the account contains S3 resources", accountID)
 		err = object.DeleteAccount(nsName, r.opManagerContext, r.objContext, accountID)
 		if err != nil {
-			return errors.Wrapf(err, "failed to delete account %q, manual cleanup may be required if the account contains S3 resources", accountID)
+			return false, errors.Wrapf(err, "failed to delete account %q, manual cleanup may be required if the account contains S3 resources", accountID)
 		}
 	}
 
 	log.NamedInfo(nsName, logger, "successfully deleted account %q", accountID)
-	return nil
+	return false, nil
 }
 
 // deleteRootUserSecret deletes the Kubernetes secret for root user credentials, treating "not found" as success.

--- a/pkg/operator/ceph/object/account/controller_test.go
+++ b/pkg/operator/ceph/object/account/controller_test.go
@@ -1101,7 +1101,7 @@ func TestDeleteAccount(t *testing.T) {
 			},
 		}
 
-		err = r.deleteAccount(account)
+		_, err = r.deleteAccount(account)
 		assert.NoError(t, err)
 		assert.True(t, userDeleteCalled, "should delete root user")
 		assert.True(t, accountDeleteCalled, "should delete account")
@@ -1156,7 +1156,7 @@ func TestDeleteAccount(t *testing.T) {
 			},
 		}
 
-		err = r.deleteAccount(account)
+		_, err = r.deleteAccount(account)
 		assert.NoError(t, err)
 		assert.True(t, userDeleteCalled, "should always attempt to delete root user even when skipCreate is true")
 		assert.True(t, accountDeleteCalled, "should delete account")
@@ -1203,7 +1203,7 @@ func TestDeleteAccount(t *testing.T) {
 			},
 		}
 
-		err = r.deleteAccount(account)
+		_, err = r.deleteAccount(account)
 		assert.NoError(t, err)
 		assert.True(t, accountDeleteCalled, "should still delete account even if root user is gone")
 	})
@@ -1247,7 +1247,7 @@ func TestDeleteAccount(t *testing.T) {
 			},
 		}
 
-		err = r.deleteAccount(account)
+		_, err = r.deleteAccount(account)
 		assert.NoError(t, err)
 	})
 
@@ -1263,7 +1263,7 @@ func TestDeleteAccount(t *testing.T) {
 			},
 		}
 
-		err := r.deleteAccount(account)
+		_, err := r.deleteAccount(account)
 		assert.NoError(t, err)
 	})
 
@@ -1303,7 +1303,7 @@ func TestDeleteAccount(t *testing.T) {
 			},
 		}
 
-		err = r.deleteAccount(account)
+		_, err = r.deleteAccount(account)
 		assert.NoError(t, err)
 		assert.False(t, deleteCalled, "should not call RGW delete for a foreign account")
 	})

--- a/pkg/operator/k8sutil/job.go
+++ b/pkg/operator/k8sutil/job.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	batch "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -38,7 +39,7 @@ func RunReplaceableJob(ctx context.Context, clientset kubernetes.Interface, job 
 	if err != nil && !errors.IsNotFound(err) {
 		logger.Warningf("failed to detect job %s. %+v", job.Name, err)
 	} else if err == nil {
-		// if the job is still running, and the caller has not asked for deletion,
+		// if the caller has not asked for deletion,
 		// allow it to continue to completion
 		if existingJob.Status.Active > 0 && !deleteIfFound {
 			logger.Infof("Found previous job %s. Status=%+v", job.Name, existingJob.Status)
@@ -51,6 +52,20 @@ func RunReplaceableJob(ctx context.Context, clientset kubernetes.Interface, job 
 		if err != nil {
 			return fmt.Errorf("failed to remove job %s. %+v", job.Name, err)
 		}
+	}
+
+	_, err = clientset.BatchV1().Jobs(job.Namespace).Create(ctx, job, metav1.CreateOptions{})
+	return err
+}
+
+func RunJob(ctx context.Context, clientset kubernetes.Interface, job *batch.Job) error {
+	// check if the job was already created and what its status is
+	existingJob, err := clientset.BatchV1().Jobs(job.Namespace).Get(ctx, job.Name, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		logger.Warningf("failed to detect job %s. %+v", job.Name, err)
+	} else if err == nil {
+		logger.Infof("Found previous job %s. Status=%+v", job.Name, existingJob.Status)
+		return nil
 	}
 
 	_, err = clientset.BatchV1().Jobs(job.Namespace).Create(ctx, job, metav1.CreateOptions{})
@@ -102,4 +117,24 @@ func AddRookVersionLabelToJob(j *batch.Job) {
 		j.Labels = map[string]string{}
 	}
 	addRookVersionLabel(j.Labels)
+}
+
+func CheckIfJobIsCompleted(ctx context.Context, clientset kubernetes.Interface, job *batch.Job) (bool, error) {
+	if job == nil {
+		return false, fmt.Errorf("job is nil")
+	}
+
+	existingJob, err := clientset.BatchV1().Jobs(job.Namespace).Get(ctx, job.Name, metav1.GetOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to get job %s. %+v", job.Name, err)
+	}
+
+	for _, condition := range existingJob.Status.Conditions {
+		if condition.Type == batch.JobComplete &&
+			condition.Status == corev1.ConditionTrue {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }


### PR DESCRIPTION
a job is used because purging large
amounts of data can far exceed the operator's
15-second command timeout
The Job retries on failure until the purge
completes or the account no longer exists.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

