### PR TITLE
security: keep credential values out of object store log lines

### DIFF
--- a/pkg/operator/ceph/object/topic/controller.go
+++ b/pkg/operator/ceph/object/topic/controller.go
@@ -344,8 +344,6 @@ func (r *ReconcileBucketTopic) updateStatus(observedGeneration int64, nsName typ
 		topic.Status.ObservedGeneration = observedGeneration
 	}
 
-	log.NamedDebug(nsName, logger, "updating CephBucketTopic %q .status.secrets to %+v.", nsName, referencedSecrets)
-
 	if referencedSecrets != nil {
 		secretsStatus := []cephv1.SecretReference{}
 
@@ -365,6 +363,10 @@ func (r *ReconcileBucketTopic) updateStatus(observedGeneration int64, nsName typ
 		sort.Slice(secretsStatus, func(i, j int) bool {
 			return secretsStatus[i].Name < secretsStatus[j].Name
 		})
+
+		// log the secret references rather than the secrets themselves: corev1.Secret
+		// carries a generated String() that prints its whole Data map
+		log.NamedDebug(nsName, logger, "updating CephBucketTopic %q .status.secrets to %+v", nsName, secretsStatus)
 
 		topic.Status.Secrets = secretsStatus
 	}

--- a/pkg/operator/ceph/object/topic/controller_test.go
+++ b/pkg/operator/ceph/object/topic/controller_test.go
@@ -18,7 +18,9 @@ limitations under the License.
 package topic
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -245,4 +247,49 @@ func TestCephBucketTopicController(t *testing.T) {
 		assert.NotNil(t, bucketTopic.Status.ARN)
 		assert.Equal(t, *bucketTopic.Status.ARN, expectedARN)
 	})
+}
+
+func TestUpdateStatusDoesNotLogSecretData(t *testing.T) {
+	// corev1.Secret carries a generated String() method that prints its whole Data
+	// map, and fmt calls it at any nesting depth, so formatting a collection of
+	// Secrets writes every referenced credential to the log.
+	logBuf := bytes.NewBuffer([]byte{})
+	capnslog.SetFormatter(capnslog.NewLogFormatter(logBuf, "", 0))
+	// restore the sink so later tests in this package still log to stderr
+	t.Cleanup(func() { capnslog.SetFormatter(capnslog.NewDefaultFormatter(os.Stderr)) })
+	capnslog.SetGlobalLogLevel(capnslog.DEBUG)
+
+	bucketTopic := &cephv1.CephBucketTopic{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		TypeMeta:   metav1.TypeMeta{Kind: "CephBucketTopic"},
+	}
+
+	s := scheme.Scheme
+	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephBucketTopic{})
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(bucketTopic).Build()
+	r := &ReconcileBucketTopic{client: cl, opManagerContext: context.TODO()}
+
+	//nolint:gosec // only a test value, not a real secret
+	const passwordValue = "EXAMPLEKAFKAPASSWORD0000000000000000000001"
+	referencedSecrets := map[types.UID]*corev1.Secret{
+		"uid-1": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "kafka-credentials",
+				Namespace:       namespace,
+				UID:             "uid-1",
+				ResourceVersion: "1",
+			},
+			Data: map[string][]byte{"password": []byte(passwordValue)},
+		},
+	}
+
+	r.updateStatus(k8sutil.ObservedGenerationNotAvailable, types.NamespacedName{Name: name, Namespace: namespace}, k8sutil.ReadyStatus, nil, &referencedSecrets)
+
+	logOutput := logBuf.String()
+	// Secret.Data is map[string][]byte, which the generated String() renders as
+	// decimal byte values rather than text, so check for that form too
+	assert.NotContains(t, logOutput, passwordValue)
+	assert.NotContains(t, logOutput, fmt.Sprintf("%v", []byte(passwordValue)))
+	// the secret reference is what the line exists to report, and is still logged
+	assert.Contains(t, logOutput, "kafka-credentials")
 }

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -512,7 +512,7 @@ func (r *ReconcileObjectStoreUser) createOrUpdateCephUser(u *cephv1.CephObjectSt
 		}
 
 		targetUser.Keys = []admin.UserKeySpec{liveUser.Keys[0]}
-		log.NamedDebug(nsName, logger, "reducing user %q keypairs to %v", u.Name, targetUser.Keys)
+		log.NamedDebug(nsName, logger, "reducing user %q from %d keypairs to 1", u.Name, len(liveUser.Keys))
 	}
 
 	if err := r.reconcileUserKeys(nsName, targetUser.Keys); err != nil {
@@ -896,8 +896,6 @@ func (r *ReconcileObjectStoreUser) updateKeyStatus(name types.NamespacedName, re
 		user.Status = &cephv1.ObjectStoreUserStatus{}
 	}
 
-	log.NamedDebug(name, logger, "updating CephObjectStoreUser .status.keys to %+v.", referencedSecrets)
-
 	keyStatus := []cephv1.SecretReference{}
 
 	for _, secret := range *referencedSecrets {
@@ -916,6 +914,10 @@ func (r *ReconcileObjectStoreUser) updateKeyStatus(name types.NamespacedName, re
 	sort.Slice(keyStatus, func(i, j int) bool {
 		return keyStatus[i].Name < keyStatus[j].Name
 	})
+
+	// log the secret references rather than the secrets themselves: corev1.Secret
+	// carries a generated String() that prints its whole Data map
+	log.NamedDebug(name, logger, "updating CephObjectStoreUser .status.keys to %+v", keyStatus)
 
 	user.Status.Keys = keyStatus
 
@@ -965,7 +967,7 @@ func (r *ReconcileObjectStoreUser) reconcileUserKeys(nsName types.NamespacedName
 	syncdKeys := make([]admin.UserKeySpec, len(targetKeys))
 
 	// remove any keys configured for the user that aren't present in targetKeys
-	for _, existingKey := range userInfo.Keys {
+	for i, existingKey := range userInfo.Keys {
 		targetKey, found := targetMap[existingKey.AccessKey]
 		if !found {
 			// RemoveKey() requires the UID to be set but GetUser() returns the list of keys with only .User set
@@ -973,7 +975,10 @@ func (r *ReconcileObjectStoreUser) reconcileUserKeys(nsName types.NamespacedName
 			rmKey.UID = userID
 
 			if err := client.RemoveKey(ctx, rmKey); err != nil {
-				return errors.Wrapf(err, "failed to remove key %q from user %q", existingKey.AccessKey, userID)
+				// the returned error omits the access key ID because it reaches Kubernetes
+				// events and the CR status; name the key here so debug logs still have it
+				log.NamedDebug(nsName, logger, "failed to remove key %q from user %q. %v", existingKey.AccessKey, userID, err)
+				return errors.Wrapf(err, "failed to remove key %d from user %q", i, userID)
 			}
 			log.NamedDebug(nsName, logger, "removed key %q from user %q as it is not in the target list", existingKey.AccessKey, userID)
 			continue
@@ -985,9 +990,10 @@ func (r *ReconcileObjectStoreUser) reconcileUserKeys(nsName types.NamespacedName
 			rmKey.UID = userID
 
 			if err := client.RemoveKey(ctx, rmKey); err != nil {
-				return errors.Wrapf(err, "failed to remove key %q from user %q", existingKey.AccessKey, userID)
+				log.NamedDebug(nsName, logger, "failed to remove key %q from user %q. %v", existingKey.AccessKey, userID, err)
+				return errors.Wrapf(err, "failed to remove key %d from user %q", i, userID)
 			}
-			log.NamedDebug(nsName, logger, "removed key %q from user %q needs as it needs to be recreated", existingKey.AccessKey, userID)
+			log.NamedDebug(nsName, logger, "removed key %q from user %q as it needs to be recreated", existingKey.AccessKey, userID)
 			continue
 		}
 		// else key exists and is correct, no action needed
@@ -1003,7 +1009,8 @@ func (r *ReconcileObjectStoreUser) reconcileUserKeys(nsName types.NamespacedName
 	// create each desired key
 	for _, k := range targetMap {
 		if _, err := client.CreateKey(ctx, k); err != nil {
-			return errors.Wrapf(err, "failed to create key %q for user %q", k.AccessKey, userID)
+			log.NamedDebug(nsName, logger, "failed to create key %q for user %q. %v", k.AccessKey, userID, err)
+			return errors.Wrapf(err, "failed to create a key for user %q", userID)
 		}
 		log.NamedDebug(nsName, logger, "created key %q for user %q", k.AccessKey, userID)
 	}

--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -985,4 +986,106 @@ func TestIsUserSync(t *testing.T) {
 
 		assert.False(t, isUserSync(&a, &b))
 	})
+}
+
+func TestUpdateKeyStatusDoesNotLogSecretData(t *testing.T) {
+	// corev1.Secret carries a generated String() method that prints its whole Data
+	// map, and fmt calls it at any nesting depth, so formatting a collection of
+	// Secrets writes every referenced credential to the log.
+	logBuf := bytes.NewBuffer([]byte{})
+	capnslog.SetFormatter(capnslog.NewLogFormatter(logBuf, "", 0))
+	// restore the sink so later tests in this package still log to stderr
+	t.Cleanup(func() { capnslog.SetFormatter(capnslog.NewDefaultFormatter(os.Stderr)) })
+	capnslog.SetGlobalLogLevel(capnslog.DEBUG)
+
+	objectUser := &cephv1.CephObjectStoreUser{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		TypeMeta:   metav1.TypeMeta{Kind: "CephObjectStoreUser"},
+	}
+
+	s := scheme.Scheme
+	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephObjectStoreUser{})
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objectUser).Build()
+	r := &ReconcileObjectStoreUser{client: cl, scheme: s, opManagerContext: context.TODO()}
+
+	//nolint:gosec // only a test value, not a real secret
+	const secretValue = "EXAMPLESECRETKEYVALUE00000000000000000001"
+	referencedSecrets := map[types.UID]*corev1.Secret{
+		"uid-1": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "my-user-keys",
+				Namespace:       namespace,
+				UID:             "uid-1",
+				ResourceVersion: "1",
+			},
+			Data: map[string][]byte{"SecretKey": []byte(secretValue)},
+		},
+	}
+
+	r.updateKeyStatus(types.NamespacedName{Name: name, Namespace: namespace}, &referencedSecrets)
+
+	logOutput := logBuf.String()
+	// Secret.Data is map[string][]byte, which the generated String() renders as
+	// decimal byte values rather than text, so check for that form too
+	assert.NotContains(t, logOutput, secretValue)
+	assert.NotContains(t, logOutput, fmt.Sprintf("%v", []byte(secretValue)))
+	// the secret reference is what the line exists to report, and is still logged
+	assert.Contains(t, logOutput, "my-user-keys")
+}
+
+func TestCreateOrUpdateCephUserDoesNotLogKeySecret(t *testing.T) {
+	// admin.UserKeySpec has plain exported AccessKey and SecretKey fields and no
+	// String() method, so formatting a slice of them prints both halves.
+	logBuf := bytes.NewBuffer([]byte{})
+	capnslog.SetFormatter(capnslog.NewLogFormatter(logBuf, "", 0))
+	// restore the sink so later tests in this package still log to stderr
+	t.Cleanup(func() { capnslog.SetFormatter(capnslog.NewDefaultFormatter(os.Stderr)) })
+	capnslog.SetGlobalLogLevel(capnslog.DEBUG)
+
+	objectUser := &cephv1.CephObjectStoreUser{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       cephv1.ObjectStoreUserSpec{Store: store},
+		TypeMeta:   metav1.TypeMeta{Kind: "CephObjectStoreUser"},
+	}
+
+	// A live RGW user the API returned with one key, so createOrUpdateCephUser
+	// falls back to the live user's keys and formats them.
+	//nolint:gosec // only test values, not a real secret
+	const liveSecretKey = "EXAMPLELIVESECRETKEY0000000000000000000001"
+	userWithKeysJSON := `{
+	"user_id": "my-user",
+	"display_name": "my-user",
+	"max_buckets": 1000,
+	"keys": [{"user": "my-user", "access_key": "EXAMPLELIVEACCESSKEY01", "secret_key": "` + liveSecretKey + `"}],
+	"swift_keys": [],
+	"caps": [],
+	"op_mask": "read, write, delete",
+	"bucket_quota": {"enabled": false, "max_size": -1, "max_objects": -1},
+	"user_quota": {"enabled": false, "max_size": -1, "max_objects": -1},
+	"type": "rgw"
+}`
+
+	mockClient := &cephobject.MockClient{
+		MockDo: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader([]byte(userWithKeysJSON))),
+			}, nil
+		},
+	}
+	adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient)
+	assert.NoError(t, err)
+	r := &ReconcileObjectStoreUser{
+		objContext:       &cephobject.AdminOpsContext{AdminOpsClient: adminClient},
+		opManagerContext: context.TODO(),
+	}
+
+	userConfig, err := generateUserConfig(objectUser, cephver.Minimum)
+	require.NoError(t, err)
+	require.NoError(t, r.createOrUpdateCephUser(objectUser, userConfig))
+
+	logOutput := logBuf.String()
+	assert.NotContains(t, logOutput, liveSecretKey)
+	// the reconcile is still traceable by user name
+	assert.Contains(t, logOutput, "my-user")
 }


### PR DESCRIPTION
An audit found object store controllers writing S3 credentials and Kafka passwords to the operator log on ordinary reconcile paths; some are error strings, which also reach events and CR status.

They now log the metadata views the code already builds instead of Secret objects or key specs.

**Notable decisions**

Access key IDs stay in the debug lines -- they identify rather than authenticate -- but are dropped from the error strings, which reach events and status by default. `corev1.Secret` renders `Data` as decimal bytes, so tests assert that form; text-only assertions pass unfixed code.

**AI assistance:** Claude Code found these leaks during a repo-wide audit, wrote the fixes and the regression tests, and confirmed each test fails when its fix is reverted.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [x] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
