### PR TITLE
mgr: Unset the rook mgr module when disabled

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -489,12 +489,22 @@ func (c *Cluster) rookModuleDisabledForCephVersion() bool {
 	return v.Extra >= 2 && v.Extra <= 4
 }
 
+// disableRookOrchestratorModule clears the orchestrator backend and then disables the
+// rook mgr module. The backend is cleared first so the orchestrator no longer references
+// the rook module that is about to be disabled.
+func (c *Cluster) disableRookOrchestratorModule() {
+	if err := c.setOrchestratorBackend(""); err != nil {
+		logger.Warningf("failed to clear the orchestrator backend. %v", err)
+	}
+	if err := cephclient.MgrDisableModule(c.context, c.clusterInfo, rookModuleName); err != nil {
+		logger.Warningf("failed to disable rook mgr module. %v", err)
+	}
+}
+
 func (c *Cluster) configureMgrModules() error {
 	if c.rookModuleDisabledForCephVersion() {
 		logger.Infof("disabling the rook mgr module for Ceph %s", c.clusterInfo.CephVersion.String())
-		if err := cephclient.MgrDisableModule(c.context, c.clusterInfo, rookModuleName); err != nil {
-			logger.Warningf("failed to disable rook mgr module. %v", err)
-		}
+		c.disableRookOrchestratorModule()
 	}
 
 	// Enable mgr modules from the spec
@@ -540,6 +550,10 @@ func (c *Cluster) configureMgrModules() error {
 			}
 
 		} else {
+			if module.Name == rookModuleName {
+				c.disableRookOrchestratorModule()
+				continue
+			}
 			if err := cephclient.MgrDisableModule(c.context, c.clusterInfo, module.Name); err != nil {
 				return errors.Wrapf(err, "failed to disable mgr module %q", module.Name)
 			}

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -370,6 +370,7 @@ func TestUpdateServiceSelectors(t *testing.T) {
 func TestConfigureModules(t *testing.T) {
 	modulesEnabled := 0
 	modulesDisabled := 0
+	backendCleared := 0
 	configSettings := map[string]string{}
 	lastModuleConfigured := ""
 	executor := &exectest.MockExecutor{
@@ -391,6 +392,9 @@ func TestConfigureModules(t *testing.T) {
 		MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "config" && args[1] == "set" && args[2] == "global" {
 				configSettings[args[3]] = args[4]
+			}
+			if args[0] == "orch" && args[1] == "set" && args[2] == "backend" && args[3] == "" {
+				backendCleared++
 			}
 			return "", nil
 		},
@@ -427,6 +431,7 @@ func TestConfigureModules(t *testing.T) {
 	// rook module is force-disabled on affected Ceph versions even if enabled in the spec
 	modulesEnabled = 0
 	modulesDisabled = 0
+	backendCleared = 0
 	lastModuleConfigured = ""
 	c.clusterInfo.CephVersion = cephver.CephVersion{Major: 20, Minor: 2, Extra: 3}
 	c.spec.Mgr.Modules = []cephv1.Module{
@@ -435,6 +440,7 @@ func TestConfigureModules(t *testing.T) {
 	assert.NoError(t, c.configureMgrModules())
 	assert.Equal(t, 0, modulesEnabled, "rook module should not be enabled on Ceph v20.2.3")
 	assert.Equal(t, 1, modulesDisabled, "rook module should be force-disabled on Ceph v20.2.3")
+	assert.Equal(t, 1, backendCleared, "orchestrator backend should be cleared when the rook module is disabled")
 	assert.Equal(t, "rook", lastModuleConfigured)
 
 	// rook module disabled in the spec on an affected version should still be force-disabled
@@ -460,6 +466,20 @@ func TestConfigureModules(t *testing.T) {
 	assert.NoError(t, c.configureMgrModules())
 	assert.GreaterOrEqual(t, modulesEnabled, 1, "rook module should be enabled on Ceph v20.2.5")
 	assert.Equal(t, 0, modulesDisabled)
+	assert.Equal(t, "rook", lastModuleConfigured)
+
+	// rook module disabled in the spec on a non-affected version clears the orchestrator backend
+	modulesEnabled = 0
+	modulesDisabled = 0
+	backendCleared = 0
+	lastModuleConfigured = ""
+	c.spec.Mgr.Modules = []cephv1.Module{
+		{Name: "rook", Enabled: false},
+	}
+	assert.NoError(t, c.configureMgrModules())
+	assert.Equal(t, 0, modulesEnabled)
+	assert.Equal(t, 1, modulesDisabled, "rook module should be disabled per the spec")
+	assert.Equal(t, 1, backendCleared, "orchestrator backend should be cleared when the rook module is disabled")
 	assert.Equal(t, "rook", lastModuleConfigured)
 }
 

--- a/pkg/operator/ceph/cluster/mgr/orchestrator.go
+++ b/pkg/operator/ceph/cluster/mgr/orchestrator.go
@@ -36,16 +36,16 @@ func (c *Cluster) configureOrchestratorModules() error {
 	if err := client.MgrEnableModule(c.context, c.clusterInfo, rookModuleName, true); err != nil {
 		return errors.Wrap(err, "failed to enable mgr rook module")
 	}
-	if err := c.setRookOrchestratorBackend(); err != nil {
+	if err := c.setOrchestratorBackend(rookModuleName); err != nil {
 		return errors.Wrap(err, "failed to set rook orchestrator backend")
 	}
 	return nil
 }
 
-func (c *Cluster) setRookOrchestratorBackend() error {
+func (c *Cluster) setOrchestratorBackend(name string) error {
 	// retry a few times in the case that the mgr module is not ready to accept commands
 	_, err := client.ExecuteCephCommandWithRetry(func() (string, []byte, error) {
-		args := []string{"orch", "set", "backend", "rook"}
+		args := []string{"orch", "set", "backend", name}
 		output, err := client.NewCephCommand(c.context, c.clusterInfo, args).RunWithTimeout(exec.CephCommandsTimeout)
 		return "set rook backend", output, err
 	}, 5, orchestratorInitWaitTime)

--- a/pkg/operator/ceph/cluster/mgr/orchestrator_test.go
+++ b/pkg/operator/ceph/cluster/mgr/orchestrator_test.go
@@ -72,7 +72,7 @@ func TestOrchestratorModules(t *testing.T) {
 
 	err := c.configureOrchestratorModules()
 	assert.Error(t, err)
-	err = c.setRookOrchestratorBackend()
+	err = c.setOrchestratorBackend(rookModuleName)
 	assert.NoError(t, err)
 	assert.True(t, rookModuleEnabled)
 	assert.True(t, rookBackendSet)
@@ -81,13 +81,13 @@ func TestOrchestratorModules(t *testing.T) {
 	// the rook module will succeed
 	err = c.configureOrchestratorModules()
 	assert.NoError(t, err)
-	err = c.setRookOrchestratorBackend()
+	err = c.setOrchestratorBackend(rookModuleName)
 	assert.NoError(t, err)
 	assert.True(t, rookModuleEnabled)
 	assert.True(t, rookBackendSet)
 
 	c.clusterInfo.CephVersion = cephver.Squid
-	err = c.setRookOrchestratorBackend()
+	err = c.setOrchestratorBackend(rookModuleName)
 	assert.NoError(t, err)
 	executor.MockExecuteCommandWithTimeout = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
@@ -101,6 +101,30 @@ func TestOrchestratorModules(t *testing.T) {
 		}
 		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
-	err = c.setRookOrchestratorBackend()
+	err = c.setOrchestratorBackend(rookModuleName)
 	assert.NoError(t, err)
+}
+
+func TestUnsetRookOrchestratorBackend(t *testing.T) {
+	backendCleared := false
+	executor := &exectest.MockExecutor{}
+	exec.CephCommandsTimeout = 15 * time.Second
+	executor.MockExecuteCommandWithTimeout = func(timeout time.Duration, command string, args ...string) (string, error) {
+		logger.Infof("Command: %s %v", command, args)
+		if args[0] == "orch" && args[1] == "set" && args[2] == "backend" && args[3] == "" {
+			backendCleared = true
+			return "", nil
+		}
+		return "", errors.Errorf("unexpected ceph command %q", args)
+	}
+
+	clusterInfo := &cephclient.ClusterInfo{
+		CephVersion: cephver.Squid,
+		Context:     context.TODO(),
+	}
+	c := &Cluster{clusterInfo: clusterInfo, context: &clusterd.Context{Executor: executor}}
+
+	err := c.setOrchestratorBackend("")
+	assert.NoError(t, err)
+	assert.True(t, backendCleared)
 }


### PR DESCRIPTION
When the rook mgr module is disabled, the orchestrator also needs to be unset, otherwise the nfs module will fail to create exports.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

