### PR TITLE
rgw: make daemon_id unique among multiple rgw instances

### DIFF
--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -50,11 +50,12 @@ import (
 const (
 	// ConfigInitContainerName is the name which is given to the config initialization container
 	// in all Ceph pods.
-	ConfigInitContainerName                 = "config-init"
-	logVolumeName                           = "rook-ceph-log"
-	volumeMountSubPath                      = "data"
-	crashVolumeName                         = "rook-ceph-crash"
-	daemonSocketDir                         = "/run/ceph"
+	ConfigInitContainerName = "config-init"
+	logVolumeName           = "rook-ceph-log"
+	volumeMountSubPath      = "data"
+	crashVolumeName         = "rook-ceph-crash"
+	// DaemonSocketDir is the directory where Ceph daemons create their admin sockets.
+	DaemonSocketDir                         = "/run/ceph"
 	daemonSocketsSubPath                    = "/exporter"
 	logCollector                            = "log-collector"
 	DaemonIDLabel                           = "ceph_daemon_id"
@@ -225,7 +226,7 @@ func CephVolumeMounts(dataPaths *opconfig.DataPathMap, confGeneratedInPod bool) 
 		configMount,
 		// Rook doesn't run in ceph containers, so it doesn't need the config override mounted
 	}
-	v = append(v, v1.VolumeMount{Name: "ceph-daemons-sock-dir", MountPath: daemonSocketDir})
+	v = append(v, v1.VolumeMount{Name: "ceph-daemons-sock-dir", MountPath: DaemonSocketDir})
 	v = append(v, StoredLogAndCrashVolumeMount(dataPaths.ContainerLogDir(), dataPaths.ContainerCrashDir())...)
 
 	return v
@@ -316,7 +317,7 @@ func DaemonVolumeMounts(dataPaths *opconfig.DataPathMap, keyringResourceName str
 		configOverrideMount,
 	}
 	if dataDirHostPath != "" {
-		mounts = append(mounts, v1.VolumeMount{Name: "ceph-daemons-sock-dir", MountPath: daemonSocketDir})
+		mounts = append(mounts, v1.VolumeMount{Name: "ceph-daemons-sock-dir", MountPath: DaemonSocketDir})
 	}
 	if keyringResourceName != "" {
 		mounts = append(mounts, keyring.VolumeMount().Resource(keyringResourceName))
@@ -329,7 +330,8 @@ func DaemonVolumeMounts(dataPaths *opconfig.DataPathMap, keyringResourceName str
 		// no data is stored in container, so there are no more mounts
 		return mounts
 	}
-	return append(mounts,
+	return append(
+		mounts,
 		v1.VolumeMount{Name: "ceph-daemon-data", MountPath: dataPaths.ContainerDataDir},
 	)
 }
@@ -535,13 +537,14 @@ func ChownCephDataDirsInitContainer(
 	configDir string,
 ) v1.Container {
 	args := make([]string, 0, 5)
-	args = append(args,
+	args = append(
+		args,
 		"--verbose",
 		"--recursive",
 		"ceph:ceph",
 		opconfig.VarLogCephDir,
 		opconfig.VarLibCephCrashDir,
-		daemonSocketDir,
+		DaemonSocketDir,
 	)
 	if configDir != "" {
 		args = append(args, configDir)
@@ -708,7 +711,7 @@ func (c *daemonConfig) buildSocketName() string {
 }
 
 func (c *daemonConfig) buildSocketPath() string {
-	return path.Join(daemonSocketDir, c.buildSocketName())
+	return path.Join(DaemonSocketDir, c.buildSocketName())
 }
 
 func (c *daemonConfig) buildAdminSocketCommand() string {

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -34,6 +34,7 @@ import (
 	"github.com/rook/rook/pkg/daemon/ceph/osd/kms"
 	cephconfig "github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util/log"
 	apps "k8s.io/api/apps/v1"
@@ -85,6 +86,10 @@ chown --recursive --verbose ceph:ceph $VAULT_TOKEN_NEW_PATH
 var (
 	//go:embed rgw-probe.sh
 	rgwProbeScriptTemplate string
+
+	// serviceUniqueID flag was backported to Squid in v19.2.4 and to Tentacle in v20.2.1
+	serviceUniqueIDSquidMinVersion    = cephver.CephVersion{Major: 19, Minor: 2, Extra: 4}
+	serviceUniqueIDTentacleMinVersion = cephver.CephVersion{Major: 20, Minor: 2, Extra: 1}
 
 	rgwAPIwithoutS3 = []string{"s3website", "swift", "swift_auth", "admin", "sts", "iam", "notifications"}
 
@@ -393,7 +398,8 @@ func (c *clusterConfig) vaultTokenInitContainer(rgwConfig *rgwConfig, kmsEnabled
 		Image:           c.clusterSpec.CephVersion.Image,
 		ImagePullPolicy: controller.GetContainerImagePullPolicy(c.clusterSpec.CephVersion.ImagePullPolicy),
 		VolumeMounts: append(
-			controller.DaemonVolumeMounts(c.DataPathMap, rgwConfig.ResourceName, c.clusterSpec.DataDirHostPath), vaultVolMounts...),
+			controller.DaemonVolumeMounts(c.DataPathMap, rgwConfig.ResourceName, c.clusterSpec.DataDirHostPath), vaultVolMounts...,
+		),
 		Resources:       c.store.Spec.Gateway.Resources,
 		SecurityContext: controller.RootContainerSecurityContext(),
 	}
@@ -409,6 +415,17 @@ func (c *clusterConfig) makeChownInitContainer(rgwConfig *rgwConfig) v1.Containe
 		controller.RootContainerSecurityContext(),
 		"",
 	)
+}
+
+// serviceUniqueIDSupported returns true if the running Ceph version supports the
+// service_unique_id flag. The flag was backported to Squid in v19.2.4 and to
+// Tentacle in v20.2.1.
+func (c *clusterConfig) serviceUniqueIDSupported() bool {
+	v := c.clusterInfo.CephVersion
+	if v.Major == serviceUniqueIDSquidMinVersion.Major {
+		return v.IsAtLeast(serviceUniqueIDSquidMinVersion)
+	}
+	return v.IsAtLeast(serviceUniqueIDTentacleMinVersion)
 }
 
 func (c *clusterConfig) makeDaemonContainer(rgwConfig *rgwConfig) (v1.Container, error) {
@@ -445,13 +462,24 @@ func (c *clusterConfig) makeDaemonContainer(rgwConfig *rgwConfig) (v1.Container,
 			controller.DaemonVolumeMounts(c.DataPathMap, rgwConfig.ResourceName, c.clusterSpec.DataDirHostPath),
 			c.mimeTypesVolumeMount(),
 		),
-		Env:             controller.DaemonEnvVars(c.clusterSpec),
+		Env:             append(controller.DaemonEnvVars(c.clusterSpec), k8sutil.NameEnvVar()),
 		Resources:       c.store.Spec.Gateway.Resources,
 		StartupProbe:    startupProbe,
 		LivenessProbe:   noLivenessProbe(),
 		ReadinessProbe:  readinessProbe,
 		SecurityContext: controller.DefaultContainerSecurityContext(),
 		WorkingDir:      cephconfig.VarLogCephDir,
+	}
+
+	// The service_unique_id flag makes the rgw daemon_id unique among multiple rgw instances.
+	// It was backported to Squid in v19.2.4 and to Tentacle in v20.2.1, so only set it on
+	// versions that support it.
+	if c.serviceUniqueIDSupported() {
+		// serviceUniqueId is set to the pod name, obtained at runtime via the downward API
+		// (POD_NAME env var). Kubernetes expands $(POD_NAME) in the container args since the
+		// env var is defined on the container.
+		serviceUniqueId := fmt.Sprintf("$(%s)", k8sutil.PodNameEnvVar)
+		container.Args = append(container.Args, cephconfig.NewFlag("service_unique_id", serviceUniqueId))
 	}
 
 	// If the startup probe is enabled
@@ -468,7 +496,8 @@ func (c *clusterConfig) makeDaemonContainer(rgwConfig *rgwConfig) (v1.Container,
 		if supportsCurlCaBundle(c) {
 			customCaBundleMount := v1.VolumeMount{Name: caBundleVolumeName, MountPath: caBundleMountPath, ReadOnly: true}
 			container.VolumeMounts = append(container.VolumeMounts, customCaBundleMount)
-			container.Env = append(container.Env,
+			container.Env = append(
+				container.Env,
 				v1.EnvVar{
 					// Following PR introduced to specify ssl certificate for RGW
 					// admin operations with this CURL_CA_BUNDLE env variable.
@@ -500,7 +529,8 @@ func (c *clusterConfig) makeDaemonContainer(rgwConfig *rgwConfig) (v1.Container,
 	}
 	if c.store.Spec.Gateway.OpsLogSidecar != nil {
 		container.Env = append(container.Env, podNameEnvVars...)
-		container.Args = append(container.Args,
+		container.Args = append(
+			container.Args,
 			cephconfig.NewFlag("rgw_enable_ops_log", "true"),
 			cephconfig.NewFlag("rgw_ops_log_file_path", opsLogAbsFilename),
 		)

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -1757,3 +1757,66 @@ func TestGenerateServiceLabels(t *testing.T) {
 	// Verify default labels are still present
 	assert.Equal(t, "rook-ceph-rgw", svc.ObjectMeta.Labels["app"])
 }
+
+func TestServiceUniqueIDSupported(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  cephver.CephVersion
+		expected bool
+	}{
+		{"squid below min", cephver.CephVersion{Major: 19, Minor: 2, Extra: 3}, false},
+		{"squid at min", cephver.CephVersion{Major: 19, Minor: 2, Extra: 4}, true},
+		{"squid above min", cephver.CephVersion{Major: 19, Minor: 2, Extra: 5}, true},
+		{"tentacle below min", cephver.CephVersion{Major: 20, Minor: 2, Extra: 0}, false},
+		{"tentacle at min", cephver.CephVersion{Major: 20, Minor: 2, Extra: 1}, true},
+		{"tentacle above min", cephver.CephVersion{Major: 20, Minor: 2, Extra: 2}, true},
+		{"future major", cephver.CephVersion{Major: 21, Minor: 0, Extra: 0}, true},
+		{"below squid", cephver.CephVersion{Major: 18, Minor: 2, Extra: 9}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &clusterConfig{
+				clusterInfo: &client.ClusterInfo{CephVersion: tt.version},
+			}
+			assert.Equal(t, tt.expected, c.serviceUniqueIDSupported())
+		})
+	}
+}
+
+func TestServiceUniqueIDFlag(t *testing.T) {
+	store := simpleStore()
+	data := cephconfig.NewStatelessDaemonDataPathMap(cephconfig.RgwType, "default", "rook-ceph", "/var/lib/rook/")
+	rgwConfig := &rgwConfig{
+		ResourceName: fmt.Sprintf("%s-%s", AppName, store.Name),
+		DaemonID:     "default",
+	}
+
+	newClusterConfig := func(v cephver.CephVersion) *clusterConfig {
+		info := clienttest.CreateTestClusterInfo(1)
+		info.CephVersion = v
+		return &clusterConfig{
+			context:     &clusterd.Context{Executor: &exectest.MockExecutor{}, Clientset: test.New(t, 0)},
+			clusterInfo: info,
+			store:       store,
+			clusterSpec: &cephv1.ClusterSpec{
+				CephVersion:     cephv1.CephVersionSpec{Image: "quay.io/ceph/ceph:v19"},
+				DataDirHostPath: "/var/lib/rook",
+			},
+			DataPathMap: data,
+		}
+	}
+
+	t.Run("flag set on supported version", func(t *testing.T) {
+		c := newClusterConfig(cephver.CephVersion{Major: 19, Minor: 2, Extra: 4})
+		container, err := c.makeDaemonContainer(rgwConfig)
+		assert.NoError(t, err)
+		assert.Contains(t, container.Args, "--service-unique-id=$(POD_NAME)")
+	})
+
+	t.Run("flag omitted on unsupported version", func(t *testing.T) {
+		c := newClusterConfig(cephver.CephVersion{Major: 19, Minor: 2, Extra: 3})
+		container, err := c.makeDaemonContainer(rgwConfig)
+		assert.NoError(t, err)
+		assert.NotContains(t, container.Args, "--service-unique-id=$(POD_NAME)")
+	})
+}


### PR DESCRIPTION
When multiple instances of the same deployment share the same keyring, Ceph defaults to generating identical daemon IDs across replicas because the underlying
deployment/keyring credentials match.

The Ceph Exporter pod needs to read each RGW instance's admin socket (/var/run/ceph/ceph-client.rgw.<daemon_id>.asok). Identical daemon IDs cause socket name collisions, making them block each other.

Because the exporter couldn't reliably access individual sockets, metric collection failed and caused Prometheus scrapes to break.

Adding service_unique_id, Ceph appends a unique identifier to each instance. This gives every RGW daemon a distinct socket file, allowing the exporter to correctly map and scrape metrics from every pod.

closes: https://github.com/rook/rook/issues/13674

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

