### PR TITLE
core: don't prepend /dev to a device path that already has it (backport #18080)

### DIFF
--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -132,15 +132,22 @@ func ListDevices(executor exec.Executor) ([]string, error) {
 	return strings.Split(devices, "\n"), nil
 }
 
+// resolveDevicePath returns an absolute path for a device. Callers pass either
+// a bare kernel name ("sdb") or an absolute path, which may be a device node
+// ("/dev/sdb") or a mount point for a PVC-backed block device
+// ("/mnt/<pvc-name>"). Only a bare kernel name needs the /dev prefix; adding it
+// unconditionally would produce "/dev//dev/sdb".
+func resolveDevicePath(device string) string {
+	if len(strings.Split(device, "/")) == 1 {
+		return fmt.Sprintf("/dev/%s", device)
+	}
+
+	return device
+}
+
 // GetDevicePartitions gets partitions on a given device
 func GetDevicePartitions(device string, executor exec.Executor) (partitions []Partition, unusedSpace uint64, err error) {
-	var devicePath string
-	splitDevicePath := strings.Split(device, "/")
-	if len(splitDevicePath) == 1 {
-		devicePath = fmt.Sprintf("/dev/%s", device) // device path for OSD on devices.
-	} else {
-		devicePath = device // use the exact device path (like /mnt/<pvc-name>) in case of PVC block device
-	}
+	devicePath := resolveDevicePath(device)
 
 	output, err := executor.ExecuteCommandWithOutput("lsblk", devicePath,
 		"--bytes", "--pairs", "--output", "NAME,SIZE,TYPE,PKNAME")
@@ -199,14 +206,7 @@ func GetDevicePartitions(device string, executor exec.Executor) (partitions []Pa
 
 // GetDeviceProperties gets device properties
 func GetDeviceProperties(device string, executor exec.Executor) (map[string]string, error) {
-	// As we are mounting the block mode PVs on /mnt we use the entire path,
-	// e.g., if the device path is /mnt/example-pvc then its taken completely
-	// else if its just vdb then the following is used
-	devicePath := strings.Split(device, "/")
-	if len(devicePath) == 1 {
-		device = fmt.Sprintf("/dev/%s", device)
-	}
-	return GetDevicePropertiesFromPath(device, executor)
+	return GetDevicePropertiesFromPath(resolveDevicePath(device), executor)
 }
 
 // GetDevicePropertiesFromPath gets a device property from a path
@@ -237,14 +237,7 @@ func IsLV(devicePath string, executor exec.Executor) (bool, error) {
 
 // GetUdevInfo gets udev information
 func GetUdevInfo(device string, executor exec.Executor) (map[string]string, error) {
-	// The caller may pass either a kernel name ("sdb") or a full device path
-	// ("/dev/sdb"), so only add the /dev prefix when it is missing. Adding it
-	// unconditionally produces "/dev//dev/sdb", which udevadm rejects.
-	devicePath := strings.Split(device, "/")
-	if len(devicePath) == 1 {
-		device = fmt.Sprintf("/dev/%s", device)
-	}
-	output, err := executor.ExecuteCommandWithOutput("udevadm", "info", "--query=property", device)
+	output, err := executor.ExecuteCommandWithOutput("udevadm", "info", "--query=property", resolveDevicePath(device))
 	if err != nil {
 		return nil, err
 	}
@@ -255,10 +248,7 @@ func GetUdevInfo(device string, executor exec.Executor) (map[string]string, erro
 
 // GetDeviceFilesystems get the file systems available
 func GetDeviceFilesystems(device string, executor exec.Executor) (string, error) {
-	devicePath := strings.Split(device, "/")
-	if len(devicePath) == 1 {
-		device = fmt.Sprintf("/dev/%s", device)
-	}
+	device = resolveDevicePath(device)
 	output, err := executor.ExecuteCommandWithOutput("udevadm", "info", "--query=property", device)
 	if err != nil {
 		return "", err
@@ -273,10 +263,7 @@ func GetDiskUUID(device string, executor exec.Executor) (string, error) {
 		return "", errors.Wrap(err, "sgdisk not found")
 	}
 
-	devicePath := strings.Split(device, "/")
-	if len(devicePath) == 1 {
-		device = fmt.Sprintf("/dev/%s", device)
-	}
+	device = resolveDevicePath(device)
 
 	output, err := executor.ExecuteCommandWithOutput(sgdiskCmd, "--print", device)
 	if err != nil {

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -237,7 +237,14 @@ func IsLV(devicePath string, executor exec.Executor) (bool, error) {
 
 // GetUdevInfo gets udev information
 func GetUdevInfo(device string, executor exec.Executor) (map[string]string, error) {
-	output, err := executor.ExecuteCommandWithOutput("udevadm", "info", "--query=property", fmt.Sprintf("/dev/%s", device))
+	// The caller may pass either a kernel name ("sdb") or a full device path
+	// ("/dev/sdb"), so only add the /dev prefix when it is missing. Adding it
+	// unconditionally produces "/dev//dev/sdb", which udevadm rejects.
+	devicePath := strings.Split(device, "/")
+	if len(devicePath) == 1 {
+		device = fmt.Sprintf("/dev/%s", device)
+	}
+	output, err := executor.ExecuteCommandWithOutput("udevadm", "info", "--query=property", device)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/sys/device_test.go
+++ b/pkg/util/sys/device_test.go
@@ -176,6 +176,41 @@ NAME="ceph--89fa04fa--b93a--4874--9364--c95be3ec01c6-osd--data--70847bdb--2ec1--
 	assert.Equal(t, 0, len(partitions))
 }
 
+func TestGetUdevInfo(t *testing.T) {
+	// GetUdevInfo is called both with a kernel name ("sdb") and with a full
+	// device path ("/dev/sdb"). Both must reach udevadm as "/dev/sdb"; a full
+	// path must not become "/dev//dev/sdb", which udevadm rejects.
+	// The argument is asserted exactly rather than with Contains, because a
+	// doubled prefix still contains the device name.
+	tests := []struct {
+		name     string
+		device   string
+		expected string
+	}{
+		{"kernel name", "sdb", "/dev/sdb"},
+		{"full path", "/dev/sdb", "/dev/sdb"},
+		{"by-id path", "/dev/disk/by-id/scsi-36001405d27e5d898829468b90ce4ef8c", "/dev/disk/by-id/scsi-36001405d27e5d898829468b90ce4ef8c"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var gotDevice string
+			executor := &exectest.MockExecutor{
+				MockExecuteCommandWithOutput: func(command string, arg ...string) (string, error) {
+					assert.Equal(t, "udevadm", command)
+					gotDevice = arg[len(arg)-1]
+					return udevOutput, nil
+				},
+			}
+
+			info, err := GetUdevInfo(test.device, executor)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, gotDevice)
+			assert.Equal(t, "ext2", info["ID_FS_TYPE"])
+		})
+	}
+}
+
 func TestParseUdevInfo(t *testing.T) {
 	m := parseUdevInfo(udevOutput)
 	assert.Equal(t, m["ID_FS_TYPE"], "ext2")


### PR DESCRIPTION
Manual backport of #18080 to `release-1.19`.

The Mergify backport (#18108) hit a conflict in `pkg/util/sys/device.go`, because
`GetDeviceProperties` on this branch still has the `/dev` prefix logic inline. I cherry-picked
both commits and resolved it the same way master did: the call site now uses the
`resolveDevicePath` helper introduced by the second commit.

No other differences from the master change. `go build ./...` passes, and
`pkg/util/sys` and `pkg/daemon/ceph/osd` tests pass locally.

#18108 can be closed in favour of this one.

---

AI disclosure: Claude Code was used to resolve the cherry-pick conflict and to check the
result against the master commits. The change itself is the backport of #18080.
