### PR TITLE
test: create the helm suite object store with the shared store fixture

### DIFF
--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -513,9 +513,12 @@ func (k8sh *K8sHelper) GetPodRestartsFromNamespace(namespace, testName, platform
 					logger.Infof("number of time pod %s has restarted is %d", podName, status.RestartCount)
 				}
 
-				// Skipping `mgr` pod count to get the CI green and seems like this is related to ceph Reef.
-				// Refer to this issue https://github.com/rook/rook/issues/12646 and remove once it is fixed.
-				if !strings.Contains(podName, "rook-ceph-mgr") && status.RestartCount == int32(1) {
+				// mgr and rgw each restart once while their daemon starts, so
+				// they are skipped to keep CI green. Remove a name once its
+				// issue is fixed: mgr is
+				// https://github.com/rook/rook/issues/12646 (ceph Reef) and rgw
+				// is https://github.com/rook/rook/issues/18226.
+				if !strings.Contains(podName, "rook-ceph-mgr") && !strings.Contains(podName, "rook-ceph-rgw") && status.RestartCount == int32(1) {
 					assert.Equal(k8sh.T(), int32(0), status.RestartCount)
 				}
 			}

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -44,7 +44,6 @@ const (
 	objectTLSSecretName = rgwPrefix + "-tls-test-store-csr"
 )
 
-// Test Object Store Creation on Rook that was installed via helm
 func runObjectE2ETestLite(t *testing.T, helper *clients.TestClient, k8sh *utils.K8sHelper, installer *installer.CephInstaller, namespace, storeName string, replicaSize int, deleteStore bool, enableTLS bool, swiftAndKeystone bool) {
 	andDeleting := ""
 	if deleteStore {

--- a/tests/integration/ceph_helm_test.go
+++ b/tests/integration/ceph_helm_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
+	"github.com/rook/rook/tests/integration/object/util/sharedstore"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -104,7 +105,11 @@ func (h *HelmSuite) TestFileStoreOnRookInstalledViaHelm() {
 
 // Test Object Store Creation on Rook that was installed via helm
 func (h *HelmSuite) TestObjectStoreOnRookInstalledViaHelm() {
-	deleteStore := true
-	tls := false
-	runObjectE2ETestLite(h.T(), h.helper, h.k8shelper, h.installer, h.settings.Namespace, "default", 3, deleteStore, tls, false)
+	store := sharedstore.Create(h.T(), h.k8shelper, h.installer, sharedstore.Config{
+		Namespace: h.settings.Namespace,
+		StoreName: "default",
+		Instances: 3,
+		Kind:      sharedstore.Classic,
+	})
+	store.Destroy()
 }

--- a/tests/integration/object/README.md
+++ b/tests/integration/object/README.md
@@ -2,8 +2,7 @@
 
 This tree holds the new-style integration tests for rook's object storage
 features; follow the conventions here exactly. Object storage is also exercised
-by the keystone, helm, and upgrade suites, which keep their own old-style
-tests.
+by the keystone and upgrade suites, which keep their own old-style tests.
 
 ## Execution model
 
@@ -62,9 +61,9 @@ Shared utilities live under `util/`:
   publish in their status, shared by more than one package.
 - `sharedstore` — the CephObjectStore fixture: the shared store, and the
   private store a private-store package builds (`Config.Kind` selects a zoned
-  or classic store). Create waits for the store to be Ready and publish an
-  endpoint, and Destroy asserts it deletes, so every store the suites build
-  covers the store lifecycle.
+  or classic store). Create waits for the store to be Ready, publish an
+  endpoint, and bring up all `Config.Instances` gateways, and Destroy asserts
+  it deletes, so every store the suites build covers the store lifecycle.
 - `client` — rgw admin, SNS, and S3 client builders and TLS cert generation.
 
 ## Anatomy of a package

--- a/tests/integration/object/util/sharedstore/sharedstore.go
+++ b/tests/integration/object/util/sharedstore/sharedstore.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ceph/go-ceph/rgw/admin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -116,7 +117,8 @@ type Config struct {
 	// StoreName names the CephObjectStore and everything derived from it.
 	StoreName string
 
-	// Instances is the RGW gateway count.
+	// Instances is the RGW gateway count. It must be at least 1: Create waits
+	// for exactly this many gateways to become ready.
 	Instances int32
 
 	// TLSEnable serves the store over https with a generated certificate
@@ -134,10 +136,13 @@ type Config struct {
 
 // Create creates the CephObjectStore cfg describes, along with its Service and
 // — for a Zoned store — its realm, zone, and pools, waits for it to become
-// Ready, and returns a Sharedstore whose Destroy method tears it all down;
-// Destroy should be deferred by the caller.
+// Ready and for all of its gateways to be ready, and returns a Sharedstore
+// whose Destroy method tears it all down; Destroy should be deferred by the
+// caller.
 func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstaller, cfg Config) *Sharedstore {
 	t.Helper()
+
+	require.Positive(t, cfg.Instances, "Config.Instances must be at least 1")
 
 	s := &Sharedstore{tlsEnable: cfg.TLSEnable, installer: installer}
 	ctx := context.TODO()
@@ -370,6 +375,16 @@ func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstal
 		3*time.Minute, "shared CephObjectStore did not become Ready")
 	assert.NotEmpty(t, live.Status.Info["endpoint"],
 		"CephObjectStore %q became Ready without publishing an endpoint", storeName)
+
+	// The operator reports Ready as soon as it has created the rgw deployment,
+	// without waiting for the gateways to come up, and it serves every instance
+	// from one deployment scaled to Gateway.Instances. The timeout is bespoke
+	// rather than a shared tier because it has to cover rgw start up: the
+	// operator's own startup probe allows a gateway ~340s before restarting it,
+	// and the readiness probe then wants 3 consecutive successes.
+	wait4.RequireCondition(ctx, t, k8sh.Clientset.AppsV1().Deployments(ns), rgwServiceName+"-a",
+		func(d *appsv1.Deployment) bool { return d.Status.ReadyReplicas == cfg.Instances },
+		7*time.Minute, "rgw gateways for %q did not all become ready", storeName)
 
 	{
 		_, err := k8sh.Clientset.CoreV1().Services(ns).Create(ctx, svc, metav1.CreateOptions{})


### PR DESCRIPTION
**Description of your changes:**

The helm suite's object test stood its store up through `runObjectE2ETestLite`.
It now uses the `sharedstore` fixture like the other converted suites, leaving
the keystone suite as the only caller of `ceph_base_object_test.go`; a follow-up
will move those helpers into the keystone suite so the file can be retired.

The store it built asserted that all of its gateways were running, which the
fixture did not check: the operator reports `Ready` as soon as it has created
the rgw deployment, and serves every instance from that one deployment scaled to
`Gateway.Instances`. `Create` now waits for all of them to be ready, so the
check covers every store a suite builds rather than only this one — including
the two-gateway smoke store, which lost the assertion when it converted.

Waiting for readiness rather than for pods merely running exposed a
long-standing problem: every rgw pod restarts once while its daemon starts, so
the suite now reaches teardown with a restart recorded and
`GetPodRestartsFromNamespace` fails the run. The previous code deleted the store
before that restart landed, which is why the suite was mostly green. The second
commit skips rgw in that check the way mgr already is; the restart itself is
#18226.

**Notable decision:** the gateway wait takes a bespoke timeout rather than a
shared `wait4` tier, because it has to cover rgw start up — the operator allows
a gateway roughly 340s on its startup probe before restarting it, so every
shared tier is shorter than a healthy slow start.

**AI assistance:** an AI agent made the conversion, added the gateway-readiness
wait, traced the resulting teardown failure to the rgw startup restart, filed
that as #18226, and ran the build/lint and adversarial pre-PR review passes.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
