### PR TITLE
mgr: format prometheus scrape interval with %f to converge SetIfChanged

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -444,7 +444,7 @@ func (c *Cluster) configurePrometheusModule() error {
 	// scrape interval
 	if c.spec.Monitoring.Interval != nil {
 		interval := c.spec.Monitoring.Interval.Duration.Seconds()
-		intervalHasChanged, err = monStore.SetIfChanged(daemonID, "mgr/prometheus/scrape_interval", fmt.Sprintf("%v", interval))
+		intervalHasChanged, err = monStore.SetIfChanged(daemonID, "mgr/prometheus/scrape_interval", fmt.Sprintf("%f", interval))
 		if err != nil {
 			return err
 		}

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -634,7 +634,7 @@ func TestCluster_configurePrometheusModule(t *testing.T) {
 	c.spec.Monitoring.Interval = &metav1.Duration{
 		Duration: 30 * time.Second,
 	}
-	modulesGetOutput = "30"
+	modulesGetOutput = "30.000000"
 	configSettings = make(map[string]string)
 	err = c.configurePrometheusModule()
 	assert.NoError(t, err)
@@ -655,7 +655,7 @@ func TestCluster_configurePrometheusModule(t *testing.T) {
 	assert.Equal(t, 2, modulesEnabled)
 	assert.Equal(t, 1, modulesDisabled)
 	assert.Equal(t, "30002", configSettings["mgr/prometheus/server_port"])
-	assert.Equal(t, "60", configSettings["mgr/prometheus/scrape_interval"])
+	assert.Equal(t, "60.000000", configSettings["mgr/prometheus/scrape_interval"])
 }
 
 func TestMgrKeyRotation(t *testing.T) {


### PR DESCRIPTION
Closes: https://github.com/rook/rook/issues/18292

**Problem:** With `spec.monitoring.interval` set, the operator restarts the mgr prometheus module on **every** reconcile, forever. Each restart (`mgr handle_mgr_map respawning because set of enabled modules changed!`) respawns the ceph-mgr daemon, causing mon fencing, osd blocklist churn, and metric gaps.

**Root cause:** `configurePrometheusModule()` writes `mgr/prometheus/scrape_interval` with `fmt.Sprintf("%v", interval)`, producing e.g. `"60"` for a 60s interval. Ceph normalizes this float-typed module option and reports `"60.000000"` via `ceph config get`. `MonStore.SetIfChanged` does a plain string comparison (`pkg/operator/ceph/config/monstore.go`), so `"60" != "60.000000"` on every reconcile → the value is re-set and the module is restarted each time.

**Fix:** format with `%f` so the written value matches Ceph's normalized form (`"60.000000"`), letting `SetIfChanged` converge. Updated `TestCluster_configurePrometheusModule` to reflect the normalized value (`modulesGetOutput` returns `"30.000000"`, assertion expects `"60.000000"`).

Verified with a standalone simulation of the `SetIfChanged` comparison:
- old `%v` → `"60"` vs stored `"60.000000"` → always changed (bug reproduced)
- new `%f` → `"60.000000"` vs stored `"60.000000"` → unchanged (converges)