### PR TITLE
doc: update upgrade doc oldver 1.19 to latest 

### DIFF
--- a/Documentation/Upgrade/rook-upgrade.md
+++ b/Documentation/Upgrade/rook-upgrade.md
@@ -143,7 +143,7 @@ In order to successfully upgrade a Rook cluster, the following prerequisites mus
 
 ## Rook Operator Upgrade
 
-The examples given in this guide upgrade a live Rook cluster running `v1.19.8` to
+The examples given in this guide upgrade a live Rook cluster running `v1.19.10` to
 the version `v1.20.5`. This upgrade should work from any official patch release of Rook v1.19 to any
 official patch release of v1.20.
 
@@ -271,8 +271,8 @@ rook-ceph-mon-a         req/upd/avl: 1/1/1      rook-version=v1.20.5
 rook-ceph-mon-b         req/upd/avl: 1/1/1      rook-version=v1.20.5
 rook-ceph-mon-c         req/upd/avl: 1/1/1      rook-version=v1.20.5
 rook-ceph-osd-0         req/upd/avl: 1//        rook-version=v1.20.5
-rook-ceph-osd-1         req/upd/avl: 1/1/1      rook-version=v1.19.8
-rook-ceph-osd-2         req/upd/avl: 1/1/1      rook-version=v1.19.8
+rook-ceph-osd-1         req/upd/avl: 1/1/1      rook-version=v1.19.10
+rook-ceph-osd-2         req/upd/avl: 1/1/1      rook-version=v1.19.10
 ```
 
 An easy check to see if the upgrade is totally finished is to check that there is only one
@@ -281,7 +281,7 @@ An easy check to see if the upgrade is totally finished is to check that there i
 ```console
 # kubectl -n $ROOK_CLUSTER_NAMESPACE get deployment -l rook_cluster=$ROOK_CLUSTER_NAMESPACE -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq
 This cluster is not yet finished:
-  rook-version=v1.19.8
+  rook-version=v1.19.10
   rook-version=v1.20.5
 This cluster is finished:
   rook-version=v1.20.5


### PR DESCRIPTION
Update the previous (old) 1.19 version shown as an example in the upgrade docs to the latest 1.19.10 to show best practices. 1.19.10 is practically needed for CephX key type updates.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

