### PR TITLE
ci: assign backport PRs to the author and merger

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,12 @@
+# set here rather than on each backport rule so the `@Mergifyio backport`
+# command picks it up too
+defaults:
+  actions:
+    backport:
+      assignees:
+        - "{{ author }}"
+        - "{{ merged_by }}"
+
 pull_request_rules:
   # if there is a conflict in a backport PR, ping the author to send a proper backport PR
   - name: ping author on conflicts


### PR DESCRIPTION
Mergify creates backport pull requests unassigned, and they are authored by `mergify[bot]`. Filtering the pull request list by author or assignee — how I track my own in-flight work — therefore never surfaces the backports of my own changes, and I have been assigning myself to each one by hand so as not to lose track of them.

**What changed**

Backport pull requests created by Mergify are now assigned to the original pull request's author and to the user who merged it. This applies both to the `backport-release-*` labels and to the `@Mergifyio backport` command.

**Notable decisions**

The option is set in the top-level `defaults` section rather than repeated on each of the four backport rules, because `defaults` also applies to actions run by commands, so `@Mergifyio backport` inherits it.

`{{ merged_by }}` means a maintainer who merges someone else's pull request is assigned its backports. I would rather have that than drop it: `{{ author }}` alone leaves external contributors' backports unassigned, since GitHub silently ignores assignees without push access. Happy to remove it if others would rather not be enrolled.

AI assistance: an agent researched Mergify's `defaults` and backport-assignee semantics against the documentation and the engine's own implementation, wrote the configuration change and the commit message, and adversarially reviewed the branch.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
