### PR TITLE
docs: add missing `snapshotPolicy` to CSI docs

### DIFF
--- a/Documentation/Storage-Configuration/Ceph-CSI/ceph-csi-snapshot.md
+++ b/Documentation/Storage-Configuration/Ceph-CSI/ceph-csi-snapshot.md
@@ -6,6 +6,23 @@ title: Snapshots
 
 - Install the [snapshot controller and snapshot v1 CRD](https://github.com/kubernetes-csi/external-snapshotter/tree/master#usage).
 
+- If using the **ceph-csi-operator** (ceph-csi-drivers Helm chart), set the
+`snapshotPolicy` on each driver that needs snapshot support. The default value
+is `none`, which disables the `csi-snapshotter` sidecar. For example, in the ceph-csi-drivers
+Helm chart values:
+
+    ```yaml
+    drivers:
+      rbd:
+        snapshotPolicy: volumeSnapshot
+      cephfs:
+        snapshotPolicy: volumeSnapshot
+    ```
+
+    Valid values are `none`, `volumeSnapshot`, and `volumeGroupSnapshot`.
+    Use `volumeGroupSnapshot` if you need
+    [Volume Group Snapshots](ceph-csi-volume-group-snapshot.md) instead.
+
 - We also need a `VolumeSnapshotClass` for volume snapshot to work. The purpose of a `VolumeSnapshotClass` is
 defined in [the kubernetes
 documentation](https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes/).

--- a/Documentation/Storage-Configuration/Ceph-CSI/ceph-csi-volume-group-snapshot.md
+++ b/Documentation/Storage-Configuration/Ceph-CSI/ceph-csi-volume-group-snapshot.md
@@ -14,6 +14,20 @@ or to restore existing volumes to a previous state (represented by the snapshots
 refer to VolumeGroupSnapshot documentation
 [here](https://github.com/kubernetes-csi/external-snapshotter/tree/master#volume-group-snapshot-support) for more details.
 
+- If using the **ceph-csi-operator** (ceph-csi-drivers Helm chart), set the
+`snapshotPolicy` to `volumeGroupSnapshot` on each driver that needs volume
+group snapshot support. The default value is `none`, which disables the
+`csi-snapshotter` sidecar. For example, in the ceph-csi-drivers
+Helm chart values:
+
+    ```yaml
+    drivers:
+      rbd:
+        snapshotPolicy: volumeGroupSnapshot
+      cephfs:
+        snapshotPolicy: volumeGroupSnapshot
+    ```
+
 - A `VolumeGroupSnapshotClass` is needed for the volume group snapshot to work. The purpose of a `VolumeGroupSnapshotClass` is
 defined in [the kubernetes
 documentation](https://kubernetes.io/blog/2024/12/18/kubernetes-1-32-volume-group-snapshot-beta/).

--- a/deploy/charts/ceph-csi-drivers/values.yaml
+++ b/deploy/charts/ceph-csi-drivers/values.yaml
@@ -21,9 +21,14 @@ drivers:
   rbd:
     enabled: true
     name: rook-ceph.rbd.csi.ceph.com # csi-provisioner-name
+    # Set snapshotPolicy to enable snapshot/group snapshot support.
+    # If unset/none, the csi-snapshotter sidecar is not deployed.
+    # Valid values: none, volumeSnapshot, volumeGroupSnapshot.
+    # snapshotPolicy: volumeSnapshot
   cephfs:
     enabled: true
     name: rook-ceph.cephfs.csi.ceph.com # csi-provisioner-name
+    # snapshotPolicy: volumeSnapshot
   nfs:
     enabled: false
     name: rook-ceph.nfs.csi.ceph.com # csi-provisioner-name


### PR DESCRIPTION
This patch adds the missing `snapshotPolicy` to the snapshot/volumegroup snapshot docs.

If this value is unset/missing in the helm chart values the snapshotter sidecar is not deployed.

Fixes: #18156

