### PR TITLE
core: look up mirror daemon versions by their daemon type

### DIFF
--- a/pkg/daemon/ceph/client/upgrade.go
+++ b/pkg/daemon/ceph/client/upgrade.go
@@ -278,8 +278,10 @@ func daemonMapEntry(versions *cephv1.CephDaemonsVersions, daemonType string) (ma
 		return versions.Osd, nil
 	case "rgw":
 		return versions.Rgw, nil
-	case "mirror":
+	case "rbd-mirror":
 		return versions.RbdMirror, nil
+	case "fs-mirror":
+		return versions.CephFSMirror, nil
 	}
 
 	return nil, errors.Errorf("invalid daemonType %s", daemonType)

--- a/pkg/daemon/ceph/client/upgrade_test.go
+++ b/pkg/daemon/ceph/client/upgrade_test.go
@@ -127,23 +127,36 @@ func TestFindFSName(t *testing.T) {
 }
 
 func TestDaemonMapEntry(t *testing.T) {
-	dummyVersionsRaw := []byte(`
-	{
-		"mon": {
-			"ceph version 18.2.5 (cbff874f9007f1869bfd3821b7e33b2a6ffd4988) reef (stable)": 1,
-			"ceph version 19.2.0 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) squid (stable)": 2
-		}
-	}`)
+	dummyVersions := cephv1.CephDaemonsVersions{
+		Mon:          map[string]int{"mon": 1},
+		Mgr:          map[string]int{"mgr": 1},
+		Mds:          map[string]int{"mds": 1},
+		Osd:          map[string]int{"osd": 1},
+		Rgw:          map[string]int{"rgw": 1},
+		RbdMirror:    map[string]int{"rbd-mirror": 1},
+		CephFSMirror: map[string]int{"fs-mirror": 1},
+	}
+	tests := []struct {
+		daemonType string
+		expected   map[string]int
+	}{
+		{"mon", dummyVersions.Mon},
+		{"mgr", dummyVersions.Mgr},
+		{"mds", dummyVersions.Mds},
+		{"osd", dummyVersions.Osd},
+		{"rgw", dummyVersions.Rgw},
+		{"rbd-mirror", dummyVersions.RbdMirror},
+		{"fs-mirror", dummyVersions.CephFSMirror},
+	}
+	for _, tt := range tests {
+		t.Run(tt.daemonType, func(t *testing.T) {
+			m, err := daemonMapEntry(&dummyVersions, tt.daemonType)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, m)
+		})
+	}
 
-	var dummyVersions cephv1.CephDaemonsVersions
-	err := json.Unmarshal([]byte(dummyVersionsRaw), &dummyVersions)
-	assert.NoError(t, err)
-
-	m, err := daemonMapEntry(&dummyVersions, "mon")
-	assert.NoError(t, err)
-	assert.Equal(t, dummyVersions.Mon, m)
-
-	_, err = daemonMapEntry(&dummyVersions, "dummy")
+	_, err := daemonMapEntry(&dummyVersions, "dummy")
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
Callers reach daemonMapEntry through LeastUptodateDaemonVersion, passing the daemon type strings defined in `pkg/operator/ceph/config`. That package imports this one, so the switch cannot reference the constants and matches their values instead. The rbd-mirror case matched `mirror` rather than `rbd-mirror`, and no case returned `CephFSMirror` for `fs-mirror`, so both fell through to the invalid daemonType error. This is currently latent because production callers only request mon or OSD versions.

Match `rbd-mirror` and `fs-mirror` to their corresponding version maps, and cover every supported mapping in the test.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [x] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

