### PR TITLE
test: upgrade from a classic object store again

### DIFF
--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -280,10 +280,15 @@ func (s *UpgradeSuite) deployClusterforUpgrade(baseRookImage, objectUserID, preF
 
 	if !s.settings.UseHelm {
 		logger.Infof("Initializing object before the upgrade")
+		// the previous release reconciles this store, so keep it to the classic
+		// shape the suite upgraded from before it moved to the fixture; a zoned
+		// store asks that release for a whole multisite config, and its rgw
+		// never served the admin API
 		s.objectStore = sharedstore.Create(s.T(), s.k8sh, s.installer, sharedstore.Config{
 			Namespace: s.settings.Namespace,
 			StoreName: installer.ObjectStoreName,
 			Instances: 1,
+			Kind:      sharedstore.Classic,
 		})
 	}
 


### PR DESCRIPTION
`TestCephUpgradeSuite (v1.36.1)` fails intermittently on master, in the
fixture's admin client setup: it dials the gateway's cluster IP until the HTTP
client gives up (`dial tcp 10.96.215.253:80: i/o timeout`), which is what an rgw
with no ready endpoints looks like. It reproduced twice on one branch; other
branches carrying the same code have passed, so it is a flake rather than a hard
break.

#17936 moved the suite's pre-upgrade store to the `sharedstore` fixture without
asking for a classic store, so it became a zoned one — a realm, a zonegroup, a
zone and its shared pool placements, all of which the **previous** rook release
(v1.19.5) now has to reconcile, where before it created a store with pools in
its own spec. That is a much larger ask of released code that this suite cannot
fix, and it is the only thing about the store that changed.

This asks for the classic store the suite upgraded from before the conversion.
That removes the dependency rather than proving it guilty — if the flake
survives, the cause is elsewhere and this is still the shape the suite wants.

**AI assistance:** an AI agent traced the failure, established that it is
intermittent rather than deterministic, and made the change.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
