### PR TITLE
ci: log rgw sync debug in the multisite canary stores

### DIFF
--- a/deploy/examples/object-multisite-pull-realm-test.yaml
+++ b/deploy/examples/object-multisite-pull-realm-test.yaml
@@ -70,5 +70,8 @@ spec:
       # fixes the forwarding signatures: https://tracker.ceph.com/issues/79698
       rgw_sigv4_insecure: "true"
       rgw_s3_client_max_sig_ver: "2"
+      # always-on sync debug so the rare stuck-shard sync stalls in CI produce
+      # upstream-actionable logs in the collected artifacts
+      debug_rgw_sync: "20"
   zone:
     name: zone-b

--- a/deploy/examples/object-multisite-test.yaml
+++ b/deploy/examples/object-multisite-test.yaml
@@ -58,5 +58,8 @@ spec:
       # fixes the forwarding signatures: https://tracker.ceph.com/issues/79698
       rgw_sigv4_insecure: "true"
       rgw_s3_client_max_sig_ver: "2"
+      # always-on sync debug so the rare stuck-shard sync stalls in CI produce
+      # upstream-actionable logs in the collected artifacts
+      debug_rgw_sync: "20"
   zone:
     name: zone-a


### PR DESCRIPTION
About one `rgw-multisite-testing` run in a hundred hits a metadata sync stall on a single mdlog shard after runner I/O starvation. The collected pod logs carry no sync detail, there is no local reproducer, and upstream needs sync debug logs to act (see [tracker 46563](https://tracker.ceph.com/issues/46563) history and open [tracker 72951](https://tracker.ceph.com/issues/72951)).

Both multisite canary stores now set `debug_rgw_sync: "20"`, so every future occurrence ships actionable RGW sync logs in the job's log artifacts.

**AI assistance:** Claude prepared the branch and this description from my instructions.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
