### PR TITLE
ci: fail wait_for_prepare_pod loudly on timeout

### DIFF
--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -536,6 +536,11 @@ function wait_for_prepare_pod() {
     echo 'waiting for mon.a to be created'
     sleep 5
   done
+  if ! echo "$pod" | grep 'rook-ceph-mon-a'; then
+    echo "timed out after ${timeout}s waiting for mon.a to be created" >&2
+    kubectl --namespace rook-ceph get pod || true
+    return 1
+  fi
 
   # wait for at an osd prepare pod to complete
   OSD_COUNT=$1
@@ -548,8 +553,19 @@ function wait_for_prepare_pod() {
     echo 'waiting for at least one osd prepare pod to be running or finished'
     sleep 5
   done
+  if ! echo "$pod" | grep 'Running\|Succeeded\|Failed'; then
+    echo "timed out after ${timeout}s waiting for an osd prepare pod to be running or finished" >&2
+    kubectl --namespace rook-ceph get pod || true
+    return 1
+  fi
   pod="$("${get_pod_cmd[@]}" --selector app=rook-ceph-osd-prepare --output name | awk 'FNR <= 1')"
-  kubectl --namespace rook-ceph logs --follow "$pod"
+  if [[ -z "$pod" ]]; then
+    echo "no osd prepare pod found to collect logs from" >&2
+    kubectl --namespace rook-ceph get pod || true
+    return 1
+  fi
+  # bounded: a prepare pod starved of resources must not hold --follow open until the runner dies
+  timeout 450 kubectl --namespace rook-ceph logs --follow "$pod" || true
 
   # wait for an osd daemon pod to start
   timeout=60


### PR DESCRIPTION
During the 2026-08-19 GitHub runner-capacity degradation, canary jobs failed at `wait_for_prepare_pod` with a misleading `kubectl logs` usage error, and a master job hung 51 minutes at "wait for prepare pod" until its runner died.

The mon and osd-prepare wait loops fall through on timeout as if the wait had succeeded, feeding an empty pod name into an unguarded, unbounded `kubectl logs --follow`. Each wait now fails loudly with a best-effort pod listing, the empty-name case is guarded, and the log follow is bounded.

AI assistance: Claude Code diagnosed the failure mode from CI logs and implemented the fix under my direction.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
