### PR TITLE
external: revert, if admin creds is provided stop creating csi secret

### DIFF
--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -100,6 +100,14 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 	}
 	log.NamespacedInfo(cluster.Namespace, logger, "external cluster identity established")
 
+	// Create CSI Secrets only if the user has provided the admin key
+	if cluster.ClusterInfo.CephCred.Username == client.AdminUsername {
+		err = csi.CreateCSISecrets(c.context, cluster.ClusterInfo, cluster.namespacedName)
+		if err != nil {
+			return errors.Wrap(err, "failed to create csi kubernetes secrets")
+		}
+	}
+
 	// update the msgr2 flag
 	for _, m := range cluster.ClusterInfo.InternalMonitors {
 		// m.Endpoint=10.1.115.104:3300


### PR DESCRIPTION
partial revert of https://github.com/rook/rook/pull/16882

closes: https://github.com/rook/rook/issues/18193

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

