### PR TITLE
osd: scan devices individually when listing raw OSDs node-wide

### DIFF
--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -1053,17 +1053,9 @@ func unmountDevice(context *clusterd.Context, devicePath string) error {
 // WipeDevicesFromOtherClusters wipes the OSD backed disks if they have metadata from a different ceph cluster.
 // The wiped disks can then be used to prepare OSDs for the current ceph cluster.
 func (a *OsdAgent) WipeDevicesFromOtherClusters(context *clusterd.Context) error {
-	args := []string{"raw", "list", "--format", "json"}
-
-	result, err := callCephVolume(context, args...)
+	existingOSDs, err := rawListOSDsPerDevice(context)
 	if err != nil {
 		return errors.Wrapf(err, "failed to retrieve ceph-volume raw list results")
-	}
-
-	var existingOSDs map[string]osdInfoBlock
-	err = json.Unmarshal([]byte(result), &existingOSDs)
-	if err != nil {
-		return errors.Wrapf(err, "failed to unmarshal ceph-volume raw list results")
 	}
 
 	if len(existingOSDs) == 0 {
@@ -1403,22 +1395,30 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 		}
 	}
 
-	args := []string{cvMode, "list", block, "--format", "json"}
-	if block == "" {
-		setDevicePathFromList = true
-		args = []string{cvMode, "list", "--format", "json"}
-	}
-
-	result, err := callCephVolume(context, args...)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to retrieve ceph-volume %s list results", cvMode)
-	}
-
 	var osds []oposd.OSDInfo
 	var cephVolumeResult map[string]osdInfoBlock
-	err = json.Unmarshal([]byte(result), &cephVolumeResult)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal ceph-volume %s list results", cvMode)
+	var err error
+	if block == "" {
+		// A no-argument "ceph-volume raw list" batches ceph-bluestore-tool show-label across every
+		// block device. On Ceph v19.2.3+ (Squid) and v20.2.x (Tentacle) that batched call fails two
+		// ways: one unreadable device (canonically a sub-4KiB MBR extended-partition node) aborts it
+		// and blanks the entire listing to "{}" with a zero exit code
+		// (https://tracker.ceph.com/issues/76354, rook #17992), and on a many-device node its stderr
+		// can overflow the pipe buffer and deadlock ceph-volume. List each device individually
+		// instead: one small call per device avoids both, and one bad device cannot hide the rest.
+		setDevicePathFromList = true
+		cephVolumeResult, err = rawListOSDsPerDevice(context)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to retrieve ceph-volume %s list results", cvMode)
+		}
+	} else {
+		result, err := callCephVolume(context, cvMode, "list", block, "--format", "json")
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to retrieve ceph-volume %s list results", cvMode)
+		}
+		if err := json.Unmarshal([]byte(result), &cephVolumeResult); err != nil {
+			return nil, errors.Wrapf(err, "failed to unmarshal ceph-volume %s list results", cvMode)
+		}
 	}
 
 	for _, osdInfo := range cephVolumeResult {
@@ -1557,6 +1557,116 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 	logger.Infof("%d ceph-volume raw osd devices configured on this node", len(osds))
 
 	return osds, nil
+}
+
+// listNodeScanDevices returns the block device paths to scan when listing OSDs across the whole
+// node without a specific device argument. It must see every device class the no-argument
+// "ceph-volume raw list" it replaces could report an OSD on, so it keeps physical disks, their
+// partitions, loop devices (OSDs on loop devices are supported for CI and local testing), and the
+// device-mapper node types a raw OSD presents as once opened: dmcrypt-encrypted OSDs (crypt), OSDs
+// reported through an LVM device path (lvm), multipath LUNs (mpath), and linear maps (linear).
+// Missing the mapper types would silently drop encrypted and mapped raw OSDs from cluster cleanup
+// (leaving their disks un-sanitized) and from OSD-by-id lookup. It excludes network-backed devices
+// (rbd, nbd, drbd), which can hang when opened while this node's storage is degraded, and volatile
+// RAM (zram); Rook never provisions OSDs on any of those.
+func listNodeScanDevices(context *clusterd.Context) ([]string, error) {
+	output, err := context.Executor.ExecuteCommandWithOutput(
+		"lsblk", "--noheadings", "--paths", "--list", "--output", "NAME,TYPE")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list node block devices")
+	}
+
+	scannableTypes := map[string]bool{
+		sys.DiskType:   true,
+		sys.PartType:   true,
+		sys.LoopType:   true,
+		sys.CryptType:  true,
+		sys.LVMType:    true,
+		sys.MultiPath:  true,
+		sys.LinearType: true,
+	}
+	excludedPrefixes := []string{"/dev/rbd", "/dev/nbd", "/dev/zram", "/dev/drbd"}
+	var devices []string
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		name, deviceType := fields[0], fields[1]
+		if !scannableTypes[deviceType] {
+			continue
+		}
+		excluded := false
+		for _, prefix := range excludedPrefixes {
+			if strings.HasPrefix(name, prefix) {
+				excluded = true
+				break
+			}
+		}
+		if !excluded {
+			devices = append(devices, name)
+		}
+	}
+
+	return devices, nil
+}
+
+// rawListOSDsPerDevice runs "ceph-volume raw list <device>" against each block device on the node
+// and merges the results, keyed by OSD UUID as the raw-list output is. On Ceph v19.2.3+ (Squid) and
+// v20.2.x (Tentacle) the no-argument "ceph-volume raw list" batches ceph-bluestore-tool show-label
+// across every device, which fails two ways: one unreadable device aborts the batch and blanks the
+// whole listing to "{}" with a zero exit code (https://tracker.ceph.com/issues/76354, rook #17992),
+// and a many-device node can overflow the stderr pipe buffer and deadlock ceph-volume. Listing per
+// device is immune to both; a device that fails to list is logged and skipped so one bad device
+// cannot hide the OSDs on the others.
+func rawListOSDsPerDevice(context *clusterd.Context) (map[string]osdInfoBlock, error) {
+	devices, err := listNodeScanDevices(context)
+	if err != nil {
+		return nil, err
+	}
+
+	mergedOSDs := map[string]osdInfoBlock{}
+	failures := 0
+	for _, device := range devices {
+		result, err := callCephVolume(context, "raw", "list", device, "--format", "json")
+		if err != nil {
+			failures++
+			logger.Warningf("skipping device %q that could not be listed with ceph-volume raw list: %v", device, err)
+			continue
+		}
+
+		deviceOSDs := map[string]osdInfoBlock{}
+		if err := json.Unmarshal([]byte(result), &deviceOSDs); err != nil {
+			failures++
+			logger.Warningf("skipping device %q with unparsable ceph-volume raw list output: %v", device, err)
+			continue
+		}
+
+		for osdUUID, osdInfo := range deviceOSDs {
+			// Passing a device explicitly opts out of the curation the no-argument
+			// "ceph-volume raw list" performs. Scanning a bluefs db or wal member (rather than
+			// the OSD's main block device) yields a partial record - only osd_uuid set, with an
+			// empty device and ceph_fsid - under the same osd_uuid key as the real block entry.
+			// Skip these so a partial record can never overwrite or masquerade as a real OSD (an
+			// empty ceph_fsid would otherwise read as "belongs to another cluster").
+			if osdInfo.Device == "" {
+				continue
+			}
+			mergedOSDs[osdUUID] = osdInfo
+		}
+	}
+
+	// Skipping one unreadable device is the point of listing per device, but if every enumerated
+	// device failed this is a systemic ceph-volume failure (a broken image, a missing binary),
+	// not a node that legitimately reports no OSDs. Surface it so callers that only act on an
+	// error - the cluster-cleanup sanitizer and OSD-by-id lookup - do not read "everything is
+	// broken" as "no OSDs to clean up" and silently do nothing, as the single no-argument call
+	// they replaced would have returned an error here.
+	if len(devices) > 0 && failures == len(devices) {
+		return nil, errors.Errorf("ceph-volume raw list failed for all %d scanned devices", failures)
+	}
+
+	return mergedOSDs, nil
 }
 
 func callCephVolume(context *clusterd.Context, args ...string) (string, error) {

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -570,6 +570,9 @@ func TestConfigureCVDevices(t *testing.T) {
 			if command == "lsblk" && (args[0] == "/dev/vdb1") {
 				return fmt.Sprintf(`SIZE="17179869184" ROTA="1" RO="0" TYPE="part" PKNAME="" NAME="%s" KNAME="%s"`, args[0], args[0]), nil
 			}
+			if command == "lsblk" && args[0] == "--noheadings" {
+				return "/dev/vdb1 part", nil
+			}
 			if args[1] == "ceph-volume" && args[4] == "raw" && args[5] == "list" {
 				return cephVolumeRawPartitionTestResult, nil
 			}
@@ -623,6 +626,9 @@ func TestConfigureCVDevices(t *testing.T) {
 			// get lsblk for disks from cephVolumeRAWTestResult var
 			if command == "lsblk" && (args[0] == "/dev/vdb" || args[0] == "/dev/vdc") {
 				return fmt.Sprintf(`SIZE="17179869184" ROTA="1" RO="0" TYPE="disk" PKNAME="" NAME="%s" KNAME="%s"`, args[0], args[0]), nil
+			}
+			if command == "lsblk" && args[0] == "--noheadings" {
+				return "/dev/vdb disk\n/dev/vdc disk", nil
 			}
 			if args[1] == "ceph-volume" && args[4] == "raw" && args[5] == "list" {
 				return cephVolumeRAWTestResult, nil
@@ -684,6 +690,11 @@ func TestConfigureCVDevices(t *testing.T) {
 			if args[0] == "auth" && args[1] == "get-or-create-key" {
 				return "{\"key\":\"mysecurekey\"}", nil
 			}
+			// The whole-node scan enumerates only the parent disk, so the freshly prepared
+			// partition is not scanned and its OSD is missed until it is listed individually.
+			if command == "lsblk" && args[0] == "--noheadings" {
+				return "/dev/vdb disk", nil
+			}
 			if args[1] == "ceph-volume" && args[4] == "raw" && args[5] == "list" && args[6] == "/dev/vdb1" {
 				// listing the specific device finds the OSD
 				return cephVolumeRawPartitionTestResult, nil
@@ -734,6 +745,9 @@ func TestConfigureCVDevices(t *testing.T) {
 		executor := &exectest.MockExecutor{}
 		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 			logger.Infof("[MockExecuteCommandWithOutput] %s %v", command, args)
+			if command == "lsblk" && args[0] == "--noheadings" {
+				return "/dev/vdb1 part", nil
+			}
 			if args[0] == "auth" && args[1] == "get-or-create-key" {
 				return "{\"key\":\"mysecurekey\"}", nil
 			}
@@ -1846,6 +1860,11 @@ func TestParseCephVolumeRawResult(t *testing.T) {
 			}
 		}
 
+		// whole-node device enumeration for the per-device "ceph-volume raw list" fallback
+		if command == "lsblk" && args[0] == "--noheadings" {
+			return "/dev/vdb disk\n/dev/vdc disk", nil
+		}
+
 		// get lsblk for disks from cephVolumeRAWTestResult var
 		if command == "lsblk" && (args[0] == "/dev/vdb" || args[0] == "/dev/vdc") {
 			return fmt.Sprintf(`SIZE="17179869184" ROTA="1" RO="0" TYPE="disk" PKNAME="" NAME="%s" KNAME="%s"`, args[0], args[0]), nil
@@ -2299,6 +2318,9 @@ func TestWipeDevicesFromOtherClusters(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
+		if command == "lsblk" && args[0] == "--noheadings" {
+			return "/dev/vdb disk\n/dev/vdc disk", nil
+		}
 		if slices.Contains(args, "raw") && slices.Contains(args, "list") {
 			return cephVolumeRAWTestResult, nil
 		}
@@ -2348,6 +2370,9 @@ func TestWipeDevicesFromOtherClusters(t *testing.T) {
 	// `ceph-volume raw list` returns dmcrypt devices on "vdb" and "vdc" but only "vdb" should be zapped
 	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
+		if command == "lsblk" && args[0] == "--noheadings" {
+			return "/dev/vdb disk\n/dev/vdc disk", nil
+		}
 		if slices.Contains(args, "raw") && slices.Contains(args, "list") {
 			return cephVolumeRAWEncryptedTestResult, nil
 		}
@@ -2374,6 +2399,9 @@ func TestWipeDevicesFromOtherClusters(t *testing.T) {
 	// `ceph-volume raw list` returns empty but the expected device still has luks header with cephFSID from another cluster.
 	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
+		if command == "lsblk" && args[0] == "--noheadings" {
+			return "/dev/vdb disk\n/dev/vdc disk", nil
+		}
 		if slices.Contains(args, "raw") && slices.Contains(args, "list") {
 			return `{}`, nil // return empty
 		}
@@ -2391,6 +2419,9 @@ func TestWipeDevicesFromOtherClusters(t *testing.T) {
 	// matched via DevLinks and zapped.
 	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
+		if command == "lsblk" && args[0] == "--noheadings" {
+			return "/dev/vdb disk\n/dev/vdc disk", nil
+		}
 		if slices.Contains(args, "raw") && slices.Contains(args, "list") {
 			return cephVolumeRAWLVMSymlinkTestResult, nil
 		}
@@ -2469,6 +2500,9 @@ func TestGetCephVolumeRawOSDsHonorDeviceClass(t *testing.T) {
 		if command == "stdbuf" && args[4] == "raw" && args[5] == "list" {
 			return cephVolumeRAWTestResult, nil
 		}
+		if command == "lsblk" && args[0] == "--noheadings" {
+			return "/dev/vdb disk\n/dev/vdc disk", nil
+		}
 		if command == "lsblk" && (args[0] == "/dev/vdb" || args[0] == "/dev/vdc") {
 			base := strings.TrimPrefix(args[0], "/dev/")
 			return fmt.Sprintf(`SIZE="17179869184" ROTA="1" RO="0" TYPE="disk" PKNAME="" NAME="%s" KNAME="%s"`, args[0], base), nil
@@ -2515,4 +2549,104 @@ func TestGetCephVolumeRawOSDsHonorDeviceClass(t *testing.T) {
 			assert.Equal(t, tc.wantPerDev, got)
 		})
 	}
+}
+
+func TestRawListOSDsPerDevice(t *testing.T) {
+	t.Run("scans every OSD-hosting device class, skips crash and partial records, and merges", func(t *testing.T) {
+		// lsblk enumerates a mix of device types. Disks, partitions, loop, and the device-mapper
+		// node types a raw OSD presents as (crypt, lvm, mpath, linear) must be scanned; the
+		// network-backed (rbd/nbd/drbd) and volatile-RAM (zram) devices, and a rom, are excluded.
+		lsblkOutput := strings.Join([]string{
+			"/dev/sda disk",
+			"/dev/sda1 part",
+			"/dev/loop0 loop",
+			"/dev/mapper/set1-block-dmcrypt crypt",
+			"/dev/mapper/set1-db lvm",
+			"/dev/mapper/vg-db lvm",
+			"/dev/mapper/mpatha mpath",
+			"/dev/rbd0 disk",
+			"/dev/nbd0 disk",
+			"/dev/zram0 disk",
+			"/dev/drbd0 disk",
+			"/dev/sr0 rom",
+		}, "\n")
+
+		var scanned []string
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			if command == "lsblk" && args[0] == "--noheadings" {
+				return lsblkOutput, nil
+			}
+			if command == "stdbuf" && args[4] == "raw" && args[5] == "list" {
+				device := args[6]
+				scanned = append(scanned, device)
+				switch device {
+				case "/dev/sda":
+					// A device that crashes ceph-bluestore-tool's batched show-label (ceph #76354).
+					// ceph-volume swallows the tool's non-zero rc and returns "{}" with exit 0, so
+					// per-device it contributes nothing and does not abort or fail the scan.
+					return `{}`, nil
+				case "/dev/loop0":
+					// A device that genuinely fails to list: logged and skipped, not fatal because
+					// other devices succeed.
+					return "", errors.New("ceph-volume not found for this device")
+				case "/dev/sda1":
+					return `{"uuid-0": {"ceph_fsid": "fsid", "device": "/dev/sda1", "osd_id": 0, "osd_uuid": "uuid-0", "type": "bluestore"}}`, nil
+				case "/dev/mapper/set1-block-dmcrypt":
+					// An encrypted OSD is found only by scanning its opened mapper node; the
+					// underlying disk would report {} because show-label cannot read a LUKS header.
+					return `{"uuid-1": {"ceph_fsid": "fsid", "device": "/dev/mapper/set1-block-dmcrypt", "osd_id": 1, "osd_uuid": "uuid-1", "type": "bluestore"}}`, nil
+				case "/dev/mapper/set1-db":
+					// The bluefs db LV of the SAME encrypted OSD: a partial record keyed by the
+					// same osd_uuid as its block entry. The Device=="" guard must keep it from
+					// clobbering the real block record.
+					return `{"uuid-1": {"osd_uuid": "uuid-1"}}`, nil
+				case "/dev/mapper/vg-db":
+					// The bluefs db LV of an unrelated OSD: a partial record under its own osd_uuid.
+					// It must not enter the result as a spurious (empty ceph_fsid) OSD.
+					return `{"uuid-2": {"osd_uuid": "uuid-2"}}`, nil
+				}
+				return `{}`, nil
+			}
+			return "", errors.Errorf("unknown command %s %v", command, args)
+		}
+		ctx := &clusterd.Context{Executor: executor}
+
+		result, err := rawListOSDsPerDevice(ctx)
+		require.NoError(t, err)
+
+		// Every OSD-hosting device class is scanned; rbd/nbd/zram/drbd and the rom are excluded.
+		assert.ElementsMatch(t, []string{
+			"/dev/sda", "/dev/sda1", "/dev/loop0",
+			"/dev/mapper/set1-block-dmcrypt", "/dev/mapper/set1-db", "/dev/mapper/vg-db", "/dev/mapper/mpatha",
+		}, scanned)
+
+		// Only the two real OSDs (plain + encrypted) are reported. The crash device ("{}") and the
+		// failed device contribute nothing; the db partial that shares the encrypted OSD's uuid does
+		// not overwrite its real block record; and the unrelated db partial does not enter as a
+		// spurious OSD.
+		require.Len(t, result, 2)
+		assert.Equal(t, "/dev/sda1", result["uuid-0"].Device)
+		assert.Equal(t, "/dev/mapper/set1-block-dmcrypt", result["uuid-1"].Device)
+		_, hasSpurious := result["uuid-2"]
+		assert.False(t, hasSpurious, "unrelated partial db/wal record must be skipped")
+	})
+
+	t.Run("returns an error when every scanned device fails to list", func(t *testing.T) {
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			if command == "lsblk" && args[0] == "--noheadings" {
+				return "/dev/sda disk\n/dev/sdb disk", nil
+			}
+			if command == "stdbuf" && args[4] == "raw" && args[5] == "list" {
+				return "", errors.New("ceph-volume not found")
+			}
+			return "", errors.Errorf("unknown command %s %v", command, args)
+		}
+		ctx := &clusterd.Context{Executor: executor}
+
+		_, err := rawListOSDsPerDevice(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed for all")
+	})
 }


### PR DESCRIPTION
`WipeDevicesFromOtherClusters` and node-wide raw-OSD discovery use a no-argument `ceph-volume raw list`. From Ceph v19.2.3 (Squid) and v20.2.x (Tentacle) it batches `ceph-bluestore-tool show-label` across every device, which either aborts and blanks the list to `{}` on one unreadable device (ceph tracker 76354, #17992), or overflows its stderr pipe buffer on a many-device node and deadlocks ceph-volume — hanging the prepare Job and stalling every reconcile. A blank list leaves a foreign cluster's disks un-wiped and existing OSDs un-discovered.

Each device is now listed individually and merged, so one crashing or hanging device can no longer hide the rest.

**AI assistance:** AI located the two remaining unhardened call sites, drafted the per-device listing helper and its unit tests, ran an adversarial pre-PR review that surfaced the dropped-encrypted-OSD and partial-record cases now handled, and verified the affected Ceph range and the deadlock failure mode against ceph-volume source.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [x] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
