### PR TITLE
ci: remove unused aws-sdk-go v1 lint suppression

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -37,9 +37,6 @@ linters:
       - linters:
           - staticcheck
         text: "Requeue is deprecated"
-      - linters:
-          - staticcheck
-        text: "Use aws-sdk-go-v2" # aws-sdk-go v1 deprecated warning
 formatters:
   enable:
     - gofmt


### PR DESCRIPTION
Rook's code is fully migrated to `aws-sdk-go-v2`.
The `staticcheck` suppression for the v1 deprecation warning is no longer needed since there are no v1
imports in the codebase. 
Remove the dead exclusion so any accidental `v1` reintroduction gets flagged.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

