### PR TITLE
ceph: reserve CSI keyring names in CephClient validation

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -6,6 +6,13 @@
 - The OSD prepare job now fails, and is retried by Kubernetes, when a freshly prepared device is
   missing from the `ceph-volume raw list` output, instead of silently reporting fewer OSDs than
   were prepared (which left OSDs registered in the osdmap with no OSD deployment created).
+- `CephClient` CRs are no longer allowed to use a name that resolves to one of Rook's own CSI
+  keyring usernames (`csi-rbd-node`, `csi-rbd-provisioner`, `csi-cephfs-node`,
+  `csi-cephfs-provisioner`, including rotated-generation suffixes such as `csi-rbd-node.1`). If
+  you already have a `CephClient` CR using one of these names, it will start failing
+  reconciliation with an `ignoring reserved name` error; delete it and recreate it under a
+  non-reserved name. Deleting such a CR is safe: Rook now skips deleting the underlying keyring
+  for a reserved name instead of removing the live CSI entity.
 
 ## Features
 

--- a/pkg/operator/ceph/client/controller.go
+++ b/pkg/operator/ceph/client/controller.go
@@ -374,10 +374,23 @@ func (r *ReconcileCephClient) reconcileCephClientSecret(
 	return k8sutil.UpdateSecretIfOwnedBy(r.clusterInfo.Context, r.context.Clientset, secret)
 }
 
+// reservedClientNames matches cephx entity names that Rook manages itself (the admin user,
+// daemon bootstrap keys, and Rook's own CSI keyrings, including rotated generations of the
+// latter). A CephClient CR must never be allowed to create, update, or delete one of these.
+var reservedClientNames = regexp.MustCompile(`^admin$|^rgw.*$|^rbd-mirror$|^osd.[0-9]*$|^bootstrap-(mds|mgr|mon|osd|rgw|rbd-mirror)$|^rbd-mirror-peer$|^csi-(rbd|cephfs)-(provisioner|node)(\.[0-9]+)?$`)
+
 // Delete the client
 func (r *ReconcileCephClient) deleteClient(cephClient *cephv1.CephClient) error {
 	clientName := getClientName(cephClient)
 	nsName := opcontroller.NsName(cephClient.Namespace, cephClient.Name)
+
+	// Never delete a cephx entity Rook manages itself, even if a CephClient CR was created
+	// with a colliding name. This CR did not create the entity, so it must not destroy it.
+	if reservedClientNames.MatchString(clientName) {
+		log.NamedWarning(nsName, logger, "not deleting ceph client %q since it is a reserved name that Rook manages itself", clientName)
+		return nil
+	}
+
 	log.NamedInfo(nsName, logger, "deleting client object %q", clientName)
 
 	if err := cephclient.AuthDelete(r.context, r.clusterInfo, generateClientName(clientName)); err != nil {
@@ -390,10 +403,9 @@ func (r *ReconcileCephClient) deleteClient(cephClient *cephv1.CephClient) error 
 
 // ValidateClient the client arguments
 func ValidateClient(context *clusterd.Context, cephClient *cephv1.CephClient) error {
-	reservedNames := regexp.MustCompile("^admin$|^rgw.*$|^rbd-mirror$|^osd.[0-9]*$|^bootstrap-(mds|mgr|mon|osd|rgw|rbd-mirror)$|^rbd-mirror-peer$")
 	clientName := getClientName(cephClient)
 	// validate the Client name
-	if reservedNames.Match([]byte(clientName)) {
+	if reservedClientNames.MatchString(clientName) {
 		return errors.Errorf("ignoring reserved name %q", clientName)
 	}
 

--- a/pkg/operator/ceph/client/controller_test.go
+++ b/pkg/operator/ceph/client/controller_test.go
@@ -71,6 +71,60 @@ func TestValidateClient(t *testing.T) {
 	}
 	err = ValidateClient(context, &p)
 	assert.Nil(t, err)
+
+	// reject names that collide with Rook's own CSI keyrings, including rotated
+	// generations of those keyrings
+	for _, csiName := range []string{
+		"csi-rbd-node",
+		"csi-rbd-provisioner",
+		"csi-cephfs-node",
+		"csi-cephfs-provisioner",
+		"csi-rbd-node.1",
+		"csi-cephfs-provisioner.42",
+	} {
+		p = cephv1.CephClient{ObjectMeta: metav1.ObjectMeta{Name: csiName, Namespace: "myns"}}
+		p.Spec.Caps = map[string]string{"mon": "allow r"}
+		err = ValidateClient(context, &p)
+		assert.NotNil(t, err, "expected %q to be rejected as a reserved CSI keyring name", csiName)
+	}
+}
+
+func TestDeleteClient(t *testing.T) {
+	// deleteClient must never issue `ceph auth del` against a cephx entity Rook manages
+	// itself (here, a CSI keyring), even if a CephClient CR was created with a colliding
+	// name. Rook did not create that entity through the CR, so it must not destroy it.
+	for _, tc := range []struct {
+		name             string
+		clientName       string
+		expectAuthDelete bool
+	}{
+		{name: "reserved CSI name is not deleted", clientName: "csi-rbd-node", expectAuthDelete: false},
+		{name: "reserved CSI name with generation suffix is not deleted", clientName: "csi-cephfs-provisioner.1", expectAuthDelete: false},
+		{name: "non-reserved name is deleted normally", clientName: "my-client", expectAuthDelete: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			authDeleteCalled := false
+			executor := &exectest.MockExecutor{
+				MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+					if len(args) >= 2 && args[0] == "auth" && args[1] == "del" {
+						authDeleteCalled = true
+					}
+					return "", nil
+				},
+			}
+			r := &ReconcileCephClient{
+				context:     &clusterd.Context{Executor: executor},
+				clusterInfo: &cephclient.ClusterInfo{Context: context.TODO()},
+			}
+			cephClient := &cephv1.CephClient{
+				ObjectMeta: metav1.ObjectMeta{Name: tc.clientName, Namespace: "rook-ceph"},
+			}
+
+			err := r.deleteClient(cephClient)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectAuthDelete, authDeleteCalled)
+		})
+	}
 }
 
 func TestGenerateClient(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

`ValidateClient` rejects a `CephClient` whose resolved name collides with `admin`,
`rgw*`, `rbd-mirror`, `osd.N`, and the daemon `bootstrap-*` keys, but the
reserved-name list omitted Rook's own CSI keyrings (`csi-rbd-node`,
`csi-rbd-provisioner`, `csi-cephfs-node`, `csi-cephfs-provisioner`). A `CephClient`
CR with one of those names was accepted, so `createOrUpdateClient` would overwrite
the live CSI entity's caps via `AuthUpdateCaps`, and deleting that CR would call
`AuthDelete` on the live CSI keyring unconditionally, since `deleteClient` never
checked the reserved-name list at all.

This extends the reserved-name regex to cover the four CSI usernames, including
their key-rotation generation suffix (`csi-rbd-node.1`, etc.), shares it between
`ValidateClient` and a new guard in `deleteClient`, and adds unit test coverage
for both paths.

**Issue resolved by this Pull Request:**
Resolves #18150

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [x] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

---
AI assistance: this change was drafted with Claude Code.