### PR TITLE
core: Mute health warnings in the cluster reconcile

### DIFF
--- a/pkg/operator/ceph/cluster/cephstatus.go
+++ b/pkg/operator/ceph/cluster/cephstatus.go
@@ -152,6 +152,18 @@ func (c *cephStatusChecker) configureHealthSettings(status cephclient.CephStatus
 		log.NamespacedDebug(c.clusterInfo.Namespace, logger, "Health: %q, code: %q, message: %q", check.Severity, healthCode, check.Summary.Message)
 	}
 
+	// disable the insecure global id if there are no old clients
+	if _, ok := status.Health.Checks["AUTH_INSECURE_GLOBAL_ID_RECLAIM_ALLOWED"]; ok {
+		if _, ok := status.Health.Checks["AUTH_INSECURE_GLOBAL_ID_RECLAIM"]; !ok {
+			log.NamespacedDebug(c.clusterInfo.Namespace, logger, "Disabling the insecure global ID as no legacy clients are currently connected. If you still require the insecure connections, see the CVE to suppress the health warning and re-enable the insecure connections. https://docs.ceph.com/en/latest/security/CVE-2021-20288/")
+			c.mutePolicyIfNotUnmuted("AUTH_INSECURE_GLOBAL_ID_RECLAIM")
+		} else {
+			log.NamespacedWarning(c.clusterInfo.Namespace, logger, "insecure clients are connected to the cluster, to resolve the AUTH_INSECURE_GLOBAL_ID_RECLAIM health warning please refer to the upgrade guide to ensure all Ceph daemons are updated.")
+		}
+	}
+}
+
+func (c *cephStatusChecker) mutePolicyIfNotUnmuted(warningToMute string) {
 	clusterName := c.clusterInfo.NamespacedName()
 	cephCluster, err := c.context.RookClientset.CephV1().CephClusters(clusterName.Namespace).Get(c.clusterInfo.Context, clusterName.Name, metav1.GetOptions{})
 	if err != nil {
@@ -163,32 +175,16 @@ func (c *cephStatusChecker) configureHealthSettings(status cephclient.CephStatus
 		return
 	}
 
-	muteHealthWarnings := make(map[string]string, len(cephCluster.Spec.HealthCheck.MuteHealthWarning))
 	for warning, spec := range cephCluster.Spec.HealthCheck.MuteHealthWarning {
-		muteHealthWarnings[warning] = spec.Policy
-	}
-
-	// disable the insecure global id if there are no old clients
-	if _, ok := status.Health.Checks["AUTH_INSECURE_GLOBAL_ID_RECLAIM_ALLOWED"]; ok {
-		if _, ok := status.Health.Checks["AUTH_INSECURE_GLOBAL_ID_RECLAIM"]; !ok {
-			policy, userConfigured := muteHealthWarnings["AUTH_INSECURE_GLOBAL_ID_RECLAIM"]
-			if userConfigured && policy == "unmute" {
-				log.NamespacedDebug(c.clusterInfo.Namespace, logger, "not muting AUTH_INSECURE_GLOBAL_ID_RECLAIM because user has overridden it in healthCheck.muteHealthWarning configs")
-			} else {
-				log.NamespacedDebug(c.clusterInfo.Namespace, logger, "Disabling the insecure global ID as no legacy clients are currently connected. If you still require the insecure connections, see the CVE to suppress the health warning and re-enable the insecure connections. https://docs.ceph.com/en/latest/security/CVE-2021-20288/")
-				muteHealthWarnings["AUTH_INSECURE_GLOBAL_ID_RECLAIM"] = "mute"
-			}
-		} else {
-			log.NamespacedWarning(c.clusterInfo.Namespace, logger, "insecure clients are connected to the cluster, to resolve the AUTH_INSECURE_GLOBAL_ID_RECLAIM health warning please refer to the upgrade guide to ensure all Ceph daemons are updated.")
+		if warning == warningToMute && spec.Policy == "unmute" {
+			log.NamespacedDebug(c.clusterInfo.Namespace, logger, "not muting %q because user has overridden it in healthCheck.muteHealthWarning configs", warningToMute)
+			return
 		}
 	}
 
-	for warning, value := range muteHealthWarnings {
-		log.NamespacedDebug(c.clusterInfo.Namespace, logger, "configuring health warning mute %q=%q", warning, string(value))
-		err := cephclient.MuteHealthWarning(c.context, c.clusterInfo, warning, string(value))
-		if err != nil {
-			log.NamespacedError(c.clusterInfo.Namespace, logger, "failed to configure health warning mute %q=%q: %v", warning, string(value), err)
-		}
+	err = cephclient.MuteHealthWarning(c.context, c.clusterInfo, warningToMute, "mute")
+	if err != nil {
+		log.NamespacedError(c.clusterInfo.Namespace, logger, "failed to mute health warning %q. %v", warningToMute, err)
 	}
 }
 

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -570,6 +570,9 @@ func (c *cluster) postMonStartupActions(imageCephVersion cephver.CephVersion) er
 		}
 	}
 
+	// Configure health settings such as muting health warnings from the spec
+	c.configureHealthWarnings()
+
 	crushRoot := client.GetCrushRootFromSpec(c.Spec)
 	if crushRoot != "default" {
 		// Remove the root=default and replicated_rule which are created by
@@ -591,6 +594,18 @@ func (c *cluster) postMonStartupActions(imageCephVersion cephver.CephVersion) er
 	c.deleteBootstrapKeys()
 
 	return nil
+}
+
+// configureHealthSettings mutes the health warnings configured in the cluster spec and
+// disables the insecure global ID reclaim when there are no legacy clients connected.
+func (c *cluster) configureHealthWarnings() {
+	for warning, spec := range c.Spec.HealthCheck.MuteHealthWarning {
+		log.NamespacedDebug(c.Namespace, logger, "configuring health warning mute %q=%q", warning, spec.Policy)
+		err := client.MuteHealthWarning(c.context, c.ClusterInfo, warning, spec.Policy)
+		if err != nil {
+			log.NamespacedError(c.Namespace, logger, "failed to configure health warning mute %q=%q: %v", warning, spec.Policy, err)
+		}
+	}
 }
 
 func (c *cluster) postMgrStartupActions() error {

--- a/pkg/operator/ceph/cluster/cluster_test.go
+++ b/pkg/operator/ceph/cluster/cluster_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
@@ -831,4 +832,56 @@ func Test_initClusterCephxStatus(t *testing.T) {
 		assert.Equal(t, monStatus, cluster.Status.Cephx.Mon)
 		assert.Equal(t, cephv1.CephxStatus{}, cluster.Status.Cephx.Mgr) // no status means no update
 	})
+}
+
+func TestConfigureHealthMute(t *testing.T) {
+	clusterInfo := cephclient.AdminTestClusterInfo("ns")
+	var muted string
+	c := &cluster{
+		context: &clusterd.Context{
+			RookClientset: rookclient.NewSimpleClientset(&cephv1.CephCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterInfo.NamespacedName().Name,
+					Namespace: clusterInfo.Namespace,
+				},
+			}),
+			Executor: &exectest.MockExecutor{
+				MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+					logger.Infof("Command: %s %v", command, args)
+					if args[0] == "health" && args[1] == "mute" {
+						muted = args[2]
+						return "", nil
+					}
+					return "", errors.New("mock error to simulate failure of health mute")
+				},
+			},
+		},
+		ClusterInfo: clusterInfo,
+		Namespace:   clusterInfo.Namespace,
+		Spec:        &cephv1.ClusterSpec{},
+	}
+
+	type args struct {
+		expectedMute string
+		desiredMute  map[string]cephv1.MuteHealthWarningSpec
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{"mute-mds", args{"MDS_ALL_DOWN", map[string]cephv1.MuteHealthWarningSpec{
+			"MDS_ALL_DOWN": {Policy: "mute"},
+		}}},
+		{"mute-mds", args{"", map[string]cephv1.MuteHealthWarningSpec{
+			"MDS_ALL_DOWN": {Policy: "unmute"},
+		}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			muted = ""
+			c.Spec.HealthCheck.MuteHealthWarning = tt.args.desiredMute
+			c.configureHealthWarnings()
+			assert.Equal(t, tt.args.expectedMute, muted)
+		})
+	}
 }


### PR DESCRIPTION
The ceph health warnings will now be muted or unmuted as part of the cephcluster reconcile. The specific health warning `AUTH_INSECURE_GLOBAL_ID_RECLAIM` will still be reconciled during the osd health check periodically when detected, unless the health checks override the mute.

This fixes the verbose logging of muting health warnings every 60s, particularly common now related to the new key types, since the logging of muting will only be done with the reconcile.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #18256

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

