### PR TITLE
ci: Create required cni config directory in 1.19 CI

### DIFF
--- a/.github/workflows/integration-test-setup-cluster-resources/action.yaml
+++ b/.github/workflows/integration-test-setup-cluster-resources/action.yaml
@@ -29,6 +29,10 @@ runs:
         sudo dpkg -i cri-dockerd_0.3.21.3-0.ubuntu-focal_amd64.deb
         rm -f cri-dockerd_0.3.21.3-0.ubuntu-focal_amd64.deb
 
+    - name: Ensure minikube cni config directory exists
+      shell: bash --noprofile --norc -eo pipefail -x {0}
+      run: sudo mkdir -p /etc/cni/net.d
+
     - name: Setup Minikube
       uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
       with:


### PR DESCRIPTION
The release-1.19 CI started failing because the required cni config directory is not created before minikube is configured.
The failures were observed in #18080, as well as [Canary tests in the 1.19 branch](https://github.com/rook/rook/actions/workflows/canary-integration-suite.yml?query=branch%3Arelease-1.19) since 11 Aug.
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

