### PR TITLE
core: report the actual error when cephx key fallback fails

### DIFF
--- a/pkg/operator/ceph/config/keyring/store.go
+++ b/pkg/operator/ceph/config/keyring/store.go
@@ -76,11 +76,11 @@ func (k *SecretStore) GenerateKey(user string, keyType cephv1.CephxKeyType, acce
 			"Attempting to update capabilities in case the user already exists. %v", user, err)
 		uErr := client.AuthUpdateCaps(k.context, k.clusterInfo, user, access)
 		if uErr != nil {
-			return "", errors.Wrapf(err, "failed to get, create, or update auth key for %s", user)
+			return "", errors.Wrapf(uErr, "failed to get, create, or update auth key for %s", user)
 		}
 		key, uErr = client.AuthGetKey(k.context, k.clusterInfo, user)
 		if uErr != nil {
-			return "", errors.Wrapf(err, "failed to get key after updating existing auth capabilities for %s", user)
+			return "", errors.Wrapf(uErr, "failed to get key after updating existing auth capabilities for %s", user)
 		}
 	}
 	return key, nil

--- a/pkg/operator/ceph/config/keyring/store_test.go
+++ b/pkg/operator/ceph/config/keyring/store_test.go
@@ -34,14 +34,16 @@ import (
 
 func TestGenerateKey(t *testing.T) {
 	clientset := testop.New(t, 1)
-	generateKey := ""
-	failGenerateKey := false
+	type mockResponse struct {
+		output string
+		err    error
+	}
+	responses := []mockResponse{}
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
-			if failGenerateKey {
-				return "", errors.New("test error")
-			}
-			return "{\"key\": \"" + generateKey + "\"}", nil
+			response := responses[0]
+			responses = responses[1:]
+			return response.output, response.err
 		},
 	}
 	ctx := &clusterd.Context{
@@ -52,23 +54,32 @@ func TestGenerateKey(t *testing.T) {
 	ownerInfo := k8sutil.OwnerInfo{}
 	s := GetSecretStore(ctx, cephclient.AdminTestClusterInfo(ns), &ownerInfo)
 
-	generateKey = "generatedsecretkey"
-	failGenerateKey = false
+	responses = append(responses, mockResponse{output: `{"key": "generatedsecretkey"}`})
 	k, e := s.GenerateKey("testuser", "", []string{"test", "access"})
 	assert.NoError(t, e)
 	assert.Equal(t, "generatedsecretkey", k)
 
-	generateKey = "differentsecretkey"
-	failGenerateKey = false
+	responses = append(responses, mockResponse{output: `{"key": "differentsecretkey"}`})
 	k, e = s.GenerateKey("testuser", "", []string{"test", "access"})
 	assert.NoError(t, e)
 	assert.Equal(t, "differentsecretkey", k)
 
-	// make sure error on fail
-	generateKey = "failgeneratekey"
-	failGenerateKey = true
+	responses = append(responses,
+		mockResponse{err: errors.New("get-or-create error")},
+		mockResponse{err: errors.New("update-caps error")},
+	)
 	_, e = s.GenerateKey("newuser", "", []string{"new", "access"})
-	assert.Error(t, e)
+	assert.ErrorContains(t, e, "update-caps error")
+	assert.NotContains(t, e.Error(), "get-or-create error")
+
+	responses = append(responses,
+		mockResponse{err: errors.New("get-or-create error")},
+		mockResponse{},
+		mockResponse{err: errors.New("get-key error")},
+	)
+	_, e = s.GenerateKey("existinguser", "", []string{"new", "access"})
+	assert.ErrorContains(t, e, "get-key error")
+	assert.NotContains(t, e.Error(), "get-or-create error")
 }
 
 func TestKeyringStore(t *testing.T) {


### PR DESCRIPTION
GenerateKey calls AuthGetOrCreateKey and, when that fails, falls back to AuthUpdateCaps followed by AuthGetKey so a user that already exists with different capabilities can still be reconciled.

Both fallback branches check uErr, but the errors they return wrap err, the failure from the original get-or-create attempt. Callers therefore receive that earlier error instead of the error from the fallback operation that actually failed.

Wrap uErr in both branches so each returned error identifies the operation that failed. The get-or-create error is still logged just above at info level.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [x] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

