### PR TITLE
Update Rook to use CSI 3.17.1 for AES256K compatibility

### DIFF
--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -56,7 +56,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `csi.attacher.repository` | Kubernetes CSI Attacher image repository | `"registry.k8s.io/sig-storage/csi-attacher"` |
 | `csi.attacher.tag` | Attacher image tag | `"v4.12.0"` |
 | `csi.cephcsi.repository` | Ceph CSI image repository | `"quay.io/cephcsi/cephcsi"` |
-| `csi.cephcsi.tag` | Ceph CSI image tag | `"v3.17.0"` |
+| `csi.cephcsi.tag` | Ceph CSI image tag | `"v3.17.1"` |
 | `csi.csiAddons.repository` | CSIAddons sidecar image repository | `"quay.io/csiaddons/k8s-sidecar"` |
 | `csi.csiAddons.tag` | CSIAddons sidecar image tag | `"v0.14.0"` |
 | `csi.installCsiOperator` | When true, install the ceph-csi-operator subchart (see Chart.yaml `condition`). | `true` |

--- a/Documentation/Storage-Configuration/Advanced/cephx-key-rotation.md
+++ b/Documentation/Storage-Configuration/Advanced/cephx-key-rotation.md
@@ -297,6 +297,10 @@ This will ensure any accidental AES keys raise visible warnings after full migra
 
 ### Migrating CSI keys to a new key type
 
+!!! important
+    [Ceph-CSI](https://github.com/ceph/ceph-csi) must be updated to at least v3.17.1 to support
+    AES256K keys.
+
 The [rotation example above](#rotation-example) shows how to rotate CSI keys while keeping the older
 `aes` key type for all Linux kernel versions. This section explains how to follow up to migrate the
 example's CSI keys to `aes256k` completely with minimal application downtime. At the end of this
@@ -328,6 +332,9 @@ migration, all CSI keys and all application PVCs will be utilizing new keys with
 7. As a final optional step, clean up old keys which are no longer in use by setting
     `keepPriorKeyCountMax: 0`.
 
+In the event of issues during this process, either due to kernel incompatibility or a CSI issue,
+[revert back to using AES](#reverting-back-to-an-older-key-type).
+
 ### Migrating external cluster keys to a new key type
 
 When Rook is configured to use an [external cluster](../../CRDs/Cluster/external-cluster/provider-export.md),
@@ -354,6 +361,19 @@ Support for AES256K keys is currently limited by client and Kernel support. If a
 rotated to the new type but the client/kernel does not support it, Rook allows reverting back to an
 older key type. This process is as simple as specifying `keyType: aes` for the required component.
 This will rotate the key again, and the new key will be of type `aes`.
+
+An example for reverting CSI keys back to `aes` follows:
+
+```yaml
+spec:
+  security:
+    cephx:
+      csi:
+        keyRotationPolicy: KeyGeneration
+        keyGeneration: 3 # modify as needed
+        keepPriorKeyCountMax: 2 # keep the original in-use key active
+        keyType: aes
+```
 
 ### Allowed Ciphers
 

--- a/Documentation/Storage-Configuration/Ceph-CSI/custom-images.md
+++ b/Documentation/Storage-Configuration/Ceph-CSI/custom-images.md
@@ -16,7 +16,7 @@ kubectl -n $ROOK_OPERATOR_NAMESPACE edit configmap rook-csi-operator-image-set-c
 The default upstream images are included below, which can be customized to the desired images.
 
 ```yaml
-plugin: "quay.io/cephcsi/cephcsi:v3.17.0"
+plugin: "quay.io/cephcsi/cephcsi:v3.17.1"
 provisioner: "registry.k8s.io/sig-storage/csi-provisioner:v6.2.0"
 attacher: "registry.k8s.io/sig-storage/csi-attacher:v4.12.0"
 resizer: "registry.k8s.io/sig-storage/csi-resizer:v2.1.0"

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -98,7 +98,7 @@ csi:
     # -- Ceph CSI image repository
     repository: quay.io/cephcsi/cephcsi
     # -- Ceph CSI image tag
-    tag: v3.17.0
+    tag: v3.17.1
 
   registrar:
     # -- Kubernetes CSI registrar image repository

--- a/deploy/examples/images.txt
+++ b/deploy/examples/images.txt
@@ -3,7 +3,7 @@ gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v0.2.2
 quay.io/ceph/ceph:v20.2.4
 quay.io/ceph/cosi:v0.1.4
 quay.io/cephcsi/ceph-csi-operator:v1.0.4
-quay.io/cephcsi/cephcsi:v3.17.0
+quay.io/cephcsi/cephcsi:v3.17.1
 quay.io/csiaddons/k8s-sidecar:v0.14.0
 registry.k8s.io/sig-storage/csi-attacher:v4.12.0
 registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -192,7 +192,7 @@ data:
   resizer: "registry.k8s.io/sig-storage/csi-resizer:v2.1.0"
   snapshotter: "registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0"
   registrar: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0"
-  plugin: "quay.io/cephcsi/cephcsi:v3.17.0"
+  plugin: "quay.io/cephcsi/cephcsi:v3.17.1"
   addons: "quay.io/csiaddons/k8s-sidecar:v0.14.0"
 ---
 # OperatorConfig defines the default settings for all CSI drivers.

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -112,7 +112,7 @@ data:
   resizer: "registry.k8s.io/sig-storage/csi-resizer:v2.1.0"
   snapshotter: "registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0"
   registrar: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0"
-  plugin: "quay.io/cephcsi/cephcsi:v3.17.0"
+  plugin: "quay.io/cephcsi/cephcsi:v3.17.1"
   addons: "quay.io/csiaddons/k8s-sidecar:v0.14.0"
 ---
 # OperatorConfig defines the default settings for all CSI drivers.


### PR DESCRIPTION
Add a note about the minimum Ceph-CSI version required for AES256K key support, and add a note and example to help users revert back to working keys as a workaround in case of any CSI rotation issue.

Resolves #18254

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

