### PR TITLE
mon: bind host network monitors to msgr2 port

### DIFF
--- a/pkg/operator/ceph/cluster/mon/node_test.go
+++ b/pkg/operator/ceph/cluster/mon/node_test.go
@@ -185,6 +185,31 @@ func TestHostNetwork(t *testing.T) {
 	assert.Equal(t, "", val)
 	assert.Equal(t, "arg not found: --public-bind-addr", message)
 
+	// A single-stack, msgr2-only host-network mon needs a port-qualified bind address to avoid
+	// binding a legacy v1 address that may still be present in the monmap.
+	monConfig.Port = DefaultMsgr2Port
+	c.spec.Network.Connections = &cephv1.ConnectionsSpec{RequireMsgr2: true}
+	c.spec.Network.IPFamily = cephv1.IPv4
+	pod, err = c.makeMonPod(monConfig, false)
+	assert.NoError(t, err)
+	val, message = extractArgValue(pod.Spec.Containers[0].Args, "--public-bind-addr")
+	assert.Equal(t, "$(ROOK_POD_IP):3300", val, message)
+
+	c.spec.Network.IPFamily = cephv1.IPv6
+	pod, err = c.makeMonPod(monConfig, false)
+	assert.NoError(t, err)
+	val, message = extractArgValue(pod.Spec.Containers[0].Args, "--public-bind-addr")
+	assert.Equal(t, "[$(ROOK_POD_IP)]:3300", val, message)
+
+	// Preserve Rook's existing dual-stack safety behavior because one port-qualified address cannot
+	// safely represent both address families.
+	c.spec.Network.DualStack = true
+	pod, err = c.makeMonPod(monConfig, false)
+	assert.NoError(t, err)
+	val, message = extractArgValue(pod.Spec.Containers[0].Args, "--public-bind-addr")
+	assert.Equal(t, "", val)
+	assert.Equal(t, "arg not found: --public-bind-addr", message)
+
 	// Host network setting of mons should be maintained even if the cluster spec hostnetwork is different
 	// from the mons to not be using host networking
 	monConfig.UseHostNetwork = false

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -393,10 +393,10 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) corev1.Container 
 	container = config.ConfigureStartupProbe(container, c.spec.HealthCheck.StartupProbe[cephv1.KeyMon])
 	container = config.ConfigureLivenessProbe(container, c.spec.HealthCheck.LivenessProbe[cephv1.KeyMon])
 
-	// If host networking is enabled, we don't need a bind addr that is different from the public addr
-	if !monConfig.UseHostNetwork {
-		// Opposite of the above, --public-bind-addr will *not* still advertise on the previous
-		// port, which makes sense because this is the pod IP, which changes with every new pod.
+	// With host networking, the pod and public addresses are normally the same, so a separate bind
+	// address is unnecessary. However, msgr2-only mons need the port-qualified bind address to avoid
+	// binding a legacy v1 address that may still be present in the monmap.
+	if !monConfig.UseHostNetwork || (monConfig.Port == DefaultMsgr2Port && !c.spec.Network.DualStack) {
 		container.Args = append(container.Args, config.NewFlag("public-bind-addr", bindaddr))
 	}
 


### PR DESCRIPTION
Pass a port-qualified public-bind-addr for single-stack host-network monitors using msgr2. This prevents Ceph from binding a legacy v1 address retained in the monmap when ms_bind_msgr1 is disabled.

Preserve the existing behavior for msgr1 and dual-stack monitors.

See #18171

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

