### PR TITLE
osd: fix minimum failure domain never matching region

### DIFF
--- a/pkg/operator/ceph/disruption/clusterdisruption/pools.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/pools.go
@@ -87,8 +87,7 @@ func getMinimumFailureDomain(poolList []cephv1.PoolSpec) string {
 
 	for _, pool := range poolList {
 		for index, failureDomain := range topology.CRUSHMapLevelsOrdered {
-			if index == minfailureDomainIndex {
-				// index is higher-than/equal-to the min
+			if index > minfailureDomainIndex {
 				break
 			}
 			if pool.FailureDomain == failureDomain {

--- a/pkg/operator/ceph/disruption/clusterdisruption/pools_test.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/pools_test.go
@@ -40,6 +40,13 @@ func TestGetMinimumFailureDomain(t *testing.T) {
 
 	assert.Equal(t, "zone", getMinimumFailureDomain(poolList))
 
+	// region is the highest level, so it is the minimum only when every pool uses it
+	poolList = []cephv1.PoolSpec{
+		{FailureDomain: "region"},
+	}
+
+	assert.Equal(t, "region", getMinimumFailureDomain(poolList))
+
 	poolList = []cephv1.PoolSpec{
 		{FailureDomain: "region"},
 		{FailureDomain: "zone"},


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #18228

**Motivation**

`getMinimumFailureDomain` can never return `region`: it seeds the minimum with region's index and then breaks out of the comparison loop before comparing it. A cluster whose pools all use `failureDomain: region` silently falls back to `host`, so OSD disruption budgets protect at host granularity and node maintenance serialises further than the pool's failure domain requires.

**What changed**

The loop now breaks only once the index is strictly above the current minimum, so the seeded ceiling is itself compared. A region-only case is added to `TestGetMinimumFailureDomain`, which fails before the fix and passes after.

AI assistance: this bug was surfaced during an AI-assisted review of the disruption controller; the fix, the added test case, and this description were drafted with AI assistance.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [x] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
