### PR TITLE
ci: run rgw-multisite-testing against the tracker 79698 candidate fix

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -1926,7 +1926,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     strategy:
       matrix:
-        ceph-image: ${{ fromJson(inputs.ceph_images) }}
+        ceph-image: ["quay.ceph.io/ceph-ci/ceph:19.2.6-overlord-79698"]
         kubernetes-version: ${{ fromJson(inputs.kubernetes-version) }}
     steps:
       - name: checkout

--- a/deploy/examples/object-multisite-pull-realm-test.yaml
+++ b/deploy/examples/object-multisite-pull-realm-test.yaml
@@ -63,12 +63,5 @@ spec:
     port: 80
     # securePort: 443
     instances: 1
-    rgwConfig:
-      # Ceph v19.2.6/v20.2.4 harden SigV4 validation (CVE-2026-54330), and RGW's own multisite
-      # forwarding fails it even between same-version zones, breaking writes to the secondary
-      # zone. Accept the improper signatures and keep inter-zone requests on SigV2 until Ceph
-      # fixes the forwarding signatures: https://tracker.ceph.com/issues/79698
-      rgw_sigv4_insecure: "true"
-      rgw_s3_client_max_sig_ver: "2"
   zone:
     name: zone-b

--- a/deploy/examples/object-multisite-test.yaml
+++ b/deploy/examples/object-multisite-test.yaml
@@ -51,12 +51,5 @@ spec:
     port: 80
     # securePort: 443
     instances: 1
-    rgwConfig:
-      # Ceph v19.2.6/v20.2.4 harden SigV4 validation (CVE-2026-54330), and RGW's own multisite
-      # forwarding fails it even between same-version zones, breaking writes to the secondary
-      # zone. Accept the improper signatures and keep inter-zone requests on SigV2 until Ceph
-      # fixes the forwarding signatures: https://tracker.ceph.com/issues/79698
-      rgw_sigv4_insecure: "true"
-      rgw_s3_client_max_sig_ver: "2"
   zone:
     name: zone-a


### PR DESCRIPTION
**Throwaway test vehicle — do not merge.**

The Ceph RGW team provided a build with a candidate fix for the v19.2.6 SigV4 multisite-forwarding regression ([tracker 79698](https://tracker.ceph.com/issues/79698)).

The `rgw-multisite-testing` canary now runs `quay.ceph.io/ceph-ci/ceph:19.2.6-overlord-79698` with the `rgw_sigv4_insecure`/`rgw_s3_client_max_sig_ver` workarounds reverted, so a green run demonstrates multisite works on the candidate build without them.

**AI assistance:** Claude prepared the branch and this description from my instructions.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
