### PR TITLE
osd: skip raw list entries without an osd_id during activation

### DIFF
--- a/pkg/operator/ceph/cluster/osd/activate-osd.sh
+++ b/pkg/operator/ceph/cluster/osd/activate-osd.sh
@@ -109,7 +109,7 @@ else
 		python3 -c "
 import sys, json
 for _, info in json.load(sys.stdin).items():
-	if info['osd_id'] == $OSD_ID:
+	if info.get('osd_id') == $OSD_ID:
 		print(info['device'], end='')
 		print('found device: ' + info['device'], file=sys.stderr) # log the disk we found to stderr
 		sys.exit(0)  # don't keep processing once the disk is found

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -19,6 +19,8 @@ package osd
 
 import (
 	"context"
+	"os/exec"
+	"strings"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -38,6 +40,33 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
+
+func TestFindRawOSDDevice(t *testing.T) {
+	rawList := `{
+		"aux": {
+			"osd_uuid": "abc",
+			"device_db": "/dev/db"
+		},
+		"main": {
+			"osd_id": 3,
+			"device": "/dev/sdc"
+		}
+	}`
+	_, pythonCode, found := strings.Cut(activateOSDOnNodeCode, "python3 -c \"\n")
+	if !found {
+		t.Fatal("failed to find Python device lookup in the OSD activation script")
+	}
+	pythonCode, _, found = strings.Cut(pythonCode, "\n\"")
+	if !found {
+		t.Fatal("failed to find the end of the Python device lookup in the OSD activation script")
+	}
+	command := exec.Command("python3", "-c", strings.ReplaceAll(pythonCode, "$OSD_ID", "3")) //nolint:gosec // command and arguments are test constants
+	command.Stdin = strings.NewReader(rawList)
+
+	output, err := command.Output()
+	assert.NoError(t, err)
+	assert.Equal(t, "/dev/sdc", string(output))
+}
 
 func TestPodContainer(t *testing.T) {
 	cluster := &Cluster{rookVersion: "23", clusterInfo: cephclient.AdminTestClusterInfo("myosd")}


### PR DESCRIPTION
When an OSD's persisted block path is stale, the activation script scans eligible local block devices with `ceph-volume raw list` and picks the entry whose `osd_id` matches the OSD being started.

`ceph-volume` reports `osd_id` and `device` only for an OSD's main block device. An entry describing a dedicated BlueFS DB or WAL device omits both, carrying `osd_uuid` alongside `device_db` or `device_wal`. Reading `osd_id` by subscript therefore raises `KeyError` and aborts the scan. An OSD is affected only when the fallback scan runs and such an entry is iterated before the entry for the target OSD.

Read the key with `get()` so entries that do not describe a main block device are skipped instead of aborting the scan.

Fixes #17983

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [x] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

