### PR TITLE
object: create rgw keys with the rgw cap profile

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -14,3 +14,4 @@
 - The rook-ceph-cluster Helm chart can create `CephObjectStoreUser` resources via the new `cephObjectStoreUsers` value.
 - The toolbox deployments from the Helm chart and the example manifests now reload the keyring and `ceph.conf` automatically after CephX key rotation, mon failover, or a config override change.
 - CephCluster dashboard TLS certificates can now be configured from a same-namespace Kubernetes TLS Secret with `spec.dashboard.sslCertificateRef` when dashboard SSL is enabled. Rook reconciles updates to the referenced Secret and restores the default self-signed certificate when the reference is removed.
+- RGW keys use the `profile rgw` cephx profile when the Ceph cluster supports it; existing keys are updated on the next reconcile.

--- a/pkg/daemon/ceph/client/auth.go
+++ b/pkg/daemon/ceph/client/auth.go
@@ -135,6 +135,18 @@ func Aes256kKeysSupported(ver version.CephVersion) bool {
 	}
 }
 
+// RgwCapProfileSupported returns true if the given Ceph version has the rgw cephx cap profile
+func RgwCapProfileSupported(ver version.CephVersion) bool {
+	switch ver.Major {
+	case 19:
+		return ver.IsAtLeast(version.CephVersion{Major: 19, Minor: 2, Extra: 7})
+	case 20:
+		return ver.IsAtLeast(version.CephVersion{Major: 20, Minor: 2, Extra: 5})
+	default:
+		return ver.Major >= 21
+	}
+}
+
 // AuthRotate rotates a daemon's cephx auth key, retaining existing caps.
 func AuthRotate(context *clusterd.Context, clusterInfo *ClusterInfo, name, keyType string) (string, error) {
 	logger.Infof("rotating ceph auth key %q", name)

--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	cephconfig "github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
@@ -35,13 +36,6 @@ import (
 )
 
 const (
-	keyringTemplate = `
-[%s]
-key = %s
-caps mon = "allow rw"
-caps osd = "allow rwx"
-`
-
 	caBundleVolumeName              = "rook-ceph-custom-ca-bundle"
 	caBundleUpdatedVolumeName       = "rook-ceph-ca-bundle-updated"
 	caBundleTrustedDir              = "/etc/pki/ca-trust/"
@@ -166,10 +160,12 @@ func generateCephXUser(name string) string {
 func (c *clusterConfig) generateKeyring(rgwConfig *rgwConfig) (string, error) {
 	nsName := controller.NsName(c.clusterInfo.Namespace, c.store.Name)
 	user := generateCephXUser(rgwConfig.ResourceName)
-	/* TODO: this says `osd allow rwx` while template says `osd allow *`; which is correct? */
-	access := []string{"osd", "allow rwx", "mon", "allow rw"}
 	s := keyring.GetSecretStore(c.context, c.clusterInfo, c.ownerInfo)
 
+	access := []string{"osd", "allow rwx", "mon", "allow rw"}
+	if cephclient.RgwCapProfileSupported(c.clusterInfo.CephVersion) {
+		access = []string{"mon", "profile rgw", "mgr", "profile rgw", "osd", "profile rgw"}
+	}
 	keyType := cephv1.CephxKeyTypeUndefined // daemon key type always takes the default from setDefaultCephxKeyType()
 	key, err := s.GenerateKey(user, keyType, access)
 	if err != nil {
@@ -186,7 +182,7 @@ func (c *clusterConfig) generateKeyring(rgwConfig *rgwConfig) (string, error) {
 		}
 	}
 
-	keyring := fmt.Sprintf(keyringTemplate, user, key)
+	keyring := cephclient.CephKeyring(cephclient.CephCred{Username: user, Secret: key})
 	return s.CreateOrUpdate(rgwConfig.ResourceName, keyring)
 }
 

--- a/pkg/operator/ceph/object/config_test.go
+++ b/pkg/operator/ceph/object/config_test.go
@@ -19,6 +19,7 @@ package object
 import (
 	"context"
 	"maps"
+	"strings"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -27,6 +28,7 @@ import (
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/operator/test"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -279,6 +281,35 @@ func TestBuildSslOptions(t *testing.T) {
 func TestGenerateCephXUser(t *testing.T) {
 	fakeUser := generateCephXUser("rook-ceph-rgw-fake-store-fake-user")
 	assert.Equal(t, "client.rgw.fake.store.fake.user", fakeUser)
+}
+
+func TestGenerateKeyring(t *testing.T) {
+	for name, tc := range map[string]struct {
+		version cephver.CephVersion
+		want    string
+	}{
+		"profile supported":   {cephver.CephVersion{Major: 20, Minor: 2, Extra: 5}, "mon profile rgw mgr profile rgw osd profile rgw"},
+		"profile unsupported": {cephver.CephVersion{Major: 20, Minor: 2, Extra: 4}, "osd allow rwx mon allow rw"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var granted string
+			c := newConfig(t)
+			c.clusterInfo.Context = context.TODO()
+			c.clusterInfo.CephVersion = tc.version
+			c.ownerInfo = cephclient.NewMinimumOwnerInfoWithOwnerRef()
+			c.context.Executor = &exectest.MockExecutor{
+				MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+					if args[1] == "get-or-create-key" {
+						granted = strings.Join(args, " ")
+					}
+					return `{"key":"mykey"}`, nil
+				},
+			}
+			_, err := c.generateKeyring(&rgwConfig{ResourceName: "rook-ceph-rgw-my-store-a"})
+			assert.NoError(t, err)
+			assert.Contains(t, granted, "client.rgw.my.store.a "+tc.want)
+		})
+	}
 }
 
 // general testing theory here is that this easy unit test covers almost all of the RGW configs


### PR DESCRIPTION
Create rgw keys with the new `profile rgw` cephx profile (ceph/ceph#70538) instead of `mon 'allow rw', osd 'allow rwx'`. A mon without the profile rejects it and the key keeps the old caps, so older clusters see no change. Existing keys pick the profile up through `auth caps` on the next reconcile.

An osd from before the profile reads it as granting nothing, so the object controller now waits for the osds to finish upgrading before reconciling, matching Ceph's upgrade order of rgw after the osds.

Fixes: https://github.com/rook/rook/issues/18305

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [X] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [X] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [X] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

