### PR TITLE
nvmeof: delete gateway from Ceph on pod restart, scale-down, and CR deletion

### DIFF
--- a/pkg/operator/ceph/nvmeof/controller.go
+++ b/pkg/operator/ceph/nvmeof/controller.go
@@ -227,6 +227,8 @@ func (r *ReconcileCephNVMeOFGateway) reconcile(request reconcile.Request) (recon
 		}
 		r.clusterInfo.CephVersion = runningCephVersion
 
+		r.deleteAllNVMeOFGateways(cephNVMeOFGateway)
+
 		err = opcontroller.RemoveFinalizer(r.opManagerContext, r.client, cephNVMeOFGateway)
 		if err != nil {
 			return reconcile.Result{}, *cephNVMeOFGateway, errors.Wrap(err, "failed to remove finalizer")
@@ -367,6 +369,10 @@ func (r *ReconcileCephNVMeOFGateway) downCephNVMeOFGateway(cephNVMeOFGateway *ce
 		daemonID := k8sutil.IndexToName(i)
 		name := instanceName(cephNVMeOFGateway, daemonID)
 
+		if err := r.deleteNVMeOFGateway(name, cephNVMeOFGateway.Spec.Group); err != nil {
+			return errors.Wrapf(err, "failed to delete nvme-gw %q from Ceph", name)
+		}
+
 		err := r.context.Clientset.AppsV1().Deployments(cephNVMeOFGateway.Namespace).Delete(r.opManagerContext, name, metav1.DeleteOptions{})
 		if err != nil && !kerrors.IsNotFound(err) {
 			return errors.Wrapf(err, "failed to delete deployment %q", name)
@@ -378,6 +384,28 @@ func (r *ReconcileCephNVMeOFGateway) downCephNVMeOFGateway(cephNVMeOFGateway *ce
 		}
 	}
 
+	return nil
+}
+
+func (r *ReconcileCephNVMeOFGateway) deleteAllNVMeOFGateways(cephNVMeOFGateway *cephv1.CephNVMeOFGateway) {
+	for i := 0; i < cephNVMeOFGateway.Spec.Instances; i++ {
+		daemonID := k8sutil.IndexToName(i)
+		gwName := instanceName(cephNVMeOFGateway, daemonID)
+		if err := r.deleteNVMeOFGateway(gwName, cephNVMeOFGateway.Spec.Group); err != nil {
+			logger.Warningf("failed to delete nvme-gw %q during CR deletion, continuing: %v", gwName, err)
+		}
+	}
+}
+
+func (r *ReconcileCephNVMeOFGateway) deleteNVMeOFGateway(gatewayName, group string) error {
+	logger.Infof("deleting nvme-gw %q from pool %q group %q", gatewayName, nvmeofPoolName, group)
+	args := []string{"nvme-gw", "delete", gatewayName, nvmeofPoolName, group}
+	cmd := cephclient.NewCephCommand(r.context, r.clusterInfo, args)
+	cmd.JsonOutput = false
+	_, err := cmd.Run()
+	if err != nil {
+		return errors.Wrapf(err, "failed to run ceph nvme-gw delete for %q", gatewayName)
+	}
 	return nil
 }
 

--- a/pkg/operator/ceph/nvmeof/controller_test.go
+++ b/pkg/operator/ceph/nvmeof/controller_test.go
@@ -90,6 +90,9 @@ func TestCephNVMeOFGatewayController(t *testing.T) {
 					if args[0] == "nvme-gw" && args[1] == "show" {
 						return "", nil
 					}
+					if args[0] == "nvme-gw" && args[1] == "delete" {
+						return "", nil
+					}
 				}
 				panic(fmt.Sprintf("unhandled command %s %v", command, args))
 			},
@@ -507,6 +510,9 @@ func TestNVMeOFKeyRotation(t *testing.T) {
 					return "", nil
 				}
 				if args[0] == "nvme-gw" && args[1] == "show" {
+					return "", nil
+				}
+				if args[0] == "nvme-gw" && args[1] == "delete" {
 					return "", nil
 				}
 			}

--- a/pkg/operator/ceph/nvmeof/prestop.py
+++ b/pkg/operator/ceph/nvmeof/prestop.py
@@ -1,0 +1,14 @@
+import json, rados, os  # pylint: disable=import-error
+
+cluster = rados.Rados(conffile="/etc/ceph/ceph.conf")
+cluster.connect()
+cmd = json.dumps(
+    {
+        "prefix": "nvme-gw delete",
+        "id": os.environ["GATEWAY_NAME"],
+        "pool": os.environ["POOL_NAME"],
+        "group": os.environ["ANA_GROUP"],
+    }
+)
+cluster.mon_command(cmd, b"")
+cluster.shutdown()

--- a/pkg/operator/ceph/nvmeof/spec.go
+++ b/pkg/operator/ceph/nvmeof/spec.go
@@ -73,6 +73,14 @@ func getPorts(nvmeof *cephv1.CephNVMeOFGateway) (ioPort, gatewayPort, monitorPor
 //go:embed connectionconfig.sh
 var connectionConfigScript string
 
+// preStopScript deregisters the NVMe-oF gateway from Ceph when the pod is
+// being terminated (scale-down, pod delete, node drain, etc.). It uses the
+// rados library available in the gateway container image since the ceph CLI
+// is not present.
+//
+//go:embed prestop.py
+var preStopScript string
+
 func (r *ReconcileCephNVMeOFGateway) generateCephNVMeOFService(nvmeof *cephv1.CephNVMeOFGateway, daemonID string) *v1.Service {
 	labels := getLabels(nvmeof, daemonID)
 	serviceName := instanceName(nvmeof, daemonID)
@@ -181,7 +189,7 @@ func (r *ReconcileCephNVMeOFGateway) makeDeployment(nvmeof *cephv1.CephNVMeOFGat
 	gatewayConfigVol, gatewayConfigMount := gatewayConfigVolumeAndMount(configMapName)
 
 	initContainer := r.createCephConfigInitContainer(nvmeof, daemonID, gatewayConfigMount)
-	daemonContainer, err := r.daemonContainer(nvmeof, cephConfigMount)
+	daemonContainer, err := r.daemonContainer(nvmeof, daemonID, cephConfigMount)
 	if err != nil {
 		return nil, err
 	}
@@ -353,12 +361,13 @@ func (r *ReconcileCephNVMeOFGateway) createCephConfigInitContainer(nvmeof *cephv
 	return container
 }
 
-func (r *ReconcileCephNVMeOFGateway) daemonContainer(nvmeof *cephv1.CephNVMeOFGateway, cephConfigMount v1.VolumeMount) (v1.Container, error) {
+func (r *ReconcileCephNVMeOFGateway) daemonContainer(nvmeof *cephv1.CephNVMeOFGateway, daemonID string, cephConfigMount v1.VolumeMount) (v1.Container, error) {
 	image, err := r.getNVMeOFImage(nvmeof)
 	if err != nil {
 		return v1.Container{}, err
 	}
 
+	gatewayName := instanceName(nvmeof, daemonID)
 	privileged := true
 	container := v1.Container{
 		Name: "nvmeof-gateway",
@@ -374,16 +383,37 @@ func (r *ReconcileCephNVMeOFGateway) daemonContainer(nvmeof *cephv1.CephNVMeOFGa
 		},
 		Env: func() []v1.EnvVar {
 			envVars := controller.DaemonEnvVars(r.cephClusterSpec)
-			// Build CEPH_ARGS using DefaultFlags which includes fsid, keyring, logging flags, and mon host flags
 			cephArgs := cephconfig.DefaultFlags(r.clusterInfo.FSID, "/etc/ceph/keyring")
 			cephArgsStr := strings.Join(cephArgs, " ")
 			logger.Infof("CEPH_ARGS for nvmeof gateway: %s", cephArgsStr)
-			envVars = append(envVars, v1.EnvVar{
-				Name:  "CEPH_ARGS",
-				Value: cephArgsStr,
-			})
+			envVars = append(envVars,
+				v1.EnvVar{
+					Name:  "CEPH_ARGS",
+					Value: cephArgsStr,
+				},
+				v1.EnvVar{
+					Name:  "GATEWAY_NAME",
+					Value: gatewayName,
+				},
+				v1.EnvVar{
+					Name:  "POOL_NAME",
+					Value: nvmeofPoolName,
+				},
+				v1.EnvVar{
+					Name:  "ANA_GROUP",
+					Value: nvmeof.Spec.Group,
+				},
+			)
 			return envVars
 		}(),
+
+		Lifecycle: &v1.Lifecycle{
+			PreStop: &v1.LifecycleHandler{
+				Exec: &v1.ExecAction{
+					Command: []string{"python3", "-c", preStopScript},
+				},
+			},
+		},
 
 		Ports: func() []v1.ContainerPort {
 			ioPort, gatewayPort, monitorPort, discoveryPort := getPorts(nvmeof)


### PR DESCRIPTION
When an NVMe-oF gateway pod is deleted and recreated, the init container now runs `ceph nvme-gw delete` before `ceph nvme-gw create` to ensure clean re-registration of the specific gateway.

On scale-down, the operator calls `ceph nvme-gw delete` for each removed gateway instance before deleting its Deployment and Service.

On CR deletion, the operator deletes all gateway instances from Ceph before removing the finalizer.

Fixes https://github.com/rook/rook/issues/18180



**Test Environment:** Minikube, Ceph v20.2.4-0, operator image `quay.io/oviner/rook:aug20_4`

**Test 1: CR deletion (delete all gateways)**
```
$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph nvme-gw show .nvmeof group-a | grep "num gws"
    "num gws": 1,

$ kubectl delete cephnvmeofgateway nvmeof -n rook-ceph
cephnvmeofgateway.ceph.rook.io "nvmeof" deleted

$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph nvme-gw show .nvmeof group-a | grep "num gws"
    "num gws": 0,
```

**Test 2: Scale-down via CR (instances 2→1)**
```
$ kubectl patch cephnvmeofgateway nvmeof -n rook-ceph --type=merge -p '{"spec":{"instances":2}}'
cephnvmeofgateway.ceph.rook.io/nvmeof patched

$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph nvme-gw show .nvmeof group-a | grep "gw-id"
            "gw-id": "rook-ceph-nvmeof-nvmeof-a",
            "gw-id": "rook-ceph-nvmeof-nvmeof-b",

$ kubectl patch cephnvmeofgateway nvmeof -n rook-ceph --type=merge -p '{"spec":{"instances":1}}'
cephnvmeofgateway.ceph.rook.io/nvmeof patched

$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph nvme-gw show .nvmeof group-a | grep -E "gw-id|Availability"
            "gw-id": "rook-ceph-nvmeof-nvmeof-a",
            "Availability": "CREATED",
            "gw-id": "rook-ceph-nvmeof-nvmeof-b",
            "Availability": "DELETING",

$ kubectl get deploy -n rook-ceph -l app=rook-ceph-nvmeof
NAME                        READY   UP-TO-DATE   AVAILABLE   AGE
rook-ceph-nvmeof-nvmeof-a   1/1     1            1           10m
```

**Test 3: Deployment scale-down (preStop hook)**
```
$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph nvme-gw show .nvmeof group-a | grep "num gws"
    "num gws": 1,

$ kubectl scale deployment rook-ceph-nvmeof-nvmeof-a -n rook-ceph --replicas=0
deployment.apps/rook-ceph-nvmeof-nvmeof-a scaled

$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph nvme-gw show .nvmeof group-a | grep "num gws"
    "num gws": 0,

$ kubectl scale deployment rook-ceph-nvmeof-nvmeof-a -n rook-ceph --replicas=1
deployment.apps/rook-ceph-nvmeof-nvmeof-a scaled

$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph nvme-gw show .nvmeof group-a | grep "num gws"
    "num gws": 1,
```

**Test 4: Pod deletion (preStop hook + init container re-register)**
```
$ kubectl get pods -n rook-ceph -l app=rook-ceph-nvmeof
NAME                                       READY   STATUS    RESTARTS   AGE
rook-ceph-nvmeof-nvmeof-a-d87f8995-tr24x   1/1     Running   0          67s

$ kubectl delete pod rook-ceph-nvmeof-nvmeof-a-d87f8995-tr24x -n rook-ceph
pod "rook-ceph-nvmeof-nvmeof-a-d87f8995-tr24x" deleted

$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph nvme-gw show .nvmeof group-a | grep "num gws"
    "num gws": 1,

$ kubectl get pods -n rook-ceph -l app=rook-ceph-nvmeof
NAME                                       READY   STATUS    RESTARTS   AGE
rook-ceph-nvmeof-nvmeof-a-d87f8995-5qzb8   1/1     Running   0          13s
```
(Gateway was deleted and immediately re-registered by the new pod's init container)

**Operator logs confirming delete commands:**
```
2026-08-20 13:23:14.668921 I | ceph-nvmeof-gateway: deleting nvme-gw "rook-ceph-nvmeof-nvmeof-a" from pool ".nvmeof" group "group-a"
2026-08-20 13:23:14.668933 D | exec: Running command: ceph nvme-gw delete rook-ceph-nvmeof-nvmeof-a .nvmeof group-a
2026-08-20 13:25:09.231390 I | ceph-nvmeof-gateway: scaling down from 2 to 1
2026-08-20 13:25:09.231403 I | ceph-nvmeof-gateway: deleting nvme-gw "rook-ceph-nvmeof-nvmeof-b" from pool ".nvmeof" group "group-a"
2026-08-20 14:12:27.027443 I | ceph-nvmeof-gateway: scaling down from 2 to 1
2026-08-20 14:12:27.027499 D | exec: Running command: ceph nvme-gw delete rook-ceph-nvmeof-nvmeof-b .nvmeof group-a
```

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

