### PR TITLE
object: cleanup STS config and secrets when disabled

### DIFF
--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/util/log"
 	v1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
@@ -234,12 +235,38 @@ func mapKeystoneSecretToConfig(cfg map[string]string, secret *v1.Secret) (map[st
 }
 
 func (c *clusterConfig) setFlagsMonConfigStore(rgwConfig *rgwConfig) error {
+	nsName := controller.NsName(c.clusterInfo.Namespace, c.store.Name)
 	monStore := cephconfig.GetMonStore(c.context, c.clusterInfo)
 	who := generateCephXUser(rgwConfig.ResourceName)
 
 	configOptions, err := c.generateMonConfigOptions(rgwConfig)
 	if err != nil {
 		return err
+	}
+
+	// STS cleanup when disabled
+	if stsAuthVal, exists := configOptions["rgw_s3_auth_use_sts"]; exists && stsAuthVal == "false" {
+		log.NamedInfo(nsName, logger, "STS is being disabled, cleaning up STS configuration and secrets")
+
+		// Check if rgw_sts_key was previously set before deleting
+		prevStsKey, _ := monStore.Get(who, "rgw_sts_key")
+		if prevStsKey != "" {
+			err := monStore.Delete(who, "rgw_sts_key")
+			if err != nil {
+				log.NamedWarning(nsName, logger, "failed to delete rgw_sts_key from mon config store: %v", err)
+			}
+		}
+
+		// Delete the STS secret
+		stsSecretName := fmt.Sprintf("sts-key-%s", c.store.Name)
+		err = c.context.Clientset.CoreV1().Secrets(c.store.Namespace).Delete(
+			c.clusterInfo.Context,
+			stsSecretName,
+			metav1.DeleteOptions{},
+		)
+		if err != nil && !kerrors.IsNotFound(err) {
+			log.NamedWarning(nsName, logger, "failed to delete STS secret %q: %v", stsSecretName, err)
+		}
 	}
 
 	if err := monStore.SetAll(who, configOptions); err != nil {


### PR DESCRIPTION
When rgw_s3_auth_use_sts is set to false, the STS configuration and credentials were not being cleaned up, causing STS to remain functional even after being disabled. This commit adds logic which checks whether rgw_sts_key exists, deletes it from the mon config database if present and deletes the secret containing the STS key when rgw_s3_auth_use_sts is set to false.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

