### PR TITLE
[1.18] docs: note that new ceph versions are not supported

### DIFF
--- a/Documentation/Upgrade/ceph-upgrade.md
+++ b/Documentation/Upgrade/ceph-upgrade.md
@@ -27,8 +27,8 @@ until all the daemons have been updated.
 The following Ceph versions are supported in this release of Rook:
 
 * Ceph Reef v18.2.0 or newer
-* Ceph Squid v19.2.0 or newer
-* Ceph Tentacle v20.2.0 or newer
+* Ceph Squid v19.2.0 - v19.2.5 (**v19.2.6+ are [not supported](https://github.com/rook/rook/issues/18203#issuecomment-5397373786)**)
+* Ceph Tentacle v20.2.0 - v20.2.3 (**v20.2.4+ are [not supported](https://github.com/rook/rook/issues/18203#issuecomment-5397373786)**)
     * IMPORTANT: **There is a known data corruption issue in v20.2.0**, if the "read affinity" feature is enabled.
     Read affinity is disabled by default, and is enabled by the CephCluster setting `csi.readAffinity.enabled: true`.
     If you have enabled read affinity, we recommend waiting for v20.2.1 before upgrading to Ceph Tentacle v20.

--- a/Documentation/Upgrade/rook-upgrade.md
+++ b/Documentation/Upgrade/rook-upgrade.md
@@ -54,6 +54,8 @@ those releases.
 
 ## Breaking changes in v1.18
 
+* **Ceph versions v19.2.6+ and v20.2.4+ are [not supported](https://github.com/rook/rook/issues/18203#issuecomment-5397373786)**.
+
 * Helm: Two new properties have been added to the storage classes in the `rook-ceph-cluster` chart.
     Adding these properties will cause the helm upgrade to fail since storage classes are immutable.
     Before upgrading the `rook-ceph-cluster` chart, one of these actions is necessary:


### PR DESCRIPTION
Ceph versions v19.2.6 and v20.2.4 introduced critical CVE changes that are likely to break Rook clusters upon upgrade. Ensure documentation clarifies this for users to avoid issues.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

