### PR TITLE
ci: pin remaining jobs to ubuntu-22.04

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   actionlint:
     name: actionlint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -12,7 +12,7 @@ jobs:
       # write permissions are needed to assign the issue.
       issues: write
     name: Run self assign job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: take the issue
         uses: bdougie/take-action@1439165ac45a7461c2d89a59952cd7d941964b87 # main

--- a/.github/workflows/checkmake.yaml
+++ b/.github/workflows/checkmake.yaml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   checkmake:
     name: CheckMake
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run CheckMake

--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -43,7 +43,7 @@ jobs:
 
   check-markdown-links:
     if: github.repository == 'rook/rook'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v7.0.1
         with:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   golangci:
     name: golangci-lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -39,7 +39,7 @@ jobs:
 
   govulncheck:
     name: govulncheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -55,7 +55,7 @@ jobs:
 
   kube-api-lint:
     name: kube-api-lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   lint-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/helm-unittests.yaml
+++ b/.github/workflows/helm-unittests.yaml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   helm-unittests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   yaml-linter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -31,7 +31,7 @@ jobs:
         run: make lint.yaml
 
   pylint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/multus.yaml
+++ b/.github/workflows/multus.yaml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   test-validation-tool:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -16,7 +16,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   shellcheck:
     name: Shellcheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Lint shell scripts

--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   security:
     if: github.repository == 'rook/rook'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
GitHub-hosted runner scheduling for the `ubuntu-latest` label has been unreliable for this repo.

The 16 jobs still on `ubuntu-latest`, across 12 workflow files, now request `ubuntu-22.04` — the image the rest of the repo's Linux jobs were already pinned to. `macos-build` stays on `macos-latest`, and the arm64 suite keeps `ubuntu-22.04-arm`.

**Notable decisions**

`ubuntu-latest` resolves to a newer LTS, so for those 16 jobs this is a downgrade rather than only a pin. They are lint, security-scan and helm jobs, but that trade-off is worth a reviewer's attention.

**AI assistance:** an AI agent located the remaining `ubuntu-latest` occurrences, applied the substitution, and ran `actionlint` and `commitlint` over the result.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
