### PR TITLE
ci: fix rgw-multisite-testing on Ceph v19.2.6

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -1993,6 +1993,10 @@ jobs:
           kubectl -n rook-ceph wait --for=condition=Ready pod -l rook_object_store=multisite-store --timeout=300s
           kubectl -n rook-ceph-secondary wait --for=condition=Ready pod -l rook_object_store=zone-b-multisite-store --timeout=300s
 
+      - name: restart RGWs to pick up the final multisite period
+        run: |
+          tests/scripts/github-action-helper.sh restart_multisite_rgws
+
       - name: wait for multisite sync to be established
         run: |
           tests/scripts/github-action-helper.sh wait_for_multisite_sync_established

--- a/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-multisite.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-multisite.md
@@ -21,6 +21,20 @@ To review core multisite concepts please read the
 
 This guide assumes a Rook cluster as explained in the [Quickstart](../../Getting-Started/quickstart.md).
 
+!!! warning
+    Ceph v19.2.6 and v20.2.4 harden SigV4 signature validation
+    ([CVE-2026-54330](https://docs.ceph.com/en/latest/security/CVE-2026-54330/)), but the
+    requests RGW's own multisite forwarding generates fail that validation even when every
+    connected cluster runs those versions. S3 operations that a non-master zone must forward
+    to the master zone (bucket creation, for example) fail with `403 AccessDenied`, and
+    `rgw_sigv4_insecure` alone does not restore them. Until a Ceph release fixes the
+    forwarding signatures ([tracker 79698](https://tracker.ceph.com/issues/79698)), set both
+    `rgw_sigv4_insecure: "true"` and `rgw_s3_client_max_sig_ver: "2"` in each multisite
+    object store's
+    [`gateway.rgwConfig`](../../CRDs/Object-Storage/ceph-object-store-crd.md#gateway-settings).
+    Once all connected clusters run fixed versions, set `rgw_sigv4_insecure` back to
+    `"false"` and `rgw_s3_client_max_sig_ver` back to `"-1"`.
+
 ## Creating Object Multisite
 
 If an admin wants to set up multisite on a Rook Ceph cluster, the following resources must be created:

--- a/Documentation/Upgrade/ceph-upgrade.md
+++ b/Documentation/Upgrade/ceph-upgrade.md
@@ -29,6 +29,11 @@ The following Ceph versions are supported in this release of Rook:
 * Ceph Squid v19.2.0 or newer
 * Ceph Tentacle v20.2.1 or newer
     * Recommended: [Disable the rook mgr module](#disable-the-rook-mgr-module) before upgrading to Tentacle.
+* Ceph Squid v19.2.6 and Tentacle v20.2.4: Multisite deployments need RGW settings applied **before** upgrading
+    * The SigV4 hardening in these releases (CVE-2026-54330) rejects the requests RGW's own multisite
+    forwarding generates ([tracker 79698](https://tracker.ceph.com/issues/79698)).
+    See the [multisite documentation](../Storage-Configuration/Object-Storage-RGW/ceph-object-multisite.md)
+    for the required settings and when to revert them.
 * Ceph Tentacle v20.2.0: Not recommended
     * IMPORTANT: **There is a known data corruption issue in v20.2.0**, if the "read affinity" feature is enabled.
     Read affinity is disabled by default, and is enabled by the CephCluster setting `csi.readAffinity.enabled: true`.

--- a/deploy/examples/cluster-test.yaml
+++ b/deploy/examples/cluster-test.yaml
@@ -63,6 +63,12 @@ spec:
       bdev_flock_retry: "20"
       bluefs_buffered_io: "false"
       mon_data_avail_warn: "10"
+      # several test OSDs share one small node; the 4Gi default overcommits its memory
+      osd_memory_target: "1073741824"
+      # multisite sync polls every log shard per interval; the defaults (64/128 shards)
+      # swamp small test clusters with sync traffic. Same tuning as ceph's multisite QA.
+      rgw_md_log_max_shards: "4"
+      rgw_data_log_num_shards: "4"
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool

--- a/deploy/examples/object-multisite-pull-realm-test.yaml
+++ b/deploy/examples/object-multisite-pull-realm-test.yaml
@@ -63,5 +63,12 @@ spec:
     port: 80
     # securePort: 443
     instances: 1
+    rgwConfig:
+      # Ceph v19.2.6/v20.2.4 harden SigV4 validation (CVE-2026-54330), and RGW's own multisite
+      # forwarding fails it even between same-version zones, breaking writes to the secondary
+      # zone. Accept the improper signatures and keep inter-zone requests on SigV2 until Ceph
+      # fixes the forwarding signatures: https://tracker.ceph.com/issues/79698
+      rgw_sigv4_insecure: "true"
+      rgw_s3_client_max_sig_ver: "2"
   zone:
     name: zone-b

--- a/deploy/examples/object-multisite-test.yaml
+++ b/deploy/examples/object-multisite-test.yaml
@@ -51,5 +51,12 @@ spec:
     port: 80
     # securePort: 443
     instances: 1
+    rgwConfig:
+      # Ceph v19.2.6/v20.2.4 harden SigV4 validation (CVE-2026-54330), and RGW's own multisite
+      # forwarding fails it even between same-version zones, breaking writes to the secondary
+      # zone. Accept the improper signatures and keep inter-zone requests on SigV2 until Ceph
+      # fixes the forwarding signatures: https://tracker.ceph.com/issues/79698
+      rgw_sigv4_insecure: "true"
+      rgw_s3_client_max_sig_ver: "2"
   zone:
     name: zone-a

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -433,7 +433,9 @@ function deploy_manifest_with_local_build() {
   kubectl create -f $1
 }
 
-# Deploy toolbox with same ceph version as the cluster-test for ci
+# Deploy the toolbox from its committed manifest. The toolbox image deliberately does NOT
+# track the cluster under test: the version skew exercises Ceph's cross-version client
+# compatibility promises, which has caught real Ceph API breaks before release.
 function deploy_toolbox() {
   cd "${REPO_DIR}/deploy/examples"
   local ns

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -842,6 +842,18 @@ function nudge_multisite_secondary() {
   kubectl -n rook-ceph-secondary rollout status deploy/rook-ceph-rgw-zone-b-multisite-store-a --timeout=120s
 }
 
+# Both RGWs boot while the multisite period is still converging (zone-b joins the zonegroup
+# only after zone-a is already serving), and a gateway that raced a period change can leave its
+# sync state machine wedged in "init" without ever erroring. Restarting the gateways once the
+# join has settled makes sync initialize from the final period, mirroring ceph's own multisite
+# QA, which restarts zone gateways after committing period changes.
+function restart_multisite_rgws() {
+  kubectl -n rook-ceph rollout restart deploy/rook-ceph-rgw-multisite-store-a
+  kubectl -n rook-ceph-secondary rollout restart deploy/rook-ceph-rgw-zone-b-multisite-store-a
+  kubectl -n rook-ceph rollout status deploy/rook-ceph-rgw-multisite-store-a --timeout=120s
+  kubectl -n rook-ceph-secondary rollout status deploy/rook-ceph-rgw-zone-b-multisite-store-a --timeout=120s
+}
+
 function wait_for_multisite_sync_established() {
   # Wait until both zones report multisite sync fully established before exercising
   # replication, mirroring the checkpoints ceph's own multisite QA performs before asserting
@@ -863,10 +875,24 @@ function wait_for_multisite_sync_established() {
     fi
     nudge_multisite_secondary
   done
-  # Data sync legitimately reports caught up at 0/0 shards before any objects are written, so the
-  # meaningful precondition is that metadata sync (above) has actually initialized.
-  wait_for_sync_status rook-ceph-secondary zone-b "data is caught up with source" 300
-  wait_for_sync_status rook-ceph zone-a "data is caught up with source" 300
+  # "data is caught up with source" is vacuously true while data sync is still wedged in "init"
+  # (it reports 0/0 shards), so require the shard counts that prove sync actually initialized.
+  # A wedged gateway never leaves "init" on its own; restart it and retry once (see
+  # restart_multisite_rgws).
+  local initialized='incremental sync: [0-9]*/[1-9]'
+  wait_for_sync_status rook-ceph-secondary zone-b "$initialized" 300
+  for attempt in 1 2; do
+    if wait_for_sync_status rook-ceph zone-a "$initialized" 180; then
+      return 0
+    fi
+    if [[ $attempt -ge 2 ]]; then
+      echo "zone-a data sync never initialized after ${attempt} attempts"
+      return 1
+    fi
+    echo "nudging zone-a: restarting its RGW to re-run data sync init"
+    kubectl -n rook-ceph rollout restart deploy/rook-ceph-rgw-multisite-store-a
+    kubectl -n rook-ceph rollout status deploy/rook-ceph-rgw-multisite-store-a --timeout=120s
+  done
 }
 
 function dump_multisite_diagnostics() {

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -955,7 +955,7 @@ function write_object_read_from_replica_cluster() {
   # zone's position, the same marker-based barrier ceph's own multisite QA uses. The bucket
   # metadata has to arrive on the reading zone via metadata sync before the checkpoint can
   # resolve the bucket at all, hence the outer retry.
-  retry_for 120 kubectl -n "$read_cluster_ns" exec deploy/rook-ceph-tools -- \
+  retry_for 300 kubectl -n "$read_cluster_ns" exec deploy/rook-ceph-tools -- \
     radosgw-admin bucket sync checkpoint --rgw-realm=realm-a --rgw-zonegroup=zonegroup-a --rgw-zone="$read_zone" \
     --bucket="$test_bucket_name" --source-zone="$write_zone" --retry-delay-ms=5000 --timeout-sec=300
 

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -906,15 +906,25 @@ function dump_multisite_diagnostics() {
     if [[ "$ns" == "rook-ceph" ]]; then zone="zone-a"; else zone="zone-b"; fi
     echo "===== ${ns}: pods"
     kubectl -n "$ns" get pods -o wide
+    # the cluster this dump runs against just failed, so bound every toolbox command: an
+    # unreachable cluster must not stall the dump for the full rados client mount timeout
+    echo "===== ${ns}: ceph versions"
+    kubectl -n "$ns" exec deploy/rook-ceph-tools -- ceph --connect-timeout 10 versions
     echo "===== ${ns}: rgw pod details"
     kubectl -n "$ns" describe pods -l app=rook-ceph-rgw
-    echo "===== ${ns}: rgw pod logs"
-    kubectl -n "$ns" logs -l app=rook-ceph-rgw --all-containers --tail=100
+    echo "===== ${ns}: rgw pod logs (excluding successful requests)"
+    # multisite sync polling produces hundreds of 2xx request lines per second, so a raw tail
+    # covers only milliseconds; drop 2xx request/response lines to surface errors instead
+    kubectl -n "$ns" logs -l app=rook-ceph-rgw --all-containers --tail=5000 |
+      grep -Ev 'http_status=2[0-9]{2} |" 2[0-9]{2} |====== starting new request' | tail -n 150
+    echo "===== ${ns}: sync error list"
+    kubectl -n "$ns" exec deploy/rook-ceph-tools -- \
+      timeout 60 radosgw-admin sync error list --rgw-realm=realm-a --rgw-zonegroup=zonegroup-a --rgw-zone="$zone" | head -n 100
     echo "===== ${ns}: sync status (${zone})"
     kubectl -n "$ns" exec deploy/rook-ceph-tools -- \
-      radosgw-admin sync status --rgw-realm=realm-a --rgw-zonegroup=zonegroup-a --rgw-zone="$zone"
+      timeout 60 radosgw-admin sync status --rgw-realm=realm-a --rgw-zonegroup=zonegroup-a --rgw-zone="$zone"
     echo "===== ${ns}: period"
-    kubectl -n "$ns" exec deploy/rook-ceph-tools -- radosgw-admin period get --rgw-realm=realm-a
+    kubectl -n "$ns" exec deploy/rook-ceph-tools -- timeout 60 radosgw-admin period get --rgw-realm=realm-a
   done
   set -e
   return 0


### PR DESCRIPTION
`rgw-multisite-testing` has failed on every PR since the floating `ceph:v19` tag moved to v19.2.6: the CVE-2026-54330 SigV4 hardening rejects RGW's own multisite forwarding (broken even between same-version zones), so secondary-zone bucket creation 403s deterministically.

This sets `rgw_sigv4_insecure` and `rgw_s3_client_max_sig_ver` in the multisite manifests until fixed images exist ([tracker 79698](https://tracker.ceph.com/issues/79698)), restarts the RGWs once the second zone has joined, trims OSD memory and sync-log shard pressure, makes the multisite failure dump readable, and documents the workaround.

**Issue resolved by this Pull Request:**
Resolves #18212

AI assistance: an AI agent investigated the CI failure and the upstream Ceph regression, and drafted the changes, commit messages, and this description.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
