### PR TITLE
osd: support replacement for mixed pvc and host-based OSDs cluster

### DIFF
--- a/Documentation/Storage-Configuration/Advanced/ceph-osd-mgmt.md
+++ b/Documentation/Storage-Configuration/Advanced/ceph-osd-mgmt.md
@@ -181,7 +181,7 @@ wipe a disk on the [Cleaning up a Cluster](../ceph-teardown.md#delete-the-data-o
 This procedure replaces a failed disk while the OSD keeps its original ID and its place in the CRUSH map, so Ceph backfills only the data that was on the failed disk rather than rebalancing the whole cluster. The replacement is triggered by an annotation on the OSD deployment.
 
 !!! note
-    This applies to **host-based clusters** only. To replace a disk backing a PVC-based OSD, follow [Remove an OSD](#remove-an-osd) instead and let the operator re-create it.
+    This applies to **host-based OSDs** only. To replace a disk backing a PVC-based OSD, follow [Remove an OSD](#remove-an-osd) instead and let the operator re-create it.
 
 ### How it works
 

--- a/pkg/operator/ceph/cluster/osd/replace_destroy.go
+++ b/pkg/operator/ceph/cluster/osd/replace_destroy.go
@@ -38,12 +38,6 @@ import (
 func (m *OSDHealthMonitor) processOSDsDestroyForReplacement() (map[int]struct{}, error) {
 	osdsUnderReplacement := map[int]struct{}{}
 
-	// OSD replacement is host-based only; on a PVC-backed cluster there is nothing to process, so
-	// skip the per-tick listing of all OSD deployments to avoid a needless scan every health tick.
-	if len(m.cluster.spec.Storage.StorageClassDeviceSets) > 0 {
-		return osdsUnderReplacement, nil
-	}
-
 	deployments, err := m.cluster.getOSDDeployments()
 	if err != nil {
 		return osdsUnderReplacement, errors.Wrap(err, "failed to list OSD deployments for replacement processing")

--- a/pkg/operator/ceph/cluster/osd/replace_destroy_test.go
+++ b/pkg/operator/ceph/cluster/osd/replace_destroy_test.go
@@ -199,6 +199,20 @@ func TestProcessOSDReplacementDestroy(t *testing.T) {
 		assert.NotContains(t, st.cephCmds, fmt.Sprintf("osd destroy osd.%d --yes-i-really-mean-it", osdID))
 	})
 
+	t.Run("in-flight replacement is not stranded by device sets added to the spec", func(t *testing.T) {
+		// A host OSD stays a valid replacement target in a cluster that also has device sets; bailing out
+		// on them would leave it fenced and half torn down for good.
+		dep := replaceMarkedDep(osdID)
+		st := &replaceTestState{tree: map[int]string{osdID: "up"}, inByID: map[int]int{osdID: 1}}
+		m := newReplaceHealthMonitor(t, fake.NewClientset(dep), st)
+		m.cluster.spec.Storage.StorageClassDeviceSets = []cephv1.StorageClassDeviceSet{{Name: "set1", Count: 1}}
+
+		replacing, err := m.processOSDsDestroyForReplacement()
+		require.NoError(t, err)
+		assert.Contains(t, replacing, osdID)
+		assert.Contains(t, st.cephCmds, fmt.Sprintf("osd out %d", osdID))
+	})
+
 	t.Run("draining when out but not safe", func(t *testing.T) {
 		dep := replaceMarkedDep(osdID)
 		st := &replaceTestState{tree: map[int]string{osdID: "up"}, inByID: map[int]int{osdID: 0}, safeToDestroy: map[int]bool{}}


### PR DESCRIPTION
OSD-replacement has validation which allows replacement only for host-based OSDs. This commit removes invalid optimisation check in osd health gorotine. The check would disable any host-based OSD replacement if cluster CR has PVC config and would break osd-replacement in mixed cluster.


Originally, it was added from this discussion: https://github.com/rook/rook/pull/17865#discussion_r3554945679