### PR TITLE
osd: add LVM device filter for raw-mode OSD activation

### DIFF
--- a/pkg/operator/ceph/cluster/osd/activate-osd.sh
+++ b/pkg/operator/ceph/cluster/osd/activate-osd.sh
@@ -49,8 +49,9 @@ if [[ "$CV_MODE" == "lvm" ]]; then
 	done
 	TMP_DIR=$(mktemp -d)
 
-	# prevent LVM from trying to scan RBD volumes that may be unable to serve reads without this OSD up
-	echo 'devices { filter = ["r|/dev/rbd.*|"] }' >> /etc/lvm/lvm.conf
+	# prevent LVM from trying to scan network-backed block devices (RBD, NBD, DRBD) that
+	# may be unable to serve reads without this OSD up
+	echo 'devices { filter = ["r|/dev/rbd.*|", "r|/dev/nbd.*|", "r|/dev/drbd.*|"] }' >> /etc/lvm/lvm.conf
 
 	# activate osd
 	ceph-volume lvm activate --no-systemd "$OSD_STORE_FLAG" "$OSD_ID" "$OSD_UUID"
@@ -160,6 +161,14 @@ sys.exit('no disk found with OSD ID $OSD_ID')
 	if [ -L "$OSD_BLOCK_PATH" ] && [ "$(readlink "$OSD_BLOCK_PATH")" != "$DEVICE" ] ; then
 		rm $OSD_BLOCK_PATH
 	fi
+
+	# prevent LVM from trying to scan network-backed block devices (RBD, NBD, DRBD) that
+	# may be unable to serve reads without this OSD up — same deadlock the lvm-mode path
+	# guards against (see the filter added above for lvm-mode OSDs).
+	# ceph-volume raw activate calls lvs internally; without this filter, lvs scans all
+	# block devices including /dev/rbd*, which triggers a krbd read that needs Ceph,
+	# creating a circular dependency that leaves the lvs process in uninterruptible sleep (D state).
+	echo 'devices { filter = ["r|/dev/rbd.*|", "r|/dev/nbd.*|", "r|/dev/drbd.*|"] }' >> /etc/lvm/lvm.conf
 
 	# ceph-volume raw mode only supports bluestore so we don't need to pass a store flag
 	ceph-volume raw activate --device "$DEVICE" --no-systemd --no-tmpfs


### PR DESCRIPTION
## Summary

The lvm-mode OSD activation path in `activate-osd.sh` appends an LVM device filter to `/etc/lvm/lvm.conf` to prevent `lvs` from scanning `/dev/rbd*` devices (line 53). However, the raw-mode activation path is missing this filter entirely.

`ceph-volume raw activate` internally calls `lvs`, which scans all block devices by default. When RBD devices are mapped on the host (e.g., for CephFS-backed PVCs), `lvs` attempts to read them via the kernel RBD client. If the OSD being activated is required to serve those reads, the `lvs` process enters **uninterruptible sleep (D state)**, deadlocking the OSD activation indefinitely. The process cannot be killed (`kill -9` has no effect on D-state processes) and requires a **node reboot** to recover.

Note: the raw-mode path already filters `rbd|nbd|drbd` devices from its own disk scanning logic (the `SCAN_DEVICES` grep on line 135), but that does not prevent `lvs` from scanning them during `ceph-volume raw activate`.

### Changes

- Add the same LVM device filter to the raw-mode activation path, before `ceph-volume raw activate`
- Extend both filters to also exclude NBD and DRBD devices for consistency with the existing raw-mode scan exclusion list

Fixes: https://github.com/rook/rook/issues/18303