### PR TITLE
[1.15] docs: note that new ceph versions are not supported

### DIFF
--- a/Documentation/Upgrade/ceph-upgrade.md
+++ b/Documentation/Upgrade/ceph-upgrade.md
@@ -26,9 +26,9 @@ until all the daemons have been updated.
 
 Rook v1.15 supports the following Ceph versions:
 
-* Ceph Squid v19.2.0 or newer
-* Ceph Reef v18.2.0 or newer
 * Ceph Quincy v17.2.0 or newer
+* Ceph Reef v18.2.0 or newer
+* Ceph Squid v19.2.0 - v19.2.5 (**v19.2.6+ are [not supported](https://github.com/rook/rook/issues/18203#issuecomment-5397373786)**)
 
 !!! important
     When an update is requested, the operator will check Ceph's status,

--- a/Documentation/Upgrade/rook-upgrade.md
+++ b/Documentation/Upgrade/rook-upgrade.md
@@ -51,6 +51,8 @@ those releases.
 
 ## Breaking changes in v1.15
 
+* **Ceph versions v19.2.6+ are [not supported](https://github.com/rook/rook/issues/18203#issuecomment-5397373786)**.
+
 * The minimum supported version of Kubernetes is v1.26.
     Upgrade to Kubernetes v1.26 or higher before upgrading Rook.
 


### PR DESCRIPTION
Ceph version v19.2.6 introduced critical CVE changes that are likely to break Rook clusters upon upgrade. Ensure documentation clarifies this for users to avoid issues.

(cherry picked from commit a86fbc984c789449a92ad604bd0156ad749381fc) (cherry picked from commit 8e3c418e445bb51b0133ee2dd47e3f3c48400537)

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

