### PR TITLE
nvmeof: wait for metadata pool before deploying gw

### DIFF
--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -122,7 +122,7 @@ func GetPoolNamesByID(context *clusterd.Context, clusterInfo *ClusterInfo) (map[
 	return names, nil
 }
 
-func getPoolApplication(context *clusterd.Context, clusterInfo *ClusterInfo, poolName string) (string, error) {
+func GetPoolApplication(context *clusterd.Context, clusterInfo *ClusterInfo, poolName string) (string, error) {
 	args := []string{"osd", "pool", "application", "get", poolName}
 	appDetails, err := NewCephCommand(context, clusterInfo, args).Run()
 	if err != nil {
@@ -324,7 +324,7 @@ func DeletePool(context *clusterd.Context, clusterInfo *ClusterInfo, name string
 }
 
 func givePoolAppTag(context *clusterd.Context, clusterInfo *ClusterInfo, poolName, appName string) error {
-	currentAppName, err := getPoolApplication(context, clusterInfo, poolName)
+	currentAppName, err := GetPoolApplication(context, clusterInfo, poolName)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get application for pool %q", poolName)
 	}

--- a/pkg/operator/ceph/nvmeof/controller.go
+++ b/pkg/operator/ceph/nvmeof/controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	csiopv1 "github.com/ceph/ceph-csi-operator/api/v1"
 	"github.com/coreos/pkg/capnslog"
@@ -265,6 +266,13 @@ func (r *ReconcileCephNVMeOFGateway) reconcile(request reconcile.Request) (recon
 	}
 	if r.shouldRotateCephxKeys {
 		logger.Infof("cephx keys will be rotated for %q", request.NamespacedName)
+	}
+
+	// The gateway stores OMAP state in the .nvmeof pool. Creating pods before that
+	// pool exists causes CrashLoopBackOff. Fail and retry until the pool is ready.
+	if err := r.ensureNVMeOFMetadataPoolReady(); err != nil {
+		return reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}, *cephNVMeOFGateway,
+			errors.Wrapf(err, "waiting for nvmeof metadata pool %q to be ready before creating gateway deployments", nvmeofPoolName)
 	}
 
 	_, err = r.reconcileCreateCephNVMeOFGateway(cephNVMeOFGateway)
@@ -545,6 +553,26 @@ func validateGateway(g *cephv1.CephNVMeOFGateway) error {
 		return errors.New("gateway group name is required")
 	}
 
+	return nil
+}
+
+// ensureNVMeOFMetadataPoolReady confirms the .nvmeof RADOS pool exists and has
+// been fully initialized (application tag set) before gateway deployments are
+// created. Checking via Ceph commands is more reliable than CR status which may
+// lag behind the actual pool state.
+func (r *ReconcileCephNVMeOFGateway) ensureNVMeOFMetadataPoolReady() error {
+	_, err := cephclient.GetPoolDetails(r.context, r.clusterInfo, nvmeofPoolName)
+	if err != nil {
+		return errors.Wrapf(err, "nvmeof metadata pool %q does not exist yet", nvmeofPoolName)
+	}
+
+	app, err := cephclient.GetPoolApplication(r.context, r.clusterInfo, nvmeofPoolName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to check application for nvmeof metadata pool %q", nvmeofPoolName)
+	}
+	if app == "" {
+		return errors.Errorf("nvmeof metadata pool %q exists but is not yet initialized (no application set)", nvmeofPoolName)
+	}
 	return nil
 }
 

--- a/pkg/operator/ceph/nvmeof/controller_test.go
+++ b/pkg/operator/ceph/nvmeof/controller_test.go
@@ -84,6 +84,12 @@ func TestCephNVMeOFGatewayController(t *testing.T) {
 					if args[0] == "status" {
 						return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 					}
+					if args[0] == "osd" && args[1] == "pool" && args[2] == "get" {
+						return `{"pool":".nvmeof","pool_id":1,"size":1}`, nil
+					}
+					if args[0] == "osd" && args[1] == "pool" && args[2] == "application" && args[3] == "get" {
+						return `{"rbd":{}}`, nil
+					}
 					if args[0] == "nvme-gw" && args[1] == "create" {
 						return "", nil
 					}
@@ -247,6 +253,99 @@ func TestCephNVMeOFGatewayController(t *testing.T) {
 			assert.Contains(t, event, "ReconcileFailed")
 			assert.Contains(t, event, "invalid configuration")
 		})
+	})
+
+	t.Run("error - nvmeof metadata pool not initialized", func(t *testing.T) {
+		executor := successExecutor(t)
+		original := executor.MockExecuteCommandWithOutput
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			if command == "ceph" && len(args) >= 4 && args[0] == "osd" && args[1] == "pool" && args[2] == "application" && args[3] == "get" {
+				return `{}`, nil
+			}
+			return original(command, args...)
+		}
+		cCtx := newContext(executor)
+		cl := newControllerClient(baseCephNVMeOFGateway(), cephClusterReady(cCtx))
+		r := newReconcile(cCtx, cl)
+		fakeRecorder := events.NewFakeRecorder(50)
+		r.recorder = fakeRecorder
+
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.Equal(t, 10*time.Second, res.RequeueAfter)
+
+		deps, listErr := cCtx.Clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+		assert.NoError(t, listErr)
+		assert.Empty(t, deps.Items)
+
+		assert.GreaterOrEqual(t, len(fakeRecorder.Events), 1)
+		event := <-fakeRecorder.Events
+		assert.Contains(t, event, "ReconcileFailed")
+		assert.Contains(t, event, nvmeofPoolName)
+	})
+
+	t.Run("error - nvmeof metadata pool missing", func(t *testing.T) {
+		executor := successExecutor(t)
+		original := executor.MockExecuteCommandWithOutput
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			if command == "ceph" && len(args) >= 3 && args[0] == "osd" && args[1] == "pool" && args[2] == "get" {
+				return "", fmt.Errorf("Error ENOENT: pool '.nvmeof' does not exist")
+			}
+			return original(command, args...)
+		}
+		cCtx := newContext(executor)
+		cl := newControllerClient(baseCephNVMeOFGateway(), cephClusterReady(cCtx))
+		r := newReconcile(cCtx, cl)
+		fakeRecorder := events.NewFakeRecorder(50)
+		r.recorder = fakeRecorder
+
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.Equal(t, 10*time.Second, res.RequeueAfter)
+
+		deps, listErr := cCtx.Clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+		assert.NoError(t, listErr)
+		assert.Empty(t, deps.Items)
+
+		assert.GreaterOrEqual(t, len(fakeRecorder.Events), 1)
+		event := <-fakeRecorder.Events
+		assert.Contains(t, event, "ReconcileFailed")
+		assert.Contains(t, event, nvmeofPoolName)
+	})
+
+	t.Run("create gateway after metadata pool becomes initialized", func(t *testing.T) {
+		poolInitialized := false
+		executor := successExecutor(t)
+		original := executor.MockExecuteCommandWithOutput
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			if command == "ceph" && len(args) >= 4 && args[0] == "osd" && args[1] == "pool" && args[2] == "application" && args[3] == "get" {
+				if !poolInitialized {
+					return `{}`, nil
+				}
+				return `{"rbd":{}}`, nil
+			}
+			return original(command, args...)
+		}
+		cCtx := newContext(executor)
+		cl := newControllerClient(baseCephNVMeOFGateway(), cephClusterReady(cCtx))
+		r := newReconcile(cCtx, cl)
+
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.Equal(t, 10*time.Second, res.RequeueAfter)
+		deps, listErr := cCtx.Clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+		assert.NoError(t, listErr)
+		assert.Empty(t, deps.Items)
+
+		poolInitialized = true
+
+		res, err = r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.Equal(t, time.Duration(0), res.RequeueAfter)
+		deps, listErr = cCtx.Clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+		assert.NoError(t, listErr)
+		assert.Len(t, deps.Items, 1)
+		assert.Equal(t, "rook-ceph-nvmeof-my-nvmeof-a", deps.Items[0].Name)
 	})
 
 	assertCephNVMeOFGatewayReady := func(t *testing.T, r *ReconcileCephNVMeOFGateway, names ...string) {
@@ -502,6 +601,12 @@ func TestNVMeOFKeyRotation(t *testing.T) {
 			if command == "ceph" {
 				if args[0] == "status" {
 					return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
+				}
+				if args[0] == "osd" && args[1] == "pool" && args[2] == "get" {
+					return `{"pool":".nvmeof","pool_id":1,"size":1}`, nil
+				}
+				if args[0] == "osd" && args[1] == "pool" && args[2] == "application" && args[3] == "get" {
+					return `{"rbd":{}}`, nil
 				}
 				if args[0] == "nvme-gw" && args[1] == "create" {
 					return "", nil


### PR DESCRIPTION
Delay gateway deploy until the .nvmeof metadata pool is ready so pods do not `CrashLoopBackOff` on OMAP create.



## Setup

Cluster was already up (mon/mgr/osd Running). Operator image: `quay.io/oviner/rook:aug21_1` with the pool-ready change.

Example file: `deploy/examples/nvmeof-test.yaml`.

---

## Test 1 — Create GW CR **without** the `.nvmeof` pool

Pool section was commented out. Applied:

```yaml
apiVersion: ceph.rook.io/v1
kind: CephNVMeOFGateway
metadata:
  name: nvmeof
  namespace: rook-ceph
spec:
  group: group-a
  instances: 1
  hostNetwork: false
```

```console
kubectl create -f deploy/examples/nvmeof-test.yaml
# cephnvmeofgateway.ceph.rook.io/nvmeof created
```

**Result:** no `rook-ceph-nvmeof-*` pod. Short-lived `ceph-nvmeof-gateway-controller-detect-version` job only (version detect runs before the pool check).

**Events:**

```text
Normal   ReconcileSucceeded  ...  successfully configured CephNVMeOFGateway "rook-ceph/nvmeof"
Warning  ReconcileFailed     ...  failed to reconcile CephNVMeOFGateway "rook-ceph/nvmeof".
         nvmeof metadata pool ".nvmeof" is not ready:
         nvmeof metadata pool ".nvmeof" does not exist yet:
         failed to get pool .nvmeof details. .
         Error ENOENT: unrecognized pool '.nvmeof': exit status 2
```

**Operator logs:**

```text
Running command: ceph osd pool get .nvmeof all --connect-timeout=15 --cluster=rook-ceph ...
I | ceph-nvmeof-gateway: waiting for nvmeof metadata pool ".nvmeof" to be ready before creating gateway deployments:
   nvmeof metadata pool ".nvmeof" does not exist yet: failed to get pool .nvmeof details. .
   Error ENOENT: unrecognized pool '.nvmeof': exit status 2
E | ceph-nvmeof-gateway: failed to reconcile CephNVMeOFGateway "rook-ceph/nvmeof".
   nvmeof metadata pool ".nvmeof" is not ready: ...
```

Reconcile retried about every 10s. Gateway CR stayed not Ready. **Pass.**

---

## Test 2 — Create the `.nvmeof` pool while GW CR already exists

Applied:

```yaml
apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  name: builtin-nvmeof
  namespace: rook-ceph
spec:
  name: .nvmeof
  failureDomain: osd
  replicated:
    size: 1
    requireSafeReplicaSize: false
```

**Result:**

```text
builtin-nvmeof   Ready
nvmeof           Ready
rook-ceph-nvmeof-nvmeof-a-786d8cf6cb-vczck   1/1  Running  0 restarts
```

```console
kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd lspools
# 1 .mgr
# 2 .nvmeof
```

Gateway logs: beacons only. **No** `Unable to create OMAP` / `ObjectNotFound`. **Pass.**

---

## Test 3 — Delete GW, recreate while pool is already Ready

```console
kubectl delete cephnvmeofgateway nvmeof -n rook-ceph --wait=true
kubectl apply -f - <<'EOF'
apiVersion: ceph.rook.io/v1
kind: CephNVMeOFGateway
metadata:
  name: nvmeof
  namespace: rook-ceph
spec:
  group: group-a
  instances: 1
  hostNetwork: false
EOF
```

**Result:** pod Running in ~4s, **0 restarts**. Pool stayed Ready. **Pass.**

```text
rook-ceph-nvmeof-nvmeof-a-786d8cf6cb-j97tc   1/1  Running  0
nvmeof   Ready
```

---

## Test 4 — Original race: apply pool + GW together

```console
kubectl delete cephnvmeofgateway nvmeof -n rook-ceph --wait=true
kubectl delete cephblockpool builtin-nvmeof -n rook-ceph --wait=true
# ceph osd lspools -> only .mgr

kubectl create -f deploy/examples/nvmeof-test.yaml
```

Full YAML:

```yaml
apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  name: builtin-nvmeof
  namespace: rook-ceph
spec:
  name: .nvmeof
  failureDomain: osd
  replicated:
    size: 1
    requireSafeReplicaSize: false
---
apiVersion: ceph.rook.io/v1
kind: CephNVMeOFGateway
metadata:
  name: nvmeof
  namespace: rook-ceph
spec:
  group: group-a
  instances: 1
  hostNetwork: false
```

**Timeline:**

| Time | Pool | Gateway pod |
|------|------|-------------|
| ~0s | Progressing | none |
| ~10s | Ready | none |
| ~21s | Ready | Init then Running, **0 restarts** |

**Events (CR-Ready path, not ENOENT):**

```text
Normal   ReconcileSucceeded  ...  successfully configured CephNVMeOFGateway "rook-ceph/nvmeof"
Warning  ReconcileFailed     ...  nvmeof metadata pool ".nvmeof" is not ready:
         CephBlockPool "builtin-nvmeof" for nvmeof metadata pool ".nvmeof"
         is not ready (phase "Progressing")
Normal   ReconcileSucceeded  ...  successfully configured CephNVMeOFGateway "rook-ceph/nvmeof"
```

**Operator logs:**

```text
I | waiting for nvmeof metadata pool ".nvmeof" to be ready before creating gateway deployments:
   CephBlockPool "builtin-nvmeof" for nvmeof metadata pool ".nvmeof" is not ready (phase "Progressing")
E | failed to reconcile CephNVMeOFGateway "rook-ceph/nvmeof". nvmeof metadata pool ".nvmeof" is not ready: ...
D | successfully configured CephNVMeOFGateway "rook-ceph/nvmeof"
```

**Final:**

```text
builtin-nvmeof   Ready
nvmeof           Ready
rook-ceph-nvmeof-nvmeof-a-786d8cf6cb-6f7ch   1/1  Running  0 restarts
```

No CrashLoopBackOff. Gateway logs had no OMAP errors. **Pass.**

---

## Summary

| Test | What | Outcome |
|------|------|---------|
| 1 | GW CR only, no pool | No GW pod; requeue; ENOENT on `.nvmeof` |
| 2 | Create pool after GW CR | Pod Running, 0 restarts |
| 3 | Recreate GW, pool already Ready | Pod in ~4s, 0 restarts |
| 4 | Apply pool + GW together | Wait on Progressing, then 0 restarts, no CLBO |
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

