### PR TITLE
build: fix TMPDIR handling and mode of generated helm resources.yaml

### DIFF
--- a/build/crds/build-crds.sh
+++ b/build/crds/build-crds.sh
@@ -70,7 +70,7 @@ EOF
 }
 
 build_helm_resources() {
-  TMP_FILE=$(mktemp -q /tmp/resources.XXXXXX || exit 1)
+  TMP_FILE=$(mktemp "${TMPDIR:-/tmp}/resources.XXXXXX" || exit 1)
   echo "Generating helm resources.yaml to temp file: $TMP_FILE"
   {
     # add header
@@ -85,6 +85,9 @@ build_helm_resources() {
     echo "{{- end }}"
   } >>"$TMP_FILE"
   echo "updating helm crds file $CEPH_HELM_CRDS_FILE_PATH from temp file"
+  # mktemp creates the file 0600 and mv carries that mode over to the
+  # destination, so the mode has to be set before the move.
+  chmod 0644 "$TMP_FILE"
   mv "$TMP_FILE" "$CEPH_HELM_CRDS_FILE_PATH"
 }
 


### PR DESCRIPTION
`make crds` fails outright wherever `/tmp` is not writable, such as a sandboxed build environment. `build/crds/build-crds.sh` hardcodes `mktemp -q /tmp/resources.XXXXXX` rather than honoring `TMPDIR`, and it is the only `mktemp` call in the repo that does.

This makes the temp path honor `TMPDIR`. It also sets the temp file's mode before installing it: `mktemp` creates the file 0600 and the `mv` carries that mode to the destination, so `resources.yaml` landed 0600 on disk while `crds.yaml`, written by direct redirect, landed 0644.

**AI assistance:** AI was used to diagnose the failure, to check the rest of the repo for the same pattern, and to draft the fix and this description.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
