### PR TITLE
osd: correct comments in the osd topology package

### DIFF
--- a/pkg/operator/ceph/cluster/osd/topology/topology.go
+++ b/pkg/operator/ceph/cluster/osd/topology/topology.go
@@ -14,9 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package config provides methods for generating the Ceph config for a Ceph cluster and for
-// producing a "ceph.conf" compatible file from the config as well as Ceph command line-compatible
-// flags.
+// Package topology derives an OSD's CRUSH location from Kubernetes node topology labels.
 package topology
 
 import (
@@ -149,10 +147,10 @@ func GetDefaultTopologyLabels() string {
 	return strings.Join(Labels, ",")
 }
 
-// CheckTopologyConflicts verifies that:
-// 1. No child domain (e.g. rack) has fewer distinct values than its immediate parent.
-// 2. No topology value is used under more than one label key.
-// 3. No label value lives under more than one parent label value.
+// CheckTopologyConflicts verifies, for all topology labels other than the hostname label:
+// 1. No label carries an empty value on any node.
+// 2. No label value lives under more than one parent label value.
+// 3. No topology value is used under more than one label key.
 func CheckTopologyConflicts(nodes *[]corev1.Node) error {
 	logger.Debugf("Starting CheckTopologyConflicts with %d nodes", len(*nodes))
 


### PR DESCRIPTION
**Motivation**

The godoc for `CheckTopologyConflicts` promises a check the function has never implemented — that no child domain has fewer distinct values than its immediate parent — while omitting the empty-value check it does perform and the hostname-label exclusion. The package comment was copied from the `config` package and describes Ceph config generation.

**What changed**

Both comments now describe what the code does. Comment-only; no behavior change.

AI assistance: the discrepancy was found and the change drafted with AI assistance; I reviewed and approved the result.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
