### PR TITLE
CI: Lint python scripts  with black and improve `make lint.quick` and `make lint`

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -49,8 +49,8 @@ jobs:
           pip install requests
           pip install pygit2
 
-      - name: Lint Python scripts
-        run: make lint.python
+      - name: Lint Python scripts with pylint
+        run: make lint.python.pylint
 
-      - name: Setup black for py
-        uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e # stable
+      - name: Lint Python scripts with black
+        run: make lint.python.black

--- a/Makefile
+++ b/Makefile
@@ -239,15 +239,15 @@ test.helm: $(HELM_UNITTEST) ## Run the helm chart unit tests
 	$(HELM_UNITTEST) --strict $(addprefix $(HELM_CHARTS_DIR)/,$(HELM_CHARTS))
 
 .PHONY: lint.quick
-lint.quick: lint.yaml lint.shell lint.make lint.go lint.helm lint.markdown ## run some (faster) linters
+lint.quick: lint.yaml lint.shell lint.go lint.make lint.markdown lint.workflows lint.commits ## run some (faster) linters
 .PHONY: lint
-lint: lint.quick lint.python ## Run various linters
+lint: lint.quick lint.helm ## Run various linters
 
 .PHONY: lint.python
 lint.python: ## lint python scripts
 	pylint $(shell find $(ROOT_DIR) -name '*.py') -E
-
 .PHONY: lint.make
+
 lint.make: ## lint the Makefile
 	@$(CHECKMAKE) Makefile
 

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ CT_VERSION := v3.13.0
 KUSTOMIZE_VERSION := v5.3.0
 MARKDOWNLINT_IMAGE_VERSION := v0.22.0
 SHELLCHECK_VERSION := v0.10.0
+BLACK_VERSION := 26.5.1
 
 # For future updates,the SHA of the 'latest' tag can be obtained like this:
 # podman inspect --format='{{index .RepoDigests 0}}' docker.io/cytopia/yamllint:latest
@@ -238,16 +239,27 @@ lint.helm: $(HELM) $(KUSTOMIZE) ## Check the helm charts
 test.helm: $(HELM_UNITTEST) ## Run the helm chart unit tests
 	$(HELM_UNITTEST) --strict $(addprefix $(HELM_CHARTS_DIR)/,$(HELM_CHARTS))
 
+
 .PHONY: lint.quick
-lint.quick: lint.yaml lint.shell lint.go lint.make lint.markdown lint.workflows lint.commits ## run some (faster) linters
+lint.quick: lint.yaml lint.markdown lint.shell lint.go lint.make lint.markdown lint.workflows lint.commits lint.python ## run some (fast) linters
 .PHONY: lint
 lint: lint.quick lint.helm ## Run various linters
 
-.PHONY: lint.python
-lint.python: ## lint python scripts
-	pylint $(shell find $(ROOT_DIR) -name '*.py') -E
-.PHONY: lint.make
+.PHONY: lint.python.pylint
+lint.python.pylint: ## lint python scripts with pylint.
+	@echo "Linting python code with pylint..."
+	@pylint $(shell find $(ROOT_DIR) -name '*.py') -E
+	@echo "All python scripts are good."
 
+.PHONY: lint.python.black
+lint.python.black: check.container.runtime ## lint python scripts with the black formatter.
+	@echo "Linting python code with black..."
+	@$(BLACK) --check .
+	@echo "All python scripts are good."
+.PHONY: lint.python
+lint.python: lint.python.black ## lint python scripts
+
+.PHONY: lint.make
 lint.make: ## lint the Makefile
 	@$(CHECKMAKE) Makefile
 

--- a/Makefile
+++ b/Makefile
@@ -256,6 +256,12 @@ lint.python.black: check.container.runtime ## lint python scripts with the black
 	@echo "Linting python code with black..."
 	@$(BLACK) --check .
 	@echo "All python scripts are good."
+.PHONY: format.python.black
+format.python.black: check.container.runtime
+	@$(BLACK) .
+
+.PHONY: format.python
+format.python: format.python.black
 .PHONY: lint.python
 lint.python: lint.python.black ## lint python scripts
 

--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -40,6 +40,7 @@ check.container.runtime:
 	$(if $(shell $(DOCKERCMD) version >/dev/null 2>&1 && echo available),,$(error no usable container runtime found. Install docker or podman, or set DOCKERCMD to a working command.))
 
 MARKDOWNLINT := $(DOCKERCMD) run --rm -v $$PWD:/workdir davidanson/markdownlint-cli2:$(MARKDOWNLINT_IMAGE_VERSION)
+BLACK := $(DOCKERCMD) run --rm --volume $$PWD:/src --user $$(id -u):$$(id -g) --workdir /src pyfound/black:$(BLACK_VERSION) black
 
 ifneq ($(strip $(YAMLLINT_IMAGE_SHA)),)
 YAMLLINT := $(DOCKERCMD) run  --rm -t -v $(CURDIR):/workdir:ro -w /workdir --entrypoint yamllint cytopia/yamllint@$(YAMLLINT_IMAGE_SHA)


### PR DESCRIPTION
**Description Of Changes:** 

 First of all, despite its name, the recently added `make lint.quick` wasn't really that quick at all,
 mostly due to lint.helm taking its time (around 12 seconds).
    
 This PR  adds moves `lint.helm` from  `lint.quick` to `lint`, significantly speeding up `make lint.quick`. 

Secondly, so far, Linting of python scripts was done with pylint
in the `lint.python` make target.
    
This used to pass in the CI but failed locally.
    
This PR changes `make lint.python` to use the `black` formatter for linting.

The old functionality is retained as `make lint.python.pylint` while
the new functionality which is the new default for `make lint.python`
    can be chosen explicitly with `make lint.python.black`.
    
The lint.python target is made self-contained by running black in a
    container.
    
In addition to passing locally, this has the advantage of running faster:
    
* `make lint.pthon.pylint` takes around 4 seconds.
* `make lint.python.black` takes around 2 seconds.
    
Therefore , `lint.python` is added to the `lint.quick` target which now takes
    around 20 seconds while `make lint` take some 30 seconds.

Finally, a `make format.python` is added which reformats python code with `black` so that `make format.python && make lin.python` will always succeed.


With all these changes, `make lint.quick` takes around  20  seconds while
    `make lint.quick` takes 30+ seconds, depending on the macine.


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary (under the `Documentation` folder).
- [x] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [x] Integration tests have been added, if necessary (in the `tests/integration` folder).

