### PR TITLE
osd: return error when noout update fails

### DIFF
--- a/pkg/operator/ceph/disruption/clusterdisruption/osd.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd.go
@@ -324,9 +324,9 @@ func (r *ReconcileClusterDisruption) reconcilePDBsForOSDs(
 		}
 	}
 
-	err = r.updateNoout(clusterInfo, pdbStateMap, allFailureDomains)
-	if err != nil {
-		logger.Errorf("failed to update maintenance noout in cluster %q. %v", request, err)
+	nooutUpdateErr := r.updateNoout(clusterInfo, pdbStateMap, allFailureDomains)
+	if nooutUpdateErr != nil {
+		logger.Errorf("failed to update maintenance noout in cluster %q. %v", request, nooutUpdateErr)
 	}
 
 	// update PDB configmap
@@ -336,6 +336,10 @@ func (r *ReconcileClusterDisruption) reconcilePDBsForOSDs(
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, errors.Wrapf(err, "failed to update configMap %q in cluster %q", pdbStateMapName, request)
+	}
+
+	if nooutUpdateErr != nil {
+		return reconcile.Result{}, errors.Wrapf(nooutUpdateErr, "failed to update maintenance noout in cluster %q", request)
 	}
 
 	return r.requeuePDBController(request)

--- a/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -552,6 +553,42 @@ func TestReconcilePDBForOSD(t *testing.T) {
 			assert.Equal(t, tc.expectedSetNoOutValue, existingConfigMaps.Items[0].Data[setNoOut])
 		})
 	}
+}
+
+func TestReconcilePDBForOSDNooutUnsetFailure(t *testing.T) {
+	configMap := fakePDBConfigMap("zone-1")
+	r := getFakeReconciler(t, cephCluster, configMap)
+	clusterInfo := getFakeClusterInfo()
+	clusterInfo.Context = context.TODO()
+	request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace}}
+
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		logger.Infof("Command: %s %v", command, args)
+		if args[0] == "status" {
+			return healthyCephStatus, nil
+		}
+		if args[0] == "osd" && args[1] == "dump" {
+			return `{"OSDs": [{"OSD": 3, "Up": 3, "In": 3}], "crush_node_flags": {"zone-1": ["noout"]}}`, nil
+		}
+		if args[0] == "osd" && (args[1] == "unset-group" || args[1] == "set-group") {
+			return "", errors.Errorf("mock failure of ceph command '%v'", args)
+		}
+		return "", errors.Errorf("unexpected ceph command '%v'", args)
+	}
+	clientset := test.New(t, 3)
+	test.SetFakeKubernetesVersion(clientset, "v1.21.0")
+	r.context = &controllerconfig.Context{ClusterdContext: &clusterd.Context{Executor: executor, Clientset: clientset}}
+
+	_, err := r.reconcilePDBsForOSDs(clusterInfo, request, configMap, "zone",
+		[]string{"zone-1", "zone-2", "zone-3"}, []string{}, []string{}, []int{}, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "noout")
+
+	existingConfigMap := &corev1.ConfigMap{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pdbStateMapName, Namespace: namespace}, existingConfigMap)
+	require.NoError(t, err)
+	assert.Equal(t, "", existingConfigMap.Data[drainingFailureDomainKey])
 }
 
 func TestHasNodeDrained(t *testing.T) {


### PR DESCRIPTION
**Motivation**

The OSD PDB reconcile logs and discards errors from updating the maintenance `noout` flag. When unsetting fails at the end of a drain and the default PDB is healthy, there is no requeue: `noout` stays set indefinitely and down OSDs are never marked out.

**What changed**

The error is returned after the PDB state ConfigMap is persisted, so the reconcile retries until the flag update succeeds.

**Notable decisions**

The swallow was deliberate in 2019 (#3596), for Ceph < 14.2.2 which lacked `osd set-group`; the minimum Ceph is now 19.2.0.

AI assistance: the defect was traced and the fix and test drafted with AI assistance; I reviewed and approved the result.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [x] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
