### PR TITLE
ci: Run canary tests on tentacle instead of squid

### DIFF
--- a/.github/workflows/canary-integration-suite.yml
+++ b/.github/workflows/canary-integration-suite.yml
@@ -31,5 +31,5 @@ jobs:
   canary-tests:
     uses: ./.github/workflows/canary-integration-test.yml
     with:
-      ceph_images: '["quay.io/ceph/ceph:v19"]'
+      ceph_images: '["quay.io/ceph/ceph:v20"]'
     secrets: inherit

--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -616,7 +616,8 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     strategy:
       matrix:
-        ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        # this test fails consistently on v20, still needs investigation
+        ceph-image: ["quay.io/ceph/ceph:v19"]
         kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout


### PR DESCRIPTION
The canary tests running with PRs will now run with the latest Ceph tentacle v20 image instead of squid v19.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

