### PR TITLE
osd: factor the replacement destroy flow into a shared destroy machine

### DIFF
--- a/pkg/operator/ceph/cluster/osd/destroy_machine.go
+++ b/pkg/operator/ceph/cluster/osd/destroy_machine.go
@@ -1,0 +1,344 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util/log"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// destroyState is the per-OSD state the destroy machine derives fresh on every tick from Ceph and
+// Kubernetes; nothing here is persisted (design/ceph/osd-device-exclusion.md (design PR #18125),
+// "Shared destroy state machine").
+type destroyState struct {
+	// destroyed: the OSD's slot is marked "destroyed" in the osd tree.
+	destroyed bool
+	// downscaled: the OSD deployment is at zero replicas.
+	downscaled bool
+	// in: the OSD is "in" per the osd dump. An OSD absent from the dump while its slot is not
+	// destroyed is treated as in: marking out is idempotent and the next tick re-reads once the dump
+	// reflects reality.
+	in bool
+}
+
+func deriveDestroyState(namespace string, d *appsv1.Deployment, osdID int, osdTree *cephclient.OsdTree, osdDump *cephclient.OSDDump) destroyState {
+	st := destroyState{
+		destroyed:  isOSDDestroyedInTree(osdTree, osdID),
+		downscaled: d.Spec.Replicas != nil && *d.Spec.Replicas == 0,
+		in:         true,
+	}
+	if _, in, err := osdDump.StatusByID(int64(osdID)); err != nil {
+		if !st.destroyed {
+			log.NamespacedWarning(namespace, logger,
+				"osd.%d not found in osd dump while not destroyed; treating it as in to begin drain. %v", osdID, err)
+		}
+	} else {
+		st.in = in == inStatus
+	}
+	return st
+}
+
+// destroyFlow is one flow over the shared destroy state machine (the replacement flow today; the
+// exclusion removal modes later — see
+// design/ceph/osd-device-exclusion.md (design PR #18125), "Shared destroy state machine" for the
+// parameter table this interface encodes). Methods are the flow-specific parameters; the spine
+// (advanceDestroy) and sweep (destroySweep) own the ordering and the shared primitives (pod-gone,
+// crypt-close, scale-down).
+type destroyFlow interface {
+	// name is the flow's log prefix.
+	name() string
+	// ownsDeployment reports whether the flow's ownership marker is on the deployment.
+	ownsDeployment(d *appsv1.Deployment) bool
+	// isComplete reports whether the flow is done with the deployment: it stays in the owned set
+	// (exempt from normal health handling) but is not advanced.
+	isComplete(d *appsv1.Deployment) bool
+	// skipSweep reports whether the whole sweep is a no-op for this cluster.
+	skipSweep() bool
+	// disengageRequested reports whether the request was withdrawn; the spine honors it only while
+	// the flow's commit point has not passed, which the flow encodes in this predicate.
+	disengageRequested(d *appsv1.Deployment, st destroyState) bool
+	// disengage reverses the flow's own markers and restores the OSD. It is one opaque, idempotent
+	// step: internal ordering (e.g. crypt-close teardown before unfencing) belongs to the flow.
+	disengage(d *appsv1.Deployment, osdID int) error
+	// terminalReached reports whether the flow's Ceph-side terminal state already holds.
+	terminalReached(st destroyState) bool
+	// finalize runs the flow's post-terminal bookkeeping. Idempotent.
+	finalize(d *appsv1.Deployment, osdID int) error
+	// startDrain moves the OSD toward the stop gate and reports whether it acted; an action ends
+	// this OSD's tick (a just-started drain can never pass the stop gate in the same tick).
+	startDrain(d *appsv1.Deployment, osdID int, st destroyState) (bool, error)
+	// stopGate certifies the OSD's pod may be stopped now.
+	stopGate(osdID int) (bool, error)
+	// terminalGate re-certifies immediately before the terminal action.
+	terminalGate(osdID int) (bool, error)
+	// terminal performs the flow's Ceph-side teardown at the commit point.
+	terminal(d *appsv1.Deployment, osdID int) error
+}
+
+// advanceDestroy advances one flow-owned OSD one step per health tick. State is derived fresh; every
+// error is warn-and-retry-next-tick at the caller.
+func (m *OSDHealthMonitor) advanceDestroy(f destroyFlow, d *appsv1.Deployment, osdID int, osdTree *cephclient.OsdTree, osdDump *cephclient.OSDDump) error {
+	st := deriveDestroyState(m.clusterInfo.Namespace, d, osdID, osdTree, osdDump)
+
+	// Disengage is checked ahead of every fallible query and side effect, so a withdrawal can always reverse the flow.
+	if f.disengageRequested(d, st) {
+		return f.disengage(d, osdID)
+	}
+
+	if f.terminalReached(st) {
+		return f.finalize(d, osdID)
+	}
+
+	if st.downscaled {
+		gone, err := m.isOSDPodGone(osdID)
+		if err != nil {
+			return err
+		}
+		if !gone {
+			log.NamespacedInfo(m.clusterInfo.Namespace, logger,
+				"osd.%d is scaled down; waiting for the pod to terminate before %s teardown", osdID, f.name())
+			return nil
+		}
+		isEncrypted, err := m.isReplaceOSDEncrypted(d)
+		if err != nil {
+			return err
+		}
+		if isEncrypted {
+			done, err := m.runCryptCloseJobForOSD(d, osdID)
+			if err != nil {
+				return err
+			}
+			if !done {
+				return nil
+			}
+			if err := m.cluster.deleteCryptCloseJob(osdID); err != nil {
+				return errors.Wrapf(err, "failed to delete crypto-close job for osd.%d", osdID)
+			}
+		}
+		ok, err := f.terminalGate(osdID)
+		if err != nil {
+			log.NamespacedWarning(m.clusterInfo.Namespace, logger,
+				"failed the %s terminal gate for osd.%d; will re-check next tick. %v", f.name(), osdID, err)
+			return nil
+		}
+		if !ok {
+			log.NamespacedInfo(m.clusterInfo.Namespace, logger,
+				"osd.%d has not passed the %s terminal gate; will re-check next tick", osdID, f.name())
+			return nil
+		}
+		return f.terminal(d, osdID)
+	}
+
+	acted, err := f.startDrain(d, osdID, st)
+	if err != nil || acted {
+		return err
+	}
+
+	ok, err := f.stopGate(osdID)
+	if err != nil {
+		log.NamespacedWarning(m.clusterInfo.Namespace, logger,
+			"failed the %s stop gate for osd.%d; will re-check next tick. %v", f.name(), osdID, err)
+		return nil
+	}
+	if !ok {
+		log.NamespacedInfo(m.clusterInfo.Namespace, logger,
+			"osd.%d has not passed the %s stop gate; will re-check next tick", osdID, f.name())
+		return nil
+	}
+
+	return m.scaleDownOSDDeployment(d, osdID)
+}
+
+// destroySweep runs one flow's per-tick sweep: collect the flow-owned deployments, and advance each
+// one that still has work. Returns the owned OSD ids — including completed members — for the caller
+// to exempt from normal health handling. Fetch failures return the owned set with no advancement:
+// the set is built from deployment markers before any Ceph query.
+func (m *OSDHealthMonitor) destroySweep(f destroyFlow) (map[int]struct{}, error) {
+	owned := map[int]struct{}{}
+
+	if f.skipSweep() {
+		return owned, nil
+	}
+
+	deployments, err := m.cluster.getOSDDeployments()
+	if err != nil {
+		return owned, errors.Wrapf(err, "failed to list OSD deployments for %s processing", f.name())
+	}
+
+	var toProcess []*appsv1.Deployment
+	for i := range deployments.Items {
+		d := &deployments.Items[i]
+		if !f.ownsDeployment(d) {
+			continue
+		}
+		osdID, err := GetOSDID(d)
+		if err != nil {
+			log.NamespacedWarning(m.clusterInfo.Namespace, logger,
+				"skipping %s processing for deployment %q: %v", f.name(), d.Name, err)
+			continue
+		}
+		owned[osdID] = struct{}{}
+		if f.isComplete(d) {
+			continue
+		}
+		toProcess = append(toProcess, d)
+	}
+
+	if len(toProcess) == 0 {
+		return owned, nil
+	}
+
+	tree, err := cephclient.HostTree(m.context, m.clusterInfo)
+	if err != nil {
+		log.NamespacedWarning(m.clusterInfo.Namespace, logger,
+			"failed to get osd tree for %s processing; will retry next tick. %v", f.name(), err)
+		return owned, nil
+	}
+	osdDump, err := cephclient.GetOSDDump(m.context, m.clusterInfo)
+	if err != nil {
+		log.NamespacedWarning(m.clusterInfo.Namespace, logger,
+			"failed to get osd dump for %s processing; will retry next tick. %v", f.name(), err)
+		return owned, nil
+	}
+
+	for _, d := range toProcess {
+		osdID, _ := GetOSDID(d) // already validated above
+		if err := m.advanceDestroy(f, d, osdID, &tree, osdDump); err != nil {
+			log.NamespacedWarning(m.clusterInfo.Namespace, logger,
+				"failed to advance %s for osd.%d; will retry next tick. %v", f.name(), osdID, err)
+		}
+	}
+
+	return owned, nil
+}
+
+// isOSDPodGone reports whether the OSD daemon pod has terminated. PodsRunningWithLabel counts pods
+// whose phase is Running; a terminating pod stays Running until its containers exit, so this only
+// reads true once the daemon has actually released the data/DB LVs.
+func (m *OSDHealthMonitor) isOSDPodGone(osdID int) (bool, error) {
+	label := fmt.Sprintf("%s=%d", OsdIdLabelKey, osdID)
+	running, err := k8sutil.PodsRunningWithLabel(m.clusterInfo.Context, m.context.Clientset, m.clusterInfo.Namespace, label)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to check for running pods of osd.%d", osdID)
+	}
+	if running > 0 {
+		log.NamespacedInfo(m.clusterInfo.Namespace, logger,
+			"osd.%d still has %d running pod(s) after scale-down; will re-check next tick", osdID, running)
+		return false, nil
+	}
+	return true, nil
+}
+
+// scaleDownOSDDeployment sets the deployment replicas to 0 (only if not already). It is idempotent
+// across ticks; pod-gone is checked separately by the caller.
+func (m *OSDHealthMonitor) scaleDownOSDDeployment(d *appsv1.Deployment, osdID int) error {
+	if d.Spec.Replicas != nil && *d.Spec.Replicas == 0 {
+		return nil
+	}
+	log.NamespacedInfo(m.clusterInfo.Namespace, logger, "scaling osd.%d deployment %q to replicas=0", osdID, d.Name)
+	d.Spec.Replicas = new(int32(0))
+	updated, err := m.cluster.context.Clientset.AppsV1().Deployments(m.clusterInfo.Namespace).Update(m.clusterInfo.Context, d, metav1.UpdateOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "failed to scale osd.%d deployment %q to zero", osdID, d.Name)
+	}
+	// Keep the caller's copy in sync so a later update in the same flow does not clobber the
+	// replicas change with a stale object.
+	*d = *updated
+	return nil
+}
+
+// runCryptCloseJobForOSD ensures the per-OSD crypto-close Job exists and reports whether it has
+// succeeded. It (re)creates the Job when none exists or a previous one failed, and polls otherwise.
+// Idempotent across ticks.
+func (m *OSDHealthMonitor) runCryptCloseJobForOSD(d *appsv1.Deployment, osdID int) (bool, error) {
+	status, err := m.cluster.cryptCloseJobStatusForOSD(osdID)
+	if err != nil {
+		return false, err
+	}
+
+	switch status {
+	case cryptCloseJobSucceeded:
+		return true, nil
+	case cryptCloseJobRunning:
+		log.NamespacedInfo(m.clusterInfo.Namespace, logger, "crypto-close job for osd.%d is still running", osdID)
+		return false, nil
+	default:
+		// NotFound or Failed: (re)create the Job, pinned to the OSD's node.
+		nodeName, err := m.replaceOSDNodeName(d, osdID)
+		if err != nil {
+			return false, err
+		}
+		// A previously-Failed Job means a genuinely stuck dm-crypt close (it already exhausted its
+		// in-container BackoffLimit / ActiveDeadlineSeconds). The design has no timeout — the user
+		// cancels by removing the annotation — so we keep recreating, but at Warning level so a wedged
+		// replacement is visible rather than silently looping every tick.
+		if status == cryptCloseJobFailed {
+			log.NamespacedWarning(m.clusterInfo.Namespace, logger,
+				"crypto-close job for osd.%d previously failed; recreating it on node %q", osdID, nodeName)
+		} else {
+			log.NamespacedInfo(m.clusterInfo.Namespace, logger,
+				"creating crypto-close job for osd.%d on node %q", osdID, nodeName)
+		}
+		if err := m.cluster.startCryptCloseJob(osdID, nodeName); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+}
+
+// isReplaceOSDEncrypted reports whether the OSD deployment is encrypted, using the same detection
+// as getOSDInfo: the "encrypted" label, or a dmcrypt block path. The label is checked first so the
+// common case needs no OSD-info parse.
+func (m *OSDHealthMonitor) isReplaceOSDEncrypted(d *appsv1.Deployment) (bool, error) {
+	if d.Labels[encrypted] == "true" {
+		return true, nil
+	}
+	osdInfo, err := m.cluster.getOSDInfo(d)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to read OSD info from deployment %q to determine encryption", d.Name)
+	}
+	return osdInfo.Encrypted, nil
+}
+
+// replaceOSDNodeName resolves the node the OSD runs on, so the crypto-close Job can be pinned to it.
+func (m *OSDHealthMonitor) replaceOSDNodeName(d *appsv1.Deployment, osdID int) (string, error) {
+	osdInfo, err := m.cluster.getOSDInfo(d)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to read OSD info from deployment %q to resolve its node", d.Name)
+	}
+	if strings.TrimSpace(osdInfo.NodeName) == "" {
+		return "", errors.Errorf("could not resolve the node name for osd.%d from deployment %q", osdID, d.Name)
+	}
+	return osdInfo.NodeName, nil
+}
+
+// isOSDDestroyedInTree reports whether the given OSD's slot is marked "destroyed" in the osd tree.
+func isOSDDestroyedInTree(osdTree *cephclient.OsdTree, osdID int) bool {
+	for _, node := range osdTree.Nodes {
+		if node.Type == "osd" && node.ID == osdID {
+			return node.Status == "destroyed"
+		}
+	}
+	return false
+}

--- a/pkg/operator/ceph/cluster/osd/destroy_machine_test.go
+++ b/pkg/operator/ceph/cluster/osd/destroy_machine_test.go
@@ -1,0 +1,296 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func machineTree(t *testing.T, jsonStr string) *cephclient.OsdTree {
+	t.Helper()
+	var tree cephclient.OsdTree
+	require.NoError(t, json.Unmarshal([]byte(jsonStr), &tree))
+	return &tree
+}
+
+func machineDump(t *testing.T, jsonStr string) *cephclient.OSDDump {
+	t.Helper()
+	var dump cephclient.OSDDump
+	require.NoError(t, json.Unmarshal([]byte(jsonStr), &dump))
+	return &dump
+}
+
+func machineDeployment(osdID int, replicas int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        deploymentName(osdID),
+			Namespace:   "rook-ceph",
+			Annotations: map[string]string{},
+			// Both labels matter: the app label is what getOSDDeployments' selector lists by —
+			// without it the sweep never sees the deployment — and the id label is what GetOSDID
+			// reads.
+			Labels: map[string]string{k8sutil.AppAttr: AppName, OsdIdLabelKey: strconv.Itoa(osdID)},
+		},
+		Spec: appsv1.DeploymentSpec{Replicas: &replicas},
+	}
+}
+
+func TestDeriveDestroyState(t *testing.T) {
+	tree := machineTree(t, `{"nodes":[{"id":7,"type":"osd","status":"destroyed"},{"id":8,"type":"osd","status":"up"}]}`)
+	dump := machineDump(t, `{"osds":[{"osd":7,"up":1,"in":1},{"osd":8,"up":1,"in":0}]}`)
+
+	t.Run("up in tree, out in dump, not destroyed, not downscaled", func(t *testing.T) {
+		st := deriveDestroyState("rook-ceph", machineDeployment(8, 1), 8, tree, dump)
+		assert.False(t, st.destroyed)
+		assert.False(t, st.downscaled)
+		assert.False(t, st.in) // osd.8 is out in the dump
+	})
+	t.Run("destroyed slot", func(t *testing.T) {
+		st := deriveDestroyState("rook-ceph", machineDeployment(7, 1), 7, tree, dump)
+		assert.True(t, st.destroyed)
+		assert.True(t, st.in)
+	})
+	t.Run("downscaled deployment", func(t *testing.T) {
+		st := deriveDestroyState("rook-ceph", machineDeployment(8, 0), 8, tree, dump)
+		assert.True(t, st.downscaled)
+	})
+	t.Run("absent from dump is treated as in", func(t *testing.T) {
+		st := deriveDestroyState("rook-ceph", machineDeployment(9, 1), 9, tree, dump)
+		assert.True(t, st.in)
+		assert.False(t, st.destroyed)
+	})
+}
+
+// fakeDestroyFlow scripts every flow decision and records the calls the spine makes, in order.
+type fakeDestroyFlow struct {
+	calls []string
+
+	disengageReq bool
+	termReached  bool
+	drainActed   bool
+	stopOK       bool
+	termOK       bool
+}
+
+func (f *fakeDestroyFlow) name() string                             { return "fake" }
+func (f *fakeDestroyFlow) ownsDeployment(_ *appsv1.Deployment) bool { return true }
+func (f *fakeDestroyFlow) isComplete(_ *appsv1.Deployment) bool     { return false }
+func (f *fakeDestroyFlow) skipSweep() bool                          { return false }
+func (f *fakeDestroyFlow) disengageRequested(_ *appsv1.Deployment, _ destroyState) bool {
+	f.calls = append(f.calls, "disengageRequested")
+	return f.disengageReq
+}
+
+func (f *fakeDestroyFlow) disengage(_ *appsv1.Deployment, _ int) error {
+	f.calls = append(f.calls, "disengage")
+	return nil
+}
+
+func (f *fakeDestroyFlow) terminalReached(_ destroyState) bool {
+	f.calls = append(f.calls, "terminalReached")
+	return f.termReached
+}
+
+func (f *fakeDestroyFlow) finalize(_ *appsv1.Deployment, _ int) error {
+	f.calls = append(f.calls, "finalize")
+	return nil
+}
+
+func (f *fakeDestroyFlow) startDrain(_ *appsv1.Deployment, _ int, _ destroyState) (bool, error) {
+	f.calls = append(f.calls, "startDrain")
+	return f.drainActed, nil
+}
+
+func (f *fakeDestroyFlow) stopGate(_ int) (bool, error) {
+	f.calls = append(f.calls, "stopGate")
+	return f.stopOK, nil
+}
+
+func (f *fakeDestroyFlow) terminalGate(_ int) (bool, error) {
+	f.calls = append(f.calls, "terminalGate")
+	return f.termOK, nil
+}
+
+func (f *fakeDestroyFlow) terminal(_ *appsv1.Deployment, _ int) error {
+	f.calls = append(f.calls, "terminal")
+	return nil
+}
+
+// newMachineTestMonitor builds a real monitor over a fake clientset and an executor that fails the
+// test on ANY ceph command: the spine itself must never talk to Ceph — only flows and the shared
+// helpers it is given do.
+func newMachineTestMonitor(t *testing.T, objects ...runtime.Object) *OSDHealthMonitor {
+	t.Helper()
+	clusterInfo := cephclient.AdminTestClusterInfo("rook-ceph")
+	clusterInfo.Context = context.TODO()
+	// Stub BOTH executor hooks: cephclient commands route through WithOutput or WithTimeout
+	// depending on the command builder.
+	clusterdCtx := &clusterd.Context{
+		Clientset: fake.NewClientset(objects...),
+		Executor: &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				t.Errorf("unexpected ceph command from machine spine: %s %s", command, strings.Join(args, " "))
+				return "", errors.New("unexpected ceph command")
+			},
+			MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
+				t.Errorf("unexpected ceph command from machine spine: %s %s", command, strings.Join(args, " "))
+				return "", errors.New("unexpected ceph command")
+			},
+		},
+	}
+	return NewOSDHealthMonitor(clusterdCtx, clusterInfo, false, cephv1.CephClusterHealthCheckSpec{}, cephv1.ClusterSpec{}, "rook/rook:test")
+}
+
+func TestAdvanceDestroySpine(t *testing.T) {
+	tree := machineTree(t, `{"nodes":[{"id":7,"type":"osd","status":"up"}]}`)
+	dump := machineDump(t, `{"osds":[{"osd":7,"up":1,"in":1}]}`)
+	outDump := machineDump(t, `{"osds":[{"osd":7,"up":1,"in":0}]}`)
+	destroyedTree := machineTree(t, `{"nodes":[{"id":7,"type":"osd","status":"destroyed"}]}`)
+
+	t.Run("disengage wins over everything", func(t *testing.T) {
+		m := newMachineTestMonitor(t)
+		f := &fakeDestroyFlow{disengageReq: true, termReached: true}
+		require.NoError(t, m.advanceDestroy(f, machineDeployment(7, 1), 7, tree, dump))
+		assert.Equal(t, []string{"disengageRequested", "disengage"}, f.calls)
+	})
+	t.Run("terminal reached short-circuits to finalize", func(t *testing.T) {
+		m := newMachineTestMonitor(t)
+		f := &fakeDestroyFlow{termReached: true}
+		require.NoError(t, m.advanceDestroy(f, machineDeployment(7, 1), 7, destroyedTree, dump))
+		assert.Equal(t, []string{"disengageRequested", "terminalReached", "finalize"}, f.calls)
+	})
+	t.Run("drain action ends the tick without touching the stop gate", func(t *testing.T) {
+		m := newMachineTestMonitor(t)
+		f := &fakeDestroyFlow{drainActed: true}
+		require.NoError(t, m.advanceDestroy(f, machineDeployment(7, 1), 7, tree, dump))
+		assert.Equal(t, []string{"disengageRequested", "terminalReached", "startDrain"}, f.calls)
+	})
+	t.Run("stop gate refusal leaves the deployment up", func(t *testing.T) {
+		m := newMachineTestMonitor(t)
+		f := &fakeDestroyFlow{stopOK: false}
+		d := machineDeployment(7, 1)
+		require.NoError(t, m.advanceDestroy(f, d, 7, tree, outDump))
+		assert.Equal(t, []string{"disengageRequested", "terminalReached", "startDrain", "stopGate"}, f.calls)
+	})
+	t.Run("stop gate pass scales the deployment down", func(t *testing.T) {
+		d := machineDeployment(7, 1)
+		m := newMachineTestMonitor(t, d)
+		f := &fakeDestroyFlow{stopOK: true}
+		require.NoError(t, m.advanceDestroy(f, d, 7, tree, outDump))
+		assert.Equal(t, []string{"disengageRequested", "terminalReached", "startDrain", "stopGate"}, f.calls)
+		updated, err := m.context.Clientset.AppsV1().Deployments("rook-ceph").Get(context.TODO(), d.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, int32(0), *updated.Spec.Replicas)
+	})
+	t.Run("downscaled with pod gone runs terminal gate then terminal", func(t *testing.T) {
+		d := machineDeployment(7, 0)
+		d.Labels[encrypted] = "true"
+		succeededJob := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: cryptCloseJobName(7), Namespace: "rook-ceph"},
+			Status:     batchv1.JobStatus{Succeeded: 1},
+		}
+		m := newMachineTestMonitor(t, d, succeededJob)
+		f := &fakeDestroyFlow{termOK: true}
+		require.NoError(t, m.advanceDestroy(f, d, 7, tree, outDump))
+		assert.Equal(t, []string{"disengageRequested", "terminalReached", "terminalGate", "terminal"}, f.calls)
+	})
+	t.Run("downscaled with terminal gate refusal retries next tick", func(t *testing.T) {
+		d := machineDeployment(7, 0)
+		d.Labels[encrypted] = "true"
+		succeededJob := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: cryptCloseJobName(7), Namespace: "rook-ceph"},
+			Status:     batchv1.JobStatus{Succeeded: 1},
+		}
+		m := newMachineTestMonitor(t, d, succeededJob)
+		f := &fakeDestroyFlow{termOK: false}
+		require.NoError(t, m.advanceDestroy(f, d, 7, tree, outDump))
+		assert.Equal(t, []string{"disengageRequested", "terminalReached", "terminalGate"}, f.calls)
+	})
+}
+
+// newSweepTestMonitor is newMachineTestMonitor without the t.Errorf guard: the sweep legitimately
+// issues `osd tree`/`osd dump`, and these tests exercise the fetch-FAILURE path, so every ceph
+// command fails with a plain error instead of failing the test.
+func newSweepTestMonitor(objects ...runtime.Object) *OSDHealthMonitor {
+	clusterInfo := cephclient.AdminTestClusterInfo("rook-ceph")
+	clusterInfo.Context = context.TODO()
+	clusterdCtx := &clusterd.Context{
+		Clientset: fake.NewClientset(objects...),
+		Executor: &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				return "", errors.Errorf("induced ceph failure: %s", command)
+			},
+			MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
+				return "", errors.Errorf("induced ceph failure: %s", command)
+			},
+		},
+	}
+	return NewOSDHealthMonitor(clusterdCtx, clusterInfo, false, cephv1.CephClusterHealthCheckSpec{}, cephv1.ClusterSpec{}, "rook/rook:test")
+}
+
+func TestDestroySweepOwnedSetOnFetchFailure(t *testing.T) {
+	// The owned set must be complete even when the tree/dump fetch fails: it is built from
+	// deployment markers BEFORE any Ceph query, so the normal health path never acts on an
+	// owned OSD just because Ceph was briefly unreachable.
+	d := machineDeployment(7, 1)
+	m := newSweepTestMonitor(d)
+	f := &fakeDestroyFlow{}
+	owned, err := m.destroySweep(f)
+	require.NoError(t, err)
+	assert.Equal(t, map[int]struct{}{7: {}}, owned)
+	// advance was never reached: no flow decision calls beyond collection were made
+	assert.Empty(t, f.calls)
+}
+
+func TestDestroySweepSkip(t *testing.T) {
+	m := newSweepTestMonitor(machineDeployment(7, 1))
+	lists := 0
+	m.context.Clientset.(*fake.Clientset).PrependReactor("list", "deployments",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			lists++
+			return false, nil, nil
+		})
+	f := &skippingFlow{&fakeDestroyFlow{}}
+	owned, err := m.destroySweep(f)
+	require.NoError(t, err)
+	assert.Empty(t, owned)
+	assert.Zero(t, lists, "skipSweep must short-circuit before the deployment LIST")
+}
+
+type skippingFlow struct{ *fakeDestroyFlow }
+
+func (s *skippingFlow) skipSweep() bool { return true }

--- a/pkg/operator/ceph/cluster/osd/replace_destroy.go
+++ b/pkg/operator/ceph/cluster/osd/replace_destroy.go
@@ -17,9 +17,6 @@ limitations under the License.
 package osd
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
@@ -36,254 +33,85 @@ import (
 //
 // Called from OSD health goroutine. Returns owned OSD ids to ignore from normal OSD health goroutine flow.
 func (m *OSDHealthMonitor) processOSDsDestroyForReplacement() (map[int]struct{}, error) {
-	osdsUnderReplacement := map[int]struct{}{}
-
-	// OSD replacement is host-based only; on a PVC-backed cluster there is nothing to process, so
-	// skip the per-tick listing of all OSD deployments to avoid a needless scan every health tick.
-	if len(m.cluster.spec.Storage.StorageClassDeviceSets) > 0 {
-		return osdsUnderReplacement, nil
-	}
-
-	deployments, err := m.cluster.getOSDDeployments()
-	if err != nil {
-		return osdsUnderReplacement, errors.Wrap(err, "failed to list OSD deployments for replacement processing")
-	}
-
-	// Collect the replacement-marked deployments. Every one (incl. ready-for-swap) goes into the
-	// exclusion set, but only those with work left are processed below: a deployment the controller has
-	// not marked in-progress is not owned by this function, and one already annotated ready-for-swap is done.
-	var toProcess []*appsv1.Deployment
-	for i := range deployments.Items {
-		d := &deployments.Items[i]
-		if d.Annotations[cephv1.ReplaceInProgressOSDAnnotationKey] != "true" {
-			continue
-		}
-
-		osdID, err := GetOSDID(d)
-		if err != nil {
-			log.NamespacedWarning(m.clusterInfo.Namespace, logger,
-				"skipping replacement processing for deployment %q: %v", d.Name, err)
-			continue
-		}
-
-		osdsUnderReplacement[osdID] = struct{}{}
-		if _, readyForSwap := d.Annotations[cephv1.ReadyForSwapOSDAnnotationKey]; readyForSwap {
-			// already processed
-			continue
-		}
-		toProcess = append(toProcess, d)
-	}
-
-	if len(toProcess) == 0 {
-		return osdsUnderReplacement, nil
-	}
-
-	tree, err := cephclient.HostTree(m.context, m.clusterInfo)
-	if err != nil {
-		log.NamespacedWarning(m.clusterInfo.Namespace, logger,
-			"failed to get osd tree for replacement processing; will retry next tick. %v", err)
-		return osdsUnderReplacement, nil
-	}
-	osdDump, err := cephclient.GetOSDDump(m.context, m.clusterInfo)
-	if err != nil {
-		log.NamespacedWarning(m.clusterInfo.Namespace, logger,
-			"failed to get osd dump for replacement processing; will retry next tick. %v", err)
-		return osdsUnderReplacement, nil
-	}
-
-	for _, d := range toProcess {
-		osdID, _ := GetOSDID(d) // already validated above
-		if err := m.processOSDReplacementDestroy(d, osdID, &tree, osdDump); err != nil {
-			log.NamespacedWarning(m.clusterInfo.Namespace, logger,
-				"failed to advance replacement for osd.%d; will retry next tick. %v", osdID, err)
-		}
-	}
-
-	return osdsUnderReplacement, nil
+	return m.destroySweep(replaceFlow{m: m})
 }
 
-// processOSDReplacementDestroy advances one replacement-marked OSD's destroy flow from durable markers on every
-// OSD heath tick
-func (m *OSDHealthMonitor) processOSDReplacementDestroy(d *appsv1.Deployment, osdID int, osdTree *cephclient.OsdTree, osdDump *cephclient.OSDDump) error {
+// replaceFlow is the OSD-replacement flow over the shared destroy machine: drain fully
+// (safe-to-destroy as both stop gate and terminal gate), destroy slot-preservingly, and leave the
+// deployment as the ready-for-swap marker. Design: design/ceph/osd-replacement.md.
+type replaceFlow struct {
+	m *OSDHealthMonitor
+}
+
+func (f replaceFlow) name() string { return "replacement" }
+
+func (f replaceFlow) ownsDeployment(d *appsv1.Deployment) bool {
+	return d.Annotations[cephv1.ReplaceInProgressOSDAnnotationKey] == "true"
+}
+
+// isComplete: a ready-for-swap deployment is done (checked by presence, deliberately not by value).
+func (f replaceFlow) isComplete(d *appsv1.Deployment) bool {
+	_, readyForSwap := d.Annotations[cephv1.ReadyForSwapOSDAnnotationKey]
+	return readyForSwap
+}
+
+// skipSweep: OSD replacement is host-based only; on a PVC-backed cluster there is nothing to
+// process, so skip the per-tick listing of all OSD deployments.
+func (f replaceFlow) skipSweep() bool {
+	return len(f.m.cluster.spec.Storage.StorageClassDeviceSets) > 0
+}
+
+// disengageRequested: the replace annotation was removed. Honored only before the slot is destroyed —
+// once destroyed, the Ceph state cannot be cheaply reversed, so the flow completes instead.
+func (f replaceFlow) disengageRequested(d *appsv1.Deployment, st destroyState) bool {
 	_, isReplaceRequested := d.Annotations[cephv1.ReplaceOSDAnnotationKey]
-	isDestroyed := isOSDDestroyedInTree(osdTree, osdID)
-	isDownscaled := d.Spec.Replicas != nil && *d.Spec.Replicas == 0
-
-	// Cancellation: the replace annotation was removed. Honored only before the slot is destroyed —
-	// once destroyed, the Ceph state cannot be cheaply reversed, so the flow completes instead. Kept
-	// ahead of every query so a cancellation can always mark the OSD back in.
-	if !isReplaceRequested && !isDestroyed {
-		return m.cancelReplaceOSD(d, osdID)
-	}
-
-	// Slot already destroyed: annotate ready-for-swap to signal the user.
-	if isDestroyed {
-		log.NamespacedInfo(m.clusterInfo.Namespace, logger,
-			"osd.%d is destroyed; annotating deployment %q as ready for swap", osdID, d.Name)
-		return m.annotateReadyForSwap(d, osdID)
-	}
-
-	if isDownscaled {
-		gone, err := m.isOSDPodGone(osdID)
-		if err != nil {
-			return err
-		}
-		if !gone {
-			log.NamespacedInfo(m.clusterInfo.Namespace, logger,
-				"osd.%d is scaled down; waiting for the pod to terminate before destroying", osdID)
-			return nil
-		}
-		// Pod is gone, run job to close crypto mappings on host for encrypted OSDs only.
-		isEncrypted, err := m.isReplaceOSDEncrypted(d)
-		if err != nil {
-			return err
-		}
-		if isEncrypted {
-			// run job or check status
-			done, err := m.runCryptCloseJobForOSD(d, osdID)
-			if err != nil {
-				return err
-			}
-			if !done {
-				return nil
-			}
-			// if job done. delete right away and proceed to osd-destroy.
-			if err := m.cluster.deleteCryptCloseJob(osdID); err != nil {
-				return errors.Wrapf(err, "failed to delete crypto-close job for osd.%d", osdID)
-			}
-		}
-		// double check safe-to-destroy before destroy
-		safe, err := cephclient.OsdSafeToDestroy(m.context, m.clusterInfo, osdID)
-		if err != nil {
-			log.NamespacedWarning(m.clusterInfo.Namespace, logger,
-				"failed to check safe-to-destroy for osd.%d; will re-check next tick. %v", osdID, err)
-			return nil
-		}
-		if !safe {
-			log.NamespacedInfo(m.clusterInfo.Namespace, logger,
-				"osd.%d is not yet safe-to-destroy; will re-check next tick", osdID)
-			return nil
-		}
-		// force the mon view to down to dodge a heartbeat-lag EBUSY on destroy (idempotent), then destroy
-		if err := cephclient.OSDDown(m.context, m.clusterInfo, osdID); err != nil {
-			return err
-		}
-		if err := cephclient.OSDDestroy(m.context, m.clusterInfo, osdID); err != nil {
-			return err
-		}
-		return nil
-	}
-
-	// OSD deployment is not yet scaled down: drive the drain.
-	isOSDIn := true
-	if _, in, err := osdDump.StatusByID(int64(osdID)); err != nil {
-		// OSD absent from the dump but its slot is not destroyed. Treat it as in: marking out is
-		// idempotent and the next tick re-reads once the dump reflects reality.
-		log.NamespacedWarning(m.clusterInfo.Namespace, logger,
-			"osd.%d not found in osd dump while not destroyed; treating it as in to begin drain. %v", osdID, err)
-	} else {
-		isOSDIn = in == inStatus
-	}
-
-	// Mark the OSD out to begin the drain. A just-out OSD cannot be safe-to-destroy yet, so return
-	// and wait for the drain on the next ticks; never destroy in the same tick it went out.
-	if isOSDIn {
-		log.NamespacedInfo(m.clusterInfo.Namespace, logger, "marking osd.%d out to begin replacement drain", osdID)
-		if err := cephclient.OSDOut(m.context, m.clusterInfo, osdID); err != nil {
-			return err
-		}
-		return nil
-	}
-
-	// OSD is out: wait until it has drained and is safe to destroy, then scale the deployment to 0 so
-	// the daemon releases the data/DB LVs. The pod-gone branch above takes over once the pod exits.
-	safe, err := cephclient.OsdSafeToDestroy(m.context, m.clusterInfo, osdID)
-	if err != nil {
-		log.NamespacedWarning(m.clusterInfo.Namespace, logger,
-			"failed to check safe-to-destroy for osd.%d; will re-check next tick. %v", osdID, err)
-		return nil
-	}
-	if !safe {
-		log.NamespacedInfo(m.clusterInfo.Namespace, logger,
-			"osd.%d is draining; not yet safe-to-destroy, will re-check next tick", osdID)
-		return nil
-	}
-
-	return m.scaleDownOSDDeployment(d, osdID)
+	return !isReplaceRequested && !st.destroyed
 }
 
-// isOSDPodGone reports whether the OSD daemon pod has terminated. PodsRunningWithLabel counts pods
-// whose phase is Running; a terminating pod stays Running until its containers exit, so this only
-// reads true once the daemon has actually released the data/DB LVs.
-func (m *OSDHealthMonitor) isOSDPodGone(osdID int) (bool, error) {
-	label := fmt.Sprintf("%s=%d", OsdIdLabelKey, osdID)
-	running, err := k8sutil.PodsRunningWithLabel(m.clusterInfo.Context, m.context.Clientset, m.clusterInfo.Namespace, label)
-	if err != nil {
-		return false, errors.Wrapf(err, "failed to check for running pods of osd.%d", osdID)
-	}
-	if running > 0 {
-		log.NamespacedInfo(m.clusterInfo.Namespace, logger,
-			"osd.%d still has %d running pod(s) after scale-down; will re-check next tick", osdID, running)
-		return false, nil
-	}
-	return true, nil
+func (f replaceFlow) disengage(d *appsv1.Deployment, osdID int) error {
+	return f.m.cancelReplaceOSD(d, osdID)
 }
 
-// scaleDownOSDDeployment sets the deployment replicas to 0 (only if not already). It is idempotent
-// across ticks; pod-gone is checked separately by the caller.
-func (m *OSDHealthMonitor) scaleDownOSDDeployment(d *appsv1.Deployment, osdID int) error {
-	if d.Spec.Replicas != nil && *d.Spec.Replicas == 0 {
-		return nil
-	}
-	log.NamespacedInfo(m.clusterInfo.Namespace, logger, "scaling osd.%d deployment %q to replicas=0", osdID, d.Name)
-	d.Spec.Replicas = new(int32(0))
-	updated, err := m.cluster.context.Clientset.AppsV1().Deployments(m.clusterInfo.Namespace).Update(m.clusterInfo.Context, d, metav1.UpdateOptions{})
-	if err != nil {
-		return errors.Wrapf(err, "failed to scale osd.%d deployment %q to zero", osdID, d.Name)
-	}
-	// Keep the caller's copy in sync so a later update in the same flow does not clobber the
-	// replicas change with a stale object.
-	*d = *updated
-	return nil
+func (f replaceFlow) terminalReached(st destroyState) bool { return st.destroyed }
+
+func (f replaceFlow) finalize(d *appsv1.Deployment, osdID int) error {
+	log.NamespacedInfo(f.m.clusterInfo.Namespace, logger,
+		"osd.%d is destroyed; annotating deployment %q as ready for swap", osdID, d.Name)
+	return f.m.annotateReadyForSwap(d, osdID)
 }
 
-// runCryptCloseJobForOSD ensures the per-OSD crypto-close Job exists and reports whether it has
-// succeeded. It (re)creates the Job when none exists or a previous one failed, and polls otherwise.
-// Idempotent across ticks.
-func (m *OSDHealthMonitor) runCryptCloseJobForOSD(d *appsv1.Deployment, osdID int) (bool, error) {
-	status, err := m.cluster.cryptCloseJobStatusForOSD(osdID)
-	if err != nil {
-		return false, err
+// startDrain marks the OSD out. A just-out OSD cannot be safe-to-destroy yet, so acting ends the
+// tick; never destroy in the same tick it went out.
+func (f replaceFlow) startDrain(d *appsv1.Deployment, osdID int, st destroyState) (bool, error) {
+	if !st.in {
+		return false, nil
 	}
+	log.NamespacedInfo(f.m.clusterInfo.Namespace, logger, "marking osd.%d out to begin replacement drain", osdID)
+	return true, cephclient.OSDOut(f.m.context, f.m.clusterInfo, osdID)
+}
 
-	switch status {
-	case cryptCloseJobSucceeded:
-		return true, nil
-	case cryptCloseJobRunning:
-		log.NamespacedInfo(m.clusterInfo.Namespace, logger, "crypto-close job for osd.%d is still running", osdID)
-		return false, nil
-	default:
-		// NotFound or Failed: (re)create the Job, pinned to the OSD's node.
-		nodeName, err := m.replaceOSDNodeName(d, osdID)
-		if err != nil {
-			return false, err
-		}
-		// A previously-Failed Job means a genuinely stuck dm-crypt close (it already exhausted its
-		// in-container BackoffLimit / ActiveDeadlineSeconds). The design has no timeout — the user
-		// cancels by removing the annotation — so we keep recreating, but at Warning level so a wedged
-		// replacement is visible rather than silently looping every tick.
-		if status == cryptCloseJobFailed {
-			log.NamespacedWarning(m.clusterInfo.Namespace, logger,
-				"crypto-close job for osd.%d previously failed; recreating it on node %q", osdID, nodeName)
-		} else {
-			log.NamespacedInfo(m.clusterInfo.Namespace, logger,
-				"creating crypto-close job for osd.%d on node %q", osdID, nodeName)
-		}
-		if err := m.cluster.startCryptCloseJob(osdID, nodeName); err != nil {
-			return false, err
-		}
-		return false, nil
+func (f replaceFlow) stopGate(osdID int) (bool, error) {
+	return cephclient.OsdSafeToDestroy(f.m.context, f.m.clusterInfo, osdID)
+}
+
+func (f replaceFlow) terminalGate(osdID int) (bool, error) {
+	return cephclient.OsdSafeToDestroy(f.m.context, f.m.clusterInfo, osdID)
+}
+
+// terminal forces the mon view to down to dodge a heartbeat-lag EBUSY on destroy (idempotent), then
+// destroys the slot. The deployment stays as the ready-for-swap marker; finalize annotates it on a
+// later tick once the tree reports the slot destroyed.
+func (f replaceFlow) terminal(d *appsv1.Deployment, osdID int) error {
+	if err := cephclient.OSDDown(f.m.context, f.m.clusterInfo, osdID); err != nil {
+		return err
 	}
+	return cephclient.OSDDestroy(f.m.context, f.m.clusterInfo, osdID)
+}
+
+// processOSDReplacementDestroy advances one replacement-marked OSD's destroy flow from durable
+// markers on every OSD health tick.
+func (m *OSDHealthMonitor) processOSDReplacementDestroy(d *appsv1.Deployment, osdID int, osdTree *cephclient.OsdTree, osdDump *cephclient.OSDDump) error {
+	return m.advanceDestroy(replaceFlow{m: m}, d, osdID, osdTree, osdDump)
 }
 
 // annotateReadyForSwap adds the ready-for-swap annotation to the deployment and persists it. It is
@@ -339,40 +167,4 @@ func (m *OSDHealthMonitor) cancelReplaceOSD(d *appsv1.Deployment, osdID int) err
 		return errors.Wrapf(err, "failed to clear the replacement markers on osd.%d deployment %q", osdID, d.Name)
 	}
 	return nil
-}
-
-// isReplaceOSDEncrypted reports whether the OSD deployment is encrypted, using the same detection
-// as getOSDInfo: the "encrypted" label, or a dmcrypt block path. The label is checked first so the
-// common case needs no OSD-info parse.
-func (m *OSDHealthMonitor) isReplaceOSDEncrypted(d *appsv1.Deployment) (bool, error) {
-	if d.Labels[encrypted] == "true" {
-		return true, nil
-	}
-	osdInfo, err := m.cluster.getOSDInfo(d)
-	if err != nil {
-		return false, errors.Wrapf(err, "failed to read OSD info from deployment %q to determine encryption", d.Name)
-	}
-	return osdInfo.Encrypted, nil
-}
-
-// replaceOSDNodeName resolves the node the OSD runs on, so the crypto-close Job can be pinned to it.
-func (m *OSDHealthMonitor) replaceOSDNodeName(d *appsv1.Deployment, osdID int) (string, error) {
-	osdInfo, err := m.cluster.getOSDInfo(d)
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to read OSD info from deployment %q to resolve its node", d.Name)
-	}
-	if strings.TrimSpace(osdInfo.NodeName) == "" {
-		return "", errors.Errorf("could not resolve the node name for osd.%d from deployment %q", osdID, d.Name)
-	}
-	return osdInfo.NodeName, nil
-}
-
-// isOSDDestroyedInTree reports whether the given OSD's slot is marked "destroyed" in the osd tree.
-func isOSDDestroyedInTree(osdTree *cephclient.OsdTree, osdID int) bool {
-	for _, node := range osdTree.Nodes {
-		if node.Type == "osd" && node.ID == osdID {
-			return node.Status == "destroyed"
-		}
-	}
-	return false
 }


### PR DESCRIPTION
The OSD device-exclusion design adds removal modes that would otherwise become the codebase's fourth OSD-removal pathway, so it stages a behavior-preserving factoring of the merged replacement flow first.

The replacement destroy selector and per-tick sweep now run over a flow-parameterized destroy state machine (`destroyFlow`, `advanceDestroy`, `destroySweep`), with replacement as its first flow. Existing symbols keep their names and signatures; the untouched replacement test suite is the equivalence gate, and the machine spine gains its own tests.

Groundwork for the OSD device-exclusion design (#18125).

AI assistance: Claude Code implemented the staged refactor plan task-by-task and ran per-task adversarial equivalence reviews; I reviewed and directed each stage.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [x] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
