### PR TITLE
core: remove crash collector and exporter daemons for deleted nodes

### DIFF
--- a/pkg/operator/ceph/cluster/nodedaemon/exporter.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter.go
@@ -306,36 +306,38 @@ func applyCephExporterLabels(cephCluster cephv1.CephCluster, serviceMonitor *mon
 	}
 }
 
-// deleteOrphanedExporterDeployments lists all ceph-exporter deployments in the given namespace
-// and deletes any whose target node (stored in the node_name label) no longer exists in the cluster.
-// This cleans up stale Pending exporter pods that were left behind when a node was removed while
-// the operator was not running.
-func (r *ReconcileNode) deleteOrphanedExporterDeployments(namespace string) error {
+// deleteOrphanedNodeDaemonDeployments lists all crash collector and ceph-exporter
+// deployments in the given namespace and deletes any whose target node (stored in
+// the node_name label) no longer exists in the cluster. This cleans up stale
+// deployments that were left behind when nodes were removed while the operator
+// was not running.
+func (r *ReconcileNode) deleteOrphanedNodeDaemonDeployments(namespace string) error {
 	deploymentList := &appsv1.DeploymentList{}
 	err := r.client.List(r.opManagerContext, deploymentList,
-		client.MatchingLabels{k8sutil.AppAttr: cephExporterAppName},
+		client.HasLabels{NodeNameLabel},
 		client.InNamespace(namespace),
 	)
 	if err != nil {
-		return errors.Wrapf(err, "failed to list exporter deployments in namespace %q", namespace)
+		return errors.Wrapf(err, "failed to list node daemon deployments in namespace %q", namespace)
 	}
 
 	for i := range deploymentList.Items {
 		d := deploymentList.Items[i]
-		nodeName, ok := d.Labels[NodeNameLabel]
-		if !ok {
+		appName := d.Labels[k8sutil.AppAttr]
+		if appName != CrashCollectorAppName && appName != cephExporterAppName {
 			continue
 		}
+		nodeName := d.Labels[NodeNameLabel]
 		node := &corev1.Node{}
 		err := r.client.Get(r.opManagerContext, types.NamespacedName{Name: nodeName}, node)
 		if err != nil {
 			if kerrors.IsNotFound(err) {
-				log.NamespacedInfo(namespace, logger, "deleting orphaned ceph-exporter deployment %q: target node %q no longer exists", d.Name, nodeName)
+				log.NamespacedInfo(namespace, logger, "deleting orphaned %q deployment %q: target node %q no longer exists", appName, d.Name, nodeName)
 				if delErr := r.deleteDeployment(d); delErr != nil {
-					return errors.Wrapf(delErr, "failed to delete orphaned exporter deployment %q in namespace %q", d.Name, namespace)
+					return errors.Wrapf(delErr, "failed to delete orphaned %q deployment %q in namespace %q", appName, d.Name, namespace)
 				}
 			} else {
-				return errors.Wrapf(err, "failed to check existence of node %q for exporter deployment %q", nodeName, d.Name)
+				return errors.Wrapf(err, "failed to check existence of node %q for %q deployment %q", nodeName, appName, d.Name)
 			}
 		}
 	}

--- a/pkg/operator/ceph/cluster/nodedaemon/exporter_test.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/exporter_test.go
@@ -487,7 +487,7 @@ func TestApplyCephExporterLabels(t *testing.T) {
 	assert.Nil(t, sm.Spec.Endpoints[0].RelabelConfigs)
 }
 
-func TestDeleteOrphanedExporterDeployments(t *testing.T) {
+func TestDeleteOrphanedNodeDaemonDeployments(t *testing.T) {
 	const namespace = "rook-ceph"
 	ctx := context.TODO()
 
@@ -497,10 +497,10 @@ func TestDeleteOrphanedExporterDeployments(t *testing.T) {
 	err = corev1.AddToScheme(s)
 	assert.NoError(t, err)
 
-	// helper to build a ceph-exporter Deployment with an optional node_name label
-	makeExporterDeployment := func(name, nodeName string) *appsv1.Deployment {
+	// helper to build a node daemon Deployment with an optional node_name label
+	makeNodeDaemonDeployment := func(appName, name, nodeName string) *appsv1.Deployment {
 		labels := map[string]string{
-			k8sutil.AppAttr: cephExporterAppName,
+			k8sutil.AppAttr: appName,
 		}
 		if nodeName != "" {
 			labels[NodeNameLabel] = nodeName
@@ -525,17 +525,17 @@ func TestDeleteOrphanedExporterDeployments(t *testing.T) {
 			client:           fake.NewClientBuilder().WithScheme(s).Build(),
 			opManagerContext: ctx,
 		}
-		assert.NoError(t, r.deleteOrphanedExporterDeployments(namespace))
+		assert.NoError(t, r.deleteOrphanedNodeDaemonDeployments(namespace))
 	})
 
 	t.Run("deployment whose node still exists is not deleted", func(t *testing.T) {
-		deploy := makeExporterDeployment("exporter-existing", "node1")
+		deploy := makeNodeDaemonDeployment(cephExporterAppName, "exporter-existing", "node1")
 		node := makeNode("node1")
 		r := &ReconcileNode{
 			client:           fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(deploy, node).Build(),
 			opManagerContext: ctx,
 		}
-		assert.NoError(t, r.deleteOrphanedExporterDeployments(namespace))
+		assert.NoError(t, r.deleteOrphanedNodeDaemonDeployments(namespace))
 
 		remaining := &appsv1.DeploymentList{}
 		assert.NoError(t, r.client.List(ctx, remaining, client.InNamespace(namespace)))
@@ -543,12 +543,12 @@ func TestDeleteOrphanedExporterDeployments(t *testing.T) {
 	})
 
 	t.Run("deployment whose node no longer exists is deleted", func(t *testing.T) {
-		deploy := makeExporterDeployment("exporter-orphaned", "gone-node")
+		deploy := makeNodeDaemonDeployment(cephExporterAppName, "exporter-orphaned", "gone-node")
 		r := &ReconcileNode{
 			client:           fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(deploy).Build(),
 			opManagerContext: ctx,
 		}
-		assert.NoError(t, r.deleteOrphanedExporterDeployments(namespace))
+		assert.NoError(t, r.deleteOrphanedNodeDaemonDeployments(namespace))
 
 		remaining := &appsv1.DeploymentList{}
 		assert.NoError(t, r.client.List(ctx, remaining, client.InNamespace(namespace)))
@@ -556,12 +556,12 @@ func TestDeleteOrphanedExporterDeployments(t *testing.T) {
 	})
 
 	t.Run("deployment without node_name label is skipped", func(t *testing.T) {
-		deploy := makeExporterDeployment("exporter-no-label", "")
+		deploy := makeNodeDaemonDeployment(cephExporterAppName, "exporter-no-label", "")
 		r := &ReconcileNode{
 			client:           fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(deploy).Build(),
 			opManagerContext: ctx,
 		}
-		assert.NoError(t, r.deleteOrphanedExporterDeployments(namespace))
+		assert.NoError(t, r.deleteOrphanedNodeDaemonDeployments(namespace))
 
 		remaining := &appsv1.DeploymentList{}
 		assert.NoError(t, r.client.List(ctx, remaining, client.InNamespace(namespace)))
@@ -569,18 +569,64 @@ func TestDeleteOrphanedExporterDeployments(t *testing.T) {
 	})
 
 	t.Run("mixed: one orphaned one healthy deployment", func(t *testing.T) {
-		deployOrphaned := makeExporterDeployment("exporter-orphaned", "gone-node")
-		deployHealthy := makeExporterDeployment("exporter-healthy", "live-node")
+		deployOrphaned := makeNodeDaemonDeployment(cephExporterAppName, "exporter-orphaned", "gone-node")
+		deployHealthy := makeNodeDaemonDeployment(cephExporterAppName, "exporter-healthy", "live-node")
 		node := makeNode("live-node")
 		r := &ReconcileNode{
 			client:           fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(deployOrphaned, deployHealthy, node).Build(),
 			opManagerContext: ctx,
 		}
-		assert.NoError(t, r.deleteOrphanedExporterDeployments(namespace))
+		assert.NoError(t, r.deleteOrphanedNodeDaemonDeployments(namespace))
 
 		remaining := &appsv1.DeploymentList{}
 		assert.NoError(t, r.client.List(ctx, remaining, client.InNamespace(namespace)))
 		assert.Len(t, remaining.Items, 1)
 		assert.Equal(t, "exporter-healthy", remaining.Items[0].Name)
+	})
+
+	t.Run("crash collector whose node no longer exists is deleted", func(t *testing.T) {
+		deploy := makeNodeDaemonDeployment(CrashCollectorAppName, "crashcollector-orphaned", "gone-node")
+		r := &ReconcileNode{
+			client:           fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(deploy).Build(),
+			opManagerContext: ctx,
+		}
+		assert.NoError(t, r.deleteOrphanedNodeDaemonDeployments(namespace))
+
+		remaining := &appsv1.DeploymentList{}
+		assert.NoError(t, r.client.List(ctx, remaining, client.InNamespace(namespace)))
+		assert.Empty(t, remaining.Items)
+	})
+
+	t.Run("crash collector whose node still exists is not deleted", func(t *testing.T) {
+		deploy := makeNodeDaemonDeployment(CrashCollectorAppName, "crashcollector-existing", "node1")
+		node := makeNode("node1")
+		r := &ReconcileNode{
+			client:           fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(deploy, node).Build(),
+			opManagerContext: ctx,
+		}
+		assert.NoError(t, r.deleteOrphanedNodeDaemonDeployments(namespace))
+
+		remaining := &appsv1.DeploymentList{}
+		assert.NoError(t, r.client.List(ctx, remaining, client.InNamespace(namespace)))
+		assert.Len(t, remaining.Items, 1)
+	})
+
+	t.Run("mixed: crash collector and exporter for the same deleted node are both cleaned up", func(t *testing.T) {
+		crashOrphaned := makeNodeDaemonDeployment(CrashCollectorAppName, "crashcollector-orphaned", "gone-node")
+		exporterOrphaned := makeNodeDaemonDeployment(cephExporterAppName, "exporter-orphaned", "gone-node")
+		crashHealthy := makeNodeDaemonDeployment(CrashCollectorAppName, "crashcollector-healthy", "live-node")
+		exporterHealthy := makeNodeDaemonDeployment(cephExporterAppName, "exporter-healthy", "live-node")
+		node := makeNode("live-node")
+		r := &ReconcileNode{
+			client:           fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(crashOrphaned, exporterOrphaned, crashHealthy, exporterHealthy, node).Build(),
+			opManagerContext: ctx,
+		}
+		assert.NoError(t, r.deleteOrphanedNodeDaemonDeployments(namespace))
+
+		remaining := &appsv1.DeploymentList{}
+		assert.NoError(t, r.client.List(ctx, remaining, client.InNamespace(namespace)))
+		assert.Len(t, remaining.Items, 2)
+		remainingNames := []string{remaining.Items[0].Name, remaining.Items[1].Name}
+		assert.ElementsMatch(t, []string{"crashcollector-healthy", "exporter-healthy"}, remainingNames)
 	})
 }

--- a/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/reconcile.go
@@ -60,12 +60,12 @@ var (
 	// wait for secret "rook-ceph-crash-collector-keyring" to be created
 	waitForRequeueIfSecretNotCreated = reconcile.Result{Requeue: true, RequeueAfter: 30 * time.Second}
 
-	// exporterOrphanCheckDone tracks namespaces where the one-time orphaned
-	// exporter deployment cleanup has already run. The check only needs to
-	// happen once per operator lifetime – stale deployments can only
-	// accumulate while the operator is offline, so a single pass on startup
-	// is sufficient.
-	exporterOrphanCheckDone = map[string]bool{}
+	// nodeDaemonOrphanCheckDone tracks namespaces where the one-time orphaned
+	// crash collector and ceph-exporter deployment cleanup has already run.
+	// The check only needs to happen once per operator lifetime – stale
+	// deployments can only accumulate while the operator is offline, so a
+	// single pass on startup is sufficient.
+	nodeDaemonOrphanCheckDone = map[string]bool{}
 )
 
 // ReconcileNode reconciles ReplicaSets
@@ -99,8 +99,16 @@ func (r *ReconcileNode) reconcile(request reconcile.Request) (reconcile.Result, 
 	err := r.client.Get(r.opManagerContext, request.NamespacedName, node)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			// if a node is not present, ignore the event
-			log.NamespacedDebug(request.Namespace, logger, "node %q not found. Ignoring since object must be deleted. %v", request.Name, err)
+			// The node is gone, but crash collector or ceph-exporter deployments
+			// targeting it may remain, leaving their pods pending forever. The
+			// node is only known to be gone (NotFound), so it is safe to remove
+			// its node daemons.
+			log.NamespacedInfo(request.Namespace, logger, "node %q no longer exists, deleting its crash collector and ceph-exporter deployments. %v", request.Name, err)
+			for _, appName := range []string{CrashCollectorAppName, cephExporterAppName} {
+				if err := r.listDeploymentAndDelete(appName, request.Name, ""); err != nil {
+					return reconcile.Result{}, errors.Wrapf(err, "failed to delete node daemons for deleted node %q", request.Name)
+				}
+			}
 			return reconcile.Result{}, nil
 		} else {
 			return reconcile.Result{}, errors.Wrapf(err, "could not get node %q", request.Name)
@@ -185,16 +193,18 @@ func (r *ReconcileNode) reconcile(request reconcile.Request) (reconcile.Result, 
 			}
 		}
 
-		// Clean up any exporter deployments whose target node no longer exists.
-		// This only needs to run once per operator lifetime: stale deployments
-		// can only accumulate while the operator is offline, so a single pass
-		// on startup is sufficient. Skip subsequent reconciles to avoid the
-		// extra API calls, especially in large clusters.
-		if !exporterOrphanCheckDone[namespace] {
-			if err := r.deleteOrphanedExporterDeployments(namespace); err != nil {
-				log.NamespacedError(namespace, logger, "failed to clean up orphaned ceph-exporter deployments. %v", err)
+		// Clean up any crash collector or ceph-exporter deployments whose
+		// target node no longer exists. This only needs to run once per
+		// operator lifetime: stale deployments can only accumulate while the
+		// operator is offline, so a single pass on startup is sufficient.
+		// Skip subsequent reconciles to avoid the extra API calls, especially
+		// in large clusters. A failed pass is retried on the next reconcile.
+		if !nodeDaemonOrphanCheckDone[namespace] {
+			if err := r.deleteOrphanedNodeDaemonDeployments(namespace); err != nil {
+				log.NamespacedError(namespace, logger, "failed to clean up orphaned node daemon deployments. %v", err)
+			} else {
+				nodeDaemonOrphanCheckDone[namespace] = true
 			}
-			exporterOrphanCheckDone[namespace] = true
 		}
 
 		// If the node has Ceph pods we create the daemons

--- a/pkg/operator/ceph/cluster/nodedaemon/reconcile_test.go
+++ b/pkg/operator/ceph/cluster/nodedaemon/reconcile_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodedaemon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// When a node no longer exists (NotFound), the reconcile must delete the node
+// daemons targeting it, while never touching the daemons of nodes that still exist.
+func TestReconcileNodeNotFoundCleansUpNodeDaemons(t *testing.T) {
+	const namespace = "rook-ceph"
+	ctx := context.TODO()
+
+	s := scheme.Scheme
+	err := appsv1.AddToScheme(s)
+	assert.NoError(t, err)
+	err = corev1.AddToScheme(s)
+	assert.NoError(t, err)
+
+	makeNodeDaemonDeployment := func(appName, name, nodeName string) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels: map[string]string{
+					k8sutil.AppAttr: appName,
+					NodeNameLabel:   nodeName,
+				},
+			},
+		}
+	}
+
+	crashOrphaned := makeNodeDaemonDeployment(CrashCollectorAppName, "crashcollector-orphaned", "gone-node")
+	exporterOrphaned := makeNodeDaemonDeployment(cephExporterAppName, "exporter-orphaned", "gone-node")
+	crashHealthy := makeNodeDaemonDeployment(CrashCollectorAppName, "crashcollector-healthy", "live-node")
+	exporterHealthy := makeNodeDaemonDeployment(cephExporterAppName, "exporter-healthy", "live-node")
+	liveNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "live-node"}}
+
+	r := &ReconcileNode{
+		client:           fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(crashOrphaned, exporterOrphaned, crashHealthy, exporterHealthy, liveNode).Build(),
+		opManagerContext: ctx,
+	}
+
+	request := reconcile.Request{NamespacedName: types.NamespacedName{Name: "gone-node"}}
+	result, err := r.reconcile(request)
+	assert.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	remaining := &appsv1.DeploymentList{}
+	assert.NoError(t, r.client.List(ctx, remaining, client.InNamespace(namespace)))
+	assert.Len(t, remaining.Items, 2)
+	remainingNames := []string{remaining.Items[0].Name, remaining.Items[1].Name}
+	assert.ElementsMatch(t, []string{"crashcollector-healthy", "exporter-healthy"}, remainingNames)
+
+	// a node with no daemons at all is still a no-op
+	request = reconcile.Request{NamespacedName: types.NamespacedName{Name: "never-existed-node"}}
+	result, err = r.reconcile(request)
+	assert.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	remaining = &appsv1.DeploymentList{}
+	assert.NoError(t, r.client.List(ctx, remaining, client.InNamespace(namespace)))
+	assert.Len(t, remaining.Items, 2)
+}


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #14265
---

**Summary:**

Crash collector and ceph-exporter deployments are created per node with a `node_name` label. Two gaps left them orphaned when their node object is deleted, leaving pods Pending/unschedulable forever:

1. **Operator running**: node DELETE events do trigger a reconcile, but the reconcile returned early on node NotFound ("ignore the event"). The cleanup path was only reachable while the node object still existed.
2. **Operator offline**: the one-time startup sweep covered ceph-exporter deployments only; crash collectors were never swept.

**Changes** (all in `pkg/operator/ceph/cluster/nodedaemon/`):

- On node NotFound, the reconcile now deletes the crash collector and ceph-exporter deployments targeting that node (single list by `node_name` label, filtered to the two apps, all namespaces). Deletion only happens for nodes confirmed NotFound; daemons of existing nodes are never touched.
- The one-time startup sweep now covers both crash collectors and exporters. A failed sweep pass is no longer marked done and is retried on the next reconcile.

**Behavior change:** a NotFound node reconcile previously logged and ignored; it now deletes that node's crash collector and ceph-exporter deployments cluster-wide. This is the intent of the fix, but noting it explicitly for anyone relying on the old ignore semantics.

Returning the error from the sweep (relying on controller-runtime backoff for a guaranteed retry) was considered; we kept log-and-continue to avoid changing reconcile semantics. Happy to switch if maintainers prefer.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Not applicable: minor bugfix, no breaking or notable change.
- [x] Documentation has been updated, if necessary (under the `Documentation` folder).
  - Not applicable: no user-facing configuration change.
- [x] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [x] Integration tests have been added, if necessary (in the `tests/integration` folder).
  - Not applicable: covered by unit tests.

**AI disclosure:** this change was developed with AI assistance (opencode / GLM). The diagnosis, implementation, and tests were AI-generated under the contributor's direction; the contributor reviewed, verified (unit tests, `-race`, lint), and owns the result.
