### PR TITLE
pool: report the built-in pool name in its validation error

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/pool.go
+++ b/pkg/apis/ceph.rook.io/v1/pool.go
@@ -36,7 +36,7 @@ func (p *PoolSpec) IsHybridStoragePool() bool {
 func ValidateCephBlockPool(p *CephBlockPool) error {
 	if p.Spec.Name == ".rgw.root" || p.Spec.Name == ".mgr" || p.Spec.Name == ".nfs" {
 		if p.Spec.IsErasureCoded() {
-			return errors.Errorf("invalid CephBlockPool spec: ceph built-in pool %q cannot be erasure coded", p.Name)
+			return errors.Errorf("invalid CephBlockPool spec: ceph built-in pool %q cannot be erasure coded", p.Spec.Name)
 		}
 	}
 

--- a/pkg/apis/ceph.rook.io/v1/pool_test.go
+++ b/pkg/apis/ceph.rook.io/v1/pool_test.go
@@ -45,6 +45,21 @@ func TestValidatePoolSpec(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestValidateCephBlockPoolBuiltInPool(t *testing.T) {
+	p := &CephBlockPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pool"},
+		Spec: NamedBlockPoolSpec{
+			Name: ".mgr",
+			PoolSpec: PoolSpec{
+				ErasureCoded: ErasureCodedSpec{CodingChunks: 1, DataChunks: 2},
+			},
+		},
+	}
+
+	err := ValidateCephBlockPool(p)
+	assert.EqualError(t, err, `invalid CephBlockPool spec: ceph built-in pool ".mgr" cannot be erasure coded`)
+}
+
 func TestMirroringSpec_SnapshotSchedulesEnabled(t *testing.T) {
 	type fields struct {
 		Enabled           bool


### PR DESCRIPTION
ValidateCephBlockPool rejects an erasure-coded spec for the Ceph built-in pools, which it identifies by `spec.name`. The error it returns interpolates `metadata.name`, the name of the Kubernetes resource rather than the Ceph pool that was validated, so it points users at the wrong pool name.

Interpolate `spec.name` so the error names the rejected pool.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [x] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

