### PR TITLE
core: fix isatleast func to compare build number

### DIFF
--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -175,6 +175,12 @@ func (v *CephVersion) IsAtLeast(other CephVersion) bool {
 	} else if v.Extra < other.Extra {
 		return false
 	}
+	// If we arrive here then v.Extra == other.Extra
+	if v.Build > other.Build {
+		return true
+	} else if v.Build < other.Build {
+		return false
+	}
 	// If we arrive here then both versions are identical
 	return true
 }

--- a/pkg/operator/ceph/version/version_test.go
+++ b/pkg/operator/ceph/version/version_test.go
@@ -128,6 +128,11 @@ func TestVersionAtLeast(t *testing.T) {
 	assert.True(t, (&CephVersion{1, 1, 1, 0, ""}).IsAtLeast(CephVersion{1, 1, 0, 0, ""}))
 	assert.False(t, (&CephVersion{1, 1, 0, 0, ""}).IsAtLeast(CephVersion{1, 1, 1, 0, ""}))
 	assert.True(t, (&CephVersion{1, 1, 1, 0, ""}).IsAtLeast(CephVersion{1, 1, 1, 0, ""}))
+
+	// Build number comparisons
+	assert.True(t, (&CephVersion{20, 2, 1, 324, ""}).IsAtLeast(CephVersion{20, 2, 1, 297, ""}))
+	assert.False(t, (&CephVersion{20, 2, 1, 294, ""}).IsAtLeast(CephVersion{20, 2, 1, 297, ""}))
+	assert.True(t, (&CephVersion{20, 2, 1, 297, ""}).IsAtLeast(CephVersion{20, 2, 1, 297, ""}))
 }
 
 func TestVersionAtLeastX(t *testing.T) {


### PR DESCRIPTION
IsAtleast ignored teh build number field causing the AES256KKeySupport func to return true for the build 294 (< 297 threshbold). This made the operator run allowed chipers against the daemons that don't support it.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

