### PR TITLE
build: harden the  image build by verifying the s5cmd checksum

### DIFF
--- a/images/ceph/Dockerfile
+++ b/images/ceph/Dockerfile
@@ -18,6 +18,7 @@ FROM BASEIMAGE
 # env vars for s5cmd
 ARG S5CMD_VERSION
 ARG S5CMD_ARCH
+ARG S5CMD_SHA256
 
 # 'ip' tool must be installed for Multus.
 # Doing a 'dnf install' sometimes breaks CI when centos repos go down or have other package build errors.
@@ -26,6 +27,7 @@ RUN dnf install -y --repo baseos --setopt=install_weak_deps=False iproute && dnf
 
 # Install the s5cmd package to interact with s3 gateway
 RUN curl --fail -sSL -o /s5cmd.tar.gz https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_${S5CMD_ARCH}.tar.gz && \
+    echo "${S5CMD_SHA256}  /s5cmd.tar.gz" | sha256sum --status --check - && \
     mkdir /s5cmd && \
     tar xf /s5cmd.tar.gz -C /s5cmd && \
     install /s5cmd/s5cmd /usr/local/bin/s5cmd && \

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -30,18 +30,23 @@ ifeq ($(BUILD_CONTEXT_DIR),)
 BUILD_CONTEXT_DIR := $(shell mktemp -d)
 endif
 
+# s5cmd's version
+S5CMD_VERSION = 2.3.0
+# s5cmd tarball checksums for integrity verification
+S5CMD_SHA256_AMD64 = de0fdbfa3aceae55e069ba81a0fc17b2026567637603734a387b2fca06c299b4
+S5CMD_SHA256_ARM64 = 1439f0d00ecedcd2a2f1f2c6749bbb0152b2257bf5086f29646ec8ae38798e24
 
 ifeq ($(GOARCH),amd64)
 S5CMD_ARCH = Linux-64bit
+S5CMD_SHA256=$(S5CMD_SHA256_AMD64)
 else
 S5CMD_ARCH = Linux-arm64
+S5CMD_SHA256=$(S5CMD_SHA256_ARM64)
 endif
 
 # build by default; allow opt-out by setting to false
 BUILD_CONTAINER_IMAGE ?= true
 
-# s5cmd's version
-S5CMD_VERSION = 2.3.0
 
 YQv3 := $(TOOLS_HOST_DIR)/yq-$(YQv3_VERSION)
 export YQv3
@@ -68,6 +73,7 @@ do.build:
 		$(DOCKERCMD) build --platform linux/$(GOARCH) $(BUILD_ARGS) \
 		--build-arg S5CMD_VERSION=$(S5CMD_VERSION) \
 		--build-arg S5CMD_ARCH=$(S5CMD_ARCH) \
+		--build-arg S5CMD_SHA256=$(S5CMD_SHA256) \
 		-t $(CEPH_IMAGE) \
 		$(BUILD_CONTEXT_DIR);\
 	fi


### PR DESCRIPTION
the container image build fetches and installs s5cmd.

This was done without verifying the checksum of the downloaded file.

This change hardens the build by verifying the checksum of the downloaded tarball.


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary (under the `Documentation` folder).
- [x] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [x] Integration tests have been added, if necessary (in the `tests/integration` folder).

