### PR TITLE
doc: Add steps to handle the ceph health warnings to the common issues guide

### DIFF
--- a/Documentation/Troubleshooting/ceph-common-issues.md
+++ b/Documentation/Troubleshooting/ceph-common-issues.md
@@ -12,6 +12,7 @@ title: Ceph Common Issues
     - [Ceph Tools](#ceph-tools)
     - [Tools in the Rook Toolbox](#tools-in-the-rook-toolbox)
     - [Ceph Commands](#ceph-commands)
+- [Ceph health warnings](#ceph-health-warnings)
 - [Cluster failing to service requests](#cluster-failing-to-service-requests)
 - [Monitors are the only pods running](#monitors-are-the-only-pods-running)
 - [PVCs stay in pending state](#pvcs-stay-in-pending-state)
@@ -75,6 +76,30 @@ Here are some common commands to troubleshoot a Ceph cluster:
 The first two status commands provide the overall cluster health. The normal state for cluster operations is HEALTH_OK, but will still function when the state is in a HEALTH_WARN state. If you are in a WARN state, then the cluster is in a condition that it may enter the HEALTH_ERROR state at which point *all* disk I/O operations are halted. If a HEALTH_WARN state is observed, then one should take action to prevent the cluster from halting when it enters the HEALTH_ERROR state.
 
 There are many Ceph sub-commands to look at and manipulate Ceph objects, well beyond the scope this document. See the [Ceph documentation](https://docs.ceph.com/) for more details of gathering information about the health of the cluster. In addition, there are other helpful hints and some best practices located in the [Advanced Configuration section](../Storage-Configuration/Advanced/ceph-configuration.md). Of particular note, there are scripts for collecting logs and gathering OSD information there.
+
+## Ceph health warnings
+
+After installing Rook, `ceph status` may show health warnings since the Ceph release with
+a new AES256 key type as outlined in the [Rook advisory](https://medium.com/rook-io/rook-advisory-for-ceph-cve-2025-30156-cc1f8dee6da3).
+
+### Symptoms
+
+```console
+$ ceph status
+...
+    health: HEALTH_WARN
+            4 auth client entities with insecure key types
+            Monitors are configured to allow auth using insecure key types
+            Monitors are configured to allow creation of insecure key types
+```
+
+### Solution
+
+There are two options to resolve these health warnings:
+
+1. Update all client cephx keys to AES256K. This requires a kernel version 7.0 or newer. See the
+    [Cephx Keys and Rotation](../Storage-Configuration/Advanced/cephx-key-rotation.md) topic.
+2. The health warnings can be muted. See the topic on [muting the health warnings](../Storage-Configuration/Advanced/cephx-key-rotation.md#warnings).
 
 ## Cluster failing to service requests
 

--- a/deploy/examples/cluster-test.yaml
+++ b/deploy/examples/cluster-test.yaml
@@ -51,6 +51,15 @@ spec:
       mon:
         interval: 45s
         timeout: 600s
+    muteHealthWarning:
+      AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE:
+        policy: mute
+      AUTH_INSECURE_CLIENT_KEY_TYPE:
+        policy: mute
+      AUTH_INSECURE_KEYS_ALLOWED:
+        policy: mute
+      AUTH_INSECURE_KEYS_CREATABLE:
+        policy: mute
   priorityClassNames:
     all: system-node-critical
     mgr: system-cluster-critical


### PR DESCRIPTION
A couple of updates to help users deal with the new ceph health warnings:
- Add troubleshooting guide steps for dealing with the new health warnings, either to update the client keys or mute them.
- Mute the ceph health warnings in test clusters. All new clusters will by default will still be using aes client keys, which will trigger the ceph health warnings from the new key types. Test clusters can mute these warnings by default.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

