### PR TITLE
docs: describe how quotas and pool parameters behave when removed

### DIFF
--- a/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md
+++ b/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md
@@ -246,6 +246,9 @@ flags are present on RBD volumes.
     * `target_size_ratio:` gives a hint (%) to the Ceph PG autoscaler in terms of expected consumption of the total cluster capacity of a given pool, for more info see the [ceph documentation](https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size)
     * `compression_mode`: Configures data compression at the OSD level. If left unspecified, no compression is performed. Values supported are [these](https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#inline-compression):  `none`, `passive`, `aggressive`, and `force`.  In most cases `aggressive` is appropriate.  Specify `force` only if you really know what you're doing.
 
+    !!! important
+        Rook never unsets a pool property. Removing a parameter leaves the last value Rook wrote set on the pool, unless another spec field supplies one, in which case that field's value is applied on the next reconcile. The fields that can supply one are the deprecated `compressionMode`, `replicated.targetSizeRatio` and `replicated.size`. Some Ceph pool properties also cannot be changed back at all once enabled.
+
 * `mirroring`: Configures Ceph `rbd-mirror` replicaton of the pool to a different Ceph cluster.
     * `enabled`: whether mirroring is enabled on that pool (default: false)
     * `mode`: mirroring mode to run, possible values are "pool", "image" or "init-only" (required). Refer to the [mirroring modes Ceph documentation](https://docs.ceph.com/en/latest/rbd/rbd-mirroring/#enable-mirroring) for more details.
@@ -264,8 +267,8 @@ flags are present on RBD volumes.
     * `maxSize`: quota in bytes as a string with quantity suffixes (e.g. "10Gi")
     * `maxObjects`: quota in objects as an integer
 
-    !!! note
-        A value of 0 disables the quota.
+    !!! important
+        Rook writes only the quotas present in the spec. Removing `maxSize` or `maxObjects` issues no command to Ceph, so the last value Rook wrote stays enforced on the pool. To remove a quota, set `maxSize` to `"0"` or `maxObjects` to `0` instead of deleting the field. If the deprecated `maxBytes` is also set, removing `maxSize` applies `maxBytes` rather than leaving the quota untouched.
 
 ### Add specific pool properties
 

--- a/Documentation/CRDs/Object-Storage/ceph-object-store-user-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-user-crd.md
@@ -43,8 +43,8 @@ spec:
 * `clusterNamespace`: The namespace where the parent CephCluster and CephObjectStore are found. If not specified,
     the user must be in the same namespace as the cluster and object store.
     To enable this feature, the CephObjectStore allowUsersInNamespaces must include the namespace of this user.
-* `quotas`: This represents quota limitation can be set on the user. Please refer [here](https://docs.ceph.com/en/latest/radosgw/admin/#quota-management) for details.
-    * `maxBuckets`: The maximum bucket limit for the user.
+* `quotas`: This represents quota limitation can be set on the user. Please refer [here](https://docs.ceph.com/en/latest/radosgw/admin/#quota-management) for details. `maxSize` and `maxObjects` set to `0` apply a zero quota rather than removing the quota.
+    * `maxBuckets`: The maximum bucket limit for the user (default: 1000).
     * `maxSize`: Maximum size limit of all objects across all the user's buckets.
     * `maxObjects`: Maximum number of objects across all the user's buckets.
 * `capabilities`: Ceph allows users to be given additional permissions. Due to missing APIs in go-ceph for updating the user capabilities, this setting can currently only be used during the creation of the object store user. If a user's capabilities need modified, the user must be deleted and re-created.

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -13147,7 +13147,8 @@ int
 </td>
 <td>
 <em>(Optional)</em>
-<p>Maximum bucket limit for the ceph user</p>
+<p>Maximum bucket limit for the ceph user
+Rook applies a default limit of 1000 buckets when this is not set.</p>
 </td>
 </tr>
 <tr>
@@ -13160,7 +13161,8 @@ k8s.io/apimachinery/pkg/api/resource.Quantity
 <td>
 <em>(Optional)</em>
 <p>Maximum size limit of all objects across all the user&rsquo;s buckets
-See <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity">https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity</a> for more info.</p>
+See <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity">https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity</a> for more info.
+Setting this to 0 applies a limit of 0 rather than removing the quota.</p>
 </td>
 </tr>
 <tr>
@@ -13172,7 +13174,8 @@ int64
 </td>
 <td>
 <em>(Optional)</em>
-<p>Maximum number of objects across all the user&rsquo;s buckets</p>
+<p>Maximum number of objects across all the user&rsquo;s buckets
+Setting this to 0 applies a limit of 0 rather than removing the quota.</p>
 </td>
 </tr>
 </tbody>
@@ -13947,7 +13950,9 @@ QuotaSpec
 </td>
 <td>
 <em>(Optional)</em>
-<p>The quota settings</p>
+<p>The quota settings
+Remove a quota by setting it to zero; deleting the field does not clear the
+quota on its own. See the individual fields for what removal does.</p>
 </td>
 </tr>
 <tr>
@@ -14134,7 +14139,10 @@ uint64
 <td>
 <em>(Optional)</em>
 <p>MaxBytes represents the quota in bytes
-Deprecated in favor of MaxSize</p>
+Deprecated in favor of MaxSize
+Ignored entirely while MaxSize is set.
+Set this to 0 to remove the quota; removing the field instead leaves the
+last value enforced.</p>
 </td>
 </tr>
 <tr>
@@ -14146,7 +14154,10 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>MaxSize represents the quota in bytes as a string</p>
+<p>MaxSize represents the quota in bytes as a string
+Takes precedence over MaxBytes, which is ignored while this is set.
+Set this to the string &ldquo;0&rdquo; to remove the quota; removing the field instead
+leaves the last value enforced, or applies MaxBytes when that is also set.</p>
 </td>
 </tr>
 <tr>
@@ -14158,7 +14169,9 @@ uint64
 </td>
 <td>
 <em>(Optional)</em>
-<p>MaxObjects represents the quota in objects</p>
+<p>MaxObjects represents the quota in objects
+Set this to 0 to remove the quota; removing the field instead leaves the
+last value enforced.</p>
 </td>
 </tr>
 </tbody>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -572,21 +572,34 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 quotas:
-                  description: The quota settings
+                  description: |-
+                    The quota settings
+                    Remove a quota by setting it to zero; deleting the field does not clear the
+                    quota on its own. See the individual fields for what removal does.
                   nullable: true
                   properties:
                     maxBytes:
                       description: |-
                         MaxBytes represents the quota in bytes
                         Deprecated in favor of MaxSize
+                        Ignored entirely while MaxSize is set.
+                        Set this to 0 to remove the quota; removing the field instead leaves the
+                        last value enforced.
                       format: int64
                       type: integer
                     maxObjects:
-                      description: MaxObjects represents the quota in objects
+                      description: |-
+                        MaxObjects represents the quota in objects
+                        Set this to 0 to remove the quota; removing the field instead leaves the
+                        last value enforced.
                       format: int64
                       type: integer
                     maxSize:
-                      description: MaxSize represents the quota in bytes as a string
+                      description: |-
+                        MaxSize represents the quota in bytes as a string
+                        Takes precedence over MaxBytes, which is ignored while this is set.
+                        Set this to the string "0" to remove the quota; removing the field instead
+                        leaves the last value enforced, or applies MaxBytes when that is also set.
                       pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                       type: string
                   type: object
@@ -8079,21 +8092,34 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       quotas:
-                        description: The quota settings
+                        description: |-
+                          The quota settings
+                          Remove a quota by setting it to zero; deleting the field does not clear the
+                          quota on its own. See the individual fields for what removal does.
                         nullable: true
                         properties:
                           maxBytes:
                             description: |-
                               MaxBytes represents the quota in bytes
                               Deprecated in favor of MaxSize
+                              Ignored entirely while MaxSize is set.
+                              Set this to 0 to remove the quota; removing the field instead leaves the
+                              last value enforced.
                             format: int64
                             type: integer
                           maxObjects:
-                            description: MaxObjects represents the quota in objects
+                            description: |-
+                              MaxObjects represents the quota in objects
+                              Set this to 0 to remove the quota; removing the field instead leaves the
+                              last value enforced.
                             format: int64
                             type: integer
                           maxSize:
-                            description: MaxSize represents the quota in bytes as a string
+                            description: |-
+                              MaxSize represents the quota in bytes as a string
+                              Takes precedence over MaxBytes, which is ignored while this is set.
+                              Set this to the string "0" to remove the quota; removing the field instead
+                              leaves the last value enforced, or applies MaxBytes when that is also set.
                             pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                             type: string
                         type: object
@@ -8308,21 +8334,34 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
+                      description: |-
+                        The quota settings
+                        Remove a quota by setting it to zero; deleting the field does not clear the
+                        quota on its own. See the individual fields for what removal does.
                       nullable: true
                       properties:
                         maxBytes:
                           description: |-
                             MaxBytes represents the quota in bytes
                             Deprecated in favor of MaxSize
+                            Ignored entirely while MaxSize is set.
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
+                          description: |-
+                            MaxObjects represents the quota in objects
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
+                          description: |-
+                            MaxSize represents the quota in bytes as a string
+                            Takes precedence over MaxBytes, which is ignored while this is set.
+                            Set this to the string "0" to remove the quota; removing the field instead
+                            leaves the last value enforced, or applies MaxBytes when that is also set.
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
@@ -13294,21 +13333,34 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
+                      description: |-
+                        The quota settings
+                        Remove a quota by setting it to zero; deleting the field does not clear the
+                        quota on its own. See the individual fields for what removal does.
                       nullable: true
                       properties:
                         maxBytes:
                           description: |-
                             MaxBytes represents the quota in bytes
                             Deprecated in favor of MaxSize
+                            Ignored entirely while MaxSize is set.
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
+                          description: |-
+                            MaxObjects represents the quota in objects
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
+                          description: |-
+                            MaxSize represents the quota in bytes as a string
+                            Takes precedence over MaxBytes, which is ignored while this is set.
+                            Set this to the string "0" to remove the quota; removing the field instead
+                            leaves the last value enforced, or applies MaxBytes when that is also set.
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
@@ -14970,21 +15022,34 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
+                      description: |-
+                        The quota settings
+                        Remove a quota by setting it to zero; deleting the field does not clear the
+                        quota on its own. See the individual fields for what removal does.
                       nullable: true
                       properties:
                         maxBytes:
                           description: |-
                             MaxBytes represents the quota in bytes
                             Deprecated in favor of MaxSize
+                            Ignored entirely while MaxSize is set.
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
+                          description: |-
+                            MaxObjects represents the quota in objects
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
+                          description: |-
+                            MaxSize represents the quota in bytes as a string
+                            Takes precedence over MaxBytes, which is ignored while this is set.
+                            Set this to the string "0" to remove the quota; removing the field instead
+                            leaves the last value enforced, or applies MaxBytes when that is also set.
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
@@ -15728,11 +15793,15 @@ spec:
                   nullable: true
                   properties:
                     maxBuckets:
-                      description: Maximum bucket limit for the ceph user
+                      description: |-
+                        Maximum bucket limit for the ceph user
+                        Rook applies a default limit of 1000 buckets when this is not set.
                       nullable: true
                       type: integer
                     maxObjects:
-                      description: Maximum number of objects across all the user's buckets
+                      description: |-
+                        Maximum number of objects across all the user's buckets
+                        Setting this to 0 applies a limit of 0 rather than removing the quota.
                       format: int64
                       nullable: true
                       type: integer
@@ -15743,6 +15812,7 @@ spec:
                       description: |-
                         Maximum size limit of all objects across all the user's buckets
                         See https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity for more info.
+                        Setting this to 0 applies a limit of 0 rather than removing the quota.
                       nullable: true
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
@@ -16109,21 +16179,34 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
+                      description: |-
+                        The quota settings
+                        Remove a quota by setting it to zero; deleting the field does not clear the
+                        quota on its own. See the individual fields for what removal does.
                       nullable: true
                       properties:
                         maxBytes:
                           description: |-
                             MaxBytes represents the quota in bytes
                             Deprecated in favor of MaxSize
+                            Ignored entirely while MaxSize is set.
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
+                          description: |-
+                            MaxObjects represents the quota in objects
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
+                          description: |-
+                            MaxSize represents the quota in bytes as a string
+                            Takes precedence over MaxBytes, which is ignored while this is set.
+                            Set this to the string "0" to remove the quota; removing the field instead
+                            leaves the last value enforced, or applies MaxBytes when that is also set.
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
@@ -16333,21 +16416,34 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
+                      description: |-
+                        The quota settings
+                        Remove a quota by setting it to zero; deleting the field does not clear the
+                        quota on its own. See the individual fields for what removal does.
                       nullable: true
                       properties:
                         maxBytes:
                           description: |-
                             MaxBytes represents the quota in bytes
                             Deprecated in favor of MaxSize
+                            Ignored entirely while MaxSize is set.
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
+                          description: |-
+                            MaxObjects represents the quota in objects
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
+                          description: |-
+                            MaxSize represents the quota in bytes as a string
+                            Takes precedence over MaxBytes, which is ignored while this is set.
+                            Set this to the string "0" to remove the quota; removing the field instead
+                            leaves the last value enforced, or applies MaxBytes when that is also set.
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -574,21 +574,34 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 quotas:
-                  description: The quota settings
+                  description: |-
+                    The quota settings
+                    Remove a quota by setting it to zero; deleting the field does not clear the
+                    quota on its own. See the individual fields for what removal does.
                   nullable: true
                   properties:
                     maxBytes:
                       description: |-
                         MaxBytes represents the quota in bytes
                         Deprecated in favor of MaxSize
+                        Ignored entirely while MaxSize is set.
+                        Set this to 0 to remove the quota; removing the field instead leaves the
+                        last value enforced.
                       format: int64
                       type: integer
                     maxObjects:
-                      description: MaxObjects represents the quota in objects
+                      description: |-
+                        MaxObjects represents the quota in objects
+                        Set this to 0 to remove the quota; removing the field instead leaves the
+                        last value enforced.
                       format: int64
                       type: integer
                     maxSize:
-                      description: MaxSize represents the quota in bytes as a string
+                      description: |-
+                        MaxSize represents the quota in bytes as a string
+                        Takes precedence over MaxBytes, which is ignored while this is set.
+                        Set this to the string "0" to remove the quota; removing the field instead
+                        leaves the last value enforced, or applies MaxBytes when that is also set.
                       pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                       type: string
                   type: object
@@ -8074,21 +8087,34 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       quotas:
-                        description: The quota settings
+                        description: |-
+                          The quota settings
+                          Remove a quota by setting it to zero; deleting the field does not clear the
+                          quota on its own. See the individual fields for what removal does.
                         nullable: true
                         properties:
                           maxBytes:
                             description: |-
                               MaxBytes represents the quota in bytes
                               Deprecated in favor of MaxSize
+                              Ignored entirely while MaxSize is set.
+                              Set this to 0 to remove the quota; removing the field instead leaves the
+                              last value enforced.
                             format: int64
                             type: integer
                           maxObjects:
-                            description: MaxObjects represents the quota in objects
+                            description: |-
+                              MaxObjects represents the quota in objects
+                              Set this to 0 to remove the quota; removing the field instead leaves the
+                              last value enforced.
                             format: int64
                             type: integer
                           maxSize:
-                            description: MaxSize represents the quota in bytes as a string
+                            description: |-
+                              MaxSize represents the quota in bytes as a string
+                              Takes precedence over MaxBytes, which is ignored while this is set.
+                              Set this to the string "0" to remove the quota; removing the field instead
+                              leaves the last value enforced, or applies MaxBytes when that is also set.
                             pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                             type: string
                         type: object
@@ -8303,21 +8329,34 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
+                      description: |-
+                        The quota settings
+                        Remove a quota by setting it to zero; deleting the field does not clear the
+                        quota on its own. See the individual fields for what removal does.
                       nullable: true
                       properties:
                         maxBytes:
                           description: |-
                             MaxBytes represents the quota in bytes
                             Deprecated in favor of MaxSize
+                            Ignored entirely while MaxSize is set.
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
+                          description: |-
+                            MaxObjects represents the quota in objects
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
+                          description: |-
+                            MaxSize represents the quota in bytes as a string
+                            Takes precedence over MaxBytes, which is ignored while this is set.
+                            Set this to the string "0" to remove the quota; removing the field instead
+                            leaves the last value enforced, or applies MaxBytes when that is also set.
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
@@ -13283,21 +13322,34 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
+                      description: |-
+                        The quota settings
+                        Remove a quota by setting it to zero; deleting the field does not clear the
+                        quota on its own. See the individual fields for what removal does.
                       nullable: true
                       properties:
                         maxBytes:
                           description: |-
                             MaxBytes represents the quota in bytes
                             Deprecated in favor of MaxSize
+                            Ignored entirely while MaxSize is set.
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
+                          description: |-
+                            MaxObjects represents the quota in objects
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
+                          description: |-
+                            MaxSize represents the quota in bytes as a string
+                            Takes precedence over MaxBytes, which is ignored while this is set.
+                            Set this to the string "0" to remove the quota; removing the field instead
+                            leaves the last value enforced, or applies MaxBytes when that is also set.
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
@@ -14959,21 +15011,34 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
+                      description: |-
+                        The quota settings
+                        Remove a quota by setting it to zero; deleting the field does not clear the
+                        quota on its own. See the individual fields for what removal does.
                       nullable: true
                       properties:
                         maxBytes:
                           description: |-
                             MaxBytes represents the quota in bytes
                             Deprecated in favor of MaxSize
+                            Ignored entirely while MaxSize is set.
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
+                          description: |-
+                            MaxObjects represents the quota in objects
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
+                          description: |-
+                            MaxSize represents the quota in bytes as a string
+                            Takes precedence over MaxBytes, which is ignored while this is set.
+                            Set this to the string "0" to remove the quota; removing the field instead
+                            leaves the last value enforced, or applies MaxBytes when that is also set.
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
@@ -15716,11 +15781,15 @@ spec:
                   nullable: true
                   properties:
                     maxBuckets:
-                      description: Maximum bucket limit for the ceph user
+                      description: |-
+                        Maximum bucket limit for the ceph user
+                        Rook applies a default limit of 1000 buckets when this is not set.
                       nullable: true
                       type: integer
                     maxObjects:
-                      description: Maximum number of objects across all the user's buckets
+                      description: |-
+                        Maximum number of objects across all the user's buckets
+                        Setting this to 0 applies a limit of 0 rather than removing the quota.
                       format: int64
                       nullable: true
                       type: integer
@@ -15731,6 +15800,7 @@ spec:
                       description: |-
                         Maximum size limit of all objects across all the user's buckets
                         See https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity for more info.
+                        Setting this to 0 applies a limit of 0 rather than removing the quota.
                       nullable: true
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
@@ -16095,21 +16165,34 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
+                      description: |-
+                        The quota settings
+                        Remove a quota by setting it to zero; deleting the field does not clear the
+                        quota on its own. See the individual fields for what removal does.
                       nullable: true
                       properties:
                         maxBytes:
                           description: |-
                             MaxBytes represents the quota in bytes
                             Deprecated in favor of MaxSize
+                            Ignored entirely while MaxSize is set.
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
+                          description: |-
+                            MaxObjects represents the quota in objects
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
+                          description: |-
+                            MaxSize represents the quota in bytes as a string
+                            Takes precedence over MaxBytes, which is ignored while this is set.
+                            Set this to the string "0" to remove the quota; removing the field instead
+                            leaves the last value enforced, or applies MaxBytes when that is also set.
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
@@ -16319,21 +16402,34 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
-                      description: The quota settings
+                      description: |-
+                        The quota settings
+                        Remove a quota by setting it to zero; deleting the field does not clear the
+                        quota on its own. See the individual fields for what removal does.
                       nullable: true
                       properties:
                         maxBytes:
                           description: |-
                             MaxBytes represents the quota in bytes
                             Deprecated in favor of MaxSize
+                            Ignored entirely while MaxSize is set.
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxObjects:
-                          description: MaxObjects represents the quota in objects
+                          description: |-
+                            MaxObjects represents the quota in objects
+                            Set this to 0 to remove the quota; removing the field instead leaves the
+                            last value enforced.
                           format: int64
                           type: integer
                         maxSize:
-                          description: MaxSize represents the quota in bytes as a string
+                          description: |-
+                            MaxSize represents the quota in bytes as a string
+                            Takes precedence over MaxBytes, which is ignored while this is set.
+                            Set this to the string "0" to remove the quota; removing the field instead
+                            leaves the last value enforced, or applies MaxBytes when that is also set.
                           pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object

--- a/deploy/examples/object-user.yaml
+++ b/deploy/examples/object-user.yaml
@@ -13,7 +13,7 @@ spec:
   displayName: "my display name"
   # Quotas set on the user
   # quotas:
-  #   maxBuckets: 100
+  #   maxBuckets: 100 # Rook applies a default limit of 1000 buckets if unset
   #   maxSize: 10G
   #   maxObjects: 10000
   # Additional permissions given to the user

--- a/deploy/examples/pool-ec.yaml
+++ b/deploy/examples/pool-ec.yaml
@@ -17,7 +17,10 @@ spec:
     dataChunks: 2
     codingChunks: 1
   # Set any property on a given pool
-  # see https://docs.ceph.com/docs/master/rados/operations/pools/#set-pool-values
+  # see https://docs.ceph.com/docs/master/rados/operations/pools/#setting-pool-values
+  # Removing a parameter does not reset it. Modify values to the desired state
+  # after a parameter key is defined.
+  # Ceph does not allow disabling allow_ec_optimizations once it is enabled.
   parameters:
     # Inline compression mode for the data pool
     compression_mode: none

--- a/deploy/examples/pool.yaml
+++ b/deploy/examples/pool.yaml
@@ -39,7 +39,9 @@ spec:
   # For reference: https://docs.ceph.com/docs/master/mgr/prometheus/#rbd-io-statistics
   # enableRBDStats: true
   # Set any property on a given pool
-  # see https://docs.ceph.com/docs/master/rados/operations/pools/#set-pool-values
+  # see https://docs.ceph.com/docs/master/rados/operations/pools/#setting-pool-values
+  # Removing a parameter does not reset it. Modify values to the desired state
+  # after a parameter key is defined.
   parameters:
     # Inline compression mode for the data pool
     # Further reference: https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#inline-compression
@@ -62,7 +64,9 @@ spec:
       disabled: false
       interval: 60s
   # quota in bytes and/or objects, default value is 0 (unlimited)
-  # see https://docs.ceph.com/en/latest/rados/operations/pools/#set-pool-quotas
+  # see https://docs.ceph.com/en/latest/rados/operations/pools/#setting-pool-quotas
+  # To remove a quota set maxSize to "0" or maxObjects to 0; deleting the
+  # setting instead leaves the last value Rook wrote enforced on the pool
   # quotas:
   #   maxSize: "10Gi" # valid suffixes include k, M, G, T, P, E, Ki, Mi, Gi, Ti, Pi, Ei
   #   maxObjects: 1000000000 # 1 billion objects

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1141,6 +1141,8 @@ type PoolSpec struct {
 	StatusCheck MirrorHealthCheckSpec `json:"statusCheck,omitempty"`
 
 	// The quota settings
+	// Remove a quota by setting it to zero; deleting the field does not clear the
+	// quota on its own. See the individual fields for what removal does.
 	// +optional
 	// +nullable
 	Quotas QuotaSpec `json:"quotas,omitempty"`
@@ -1464,15 +1466,23 @@ type SnapshotScheduleSpec struct {
 type QuotaSpec struct {
 	// MaxBytes represents the quota in bytes
 	// Deprecated in favor of MaxSize
+	// Ignored entirely while MaxSize is set.
+	// Set this to 0 to remove the quota; removing the field instead leaves the
+	// last value enforced.
 	// +optional
 	MaxBytes *uint64 `json:"maxBytes,omitempty"`
 
 	// MaxSize represents the quota in bytes as a string
+	// Takes precedence over MaxBytes, which is ignored while this is set.
+	// Set this to the string "0" to remove the quota; removing the field instead
+	// leaves the last value enforced, or applies MaxBytes when that is also set.
 	// +kubebuilder:validation:Pattern=`^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$`
 	// +optional
 	MaxSize *string `json:"maxSize,omitempty"`
 
 	// MaxObjects represents the quota in objects
+	// Set this to 0 to remove the quota; removing the field instead leaves the
+	// last value enforced.
 	// +optional
 	MaxObjects *uint64 `json:"maxObjects,omitempty"`
 }
@@ -2558,15 +2568,18 @@ type ObjectUserCapSpec struct {
 // ObjectUserQuotaSpec can be used to set quotas for the object store user to limit their usage. See the [Ceph docs](https://docs.ceph.com/en/latest/radosgw/admin/?#quota-management) for more
 type ObjectUserQuotaSpec struct {
 	// Maximum bucket limit for the ceph user
+	// Rook applies a default limit of 1000 buckets when this is not set.
 	// +optional
 	// +nullable
 	MaxBuckets *int `json:"maxBuckets,omitempty"`
 	// Maximum size limit of all objects across all the user's buckets
 	// See https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity for more info.
+	// Setting this to 0 applies a limit of 0 rather than removing the quota.
 	// +optional
 	// +nullable
 	MaxSize *resource.Quantity `json:"maxSize,omitempty"`
 	// Maximum number of objects across all the user's buckets
+	// Setting this to 0 applies a limit of 0 rather than removing the quota.
 	// +optional
 	// +nullable
 	MaxObjects *int64 `json:"maxObjects,omitempty"`


### PR DESCRIPTION
**Motivation**

The CephBlockPool guide's only statement about clearing a pool quota is "A value of 0 disables the quota", which reads as a complete account of the subject. It is not. Removing `maxSize`, `maxBytes` or `maxObjects` from a CR issues no `ceph osd pool set-quota` command for that quota, so the last value Rook wrote stays enforced on the pool. An administrator who deletes the field in order to lift a quota leaves it in place.

**What changed**

Documentation only; no behavior change.

* Each `QuotaSpec` field now states that removal leaves the last value enforced and that zero is what clears a quota. This reaches every CRD embedding `PoolSpec`: CephBlockPool, CephFilesystem, CephObjectStore and CephObjectZone. `maxBytes` is documented as ignored while `maxSize` is set.
* Pool `parameters` get a matching warning, since they are never unset either and some are re-supplied from other spec fields.
* `CephObjectStoreUser` quotas look identical but behave the opposite way, which was documented nowhere. Rook rewrites that quota on every reconcile, so deleting `maxSize` or `maxObjects` does clear it, `0` applies a limit of zero rather than removing it, and deleting `maxBuckets` restores Rook's hardcoded 1000.
* Three Ceph documentation links in the pool samples used anchors that do not exist on the linked page.

**Notable decisions**

The pool behavior is documented rather than fixed. Clearing a quota on removal would issue `set-quota ... 0` against pools whose quota was set out of band with the Ceph CLI, and `CephObjectStore.spec.metadataPool` reaches `.rgw.root`, which is shared cluster-wide. Whether to change that is tracked in #18154 — a non-closing reference, since this documents the behavior rather than changing it.

**AI assistance:** an AI agent audited the reconcile paths, drafted the documentation wording, and regenerated the CRD artifacts.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
