### PR TITLE
ci: update min k8s version to v1.32

### DIFF
--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.11", "v1.34.8", "v1.37.0"]
+        kubernetes-version: ["v1.32.11", "v1.34.8", "v1.36.1", "v1.37.0"]
     steps:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -105,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.11", "v1.34.8", "v1.37.0"]
+        kubernetes-version: ["v1.32.11", "v1.34.8", "v1.36.1", "v1.37.0"]
     steps:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -148,7 +148,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.11", "v1.34.8", "v1.37.0"]
+        kubernetes-version: ["v1.32.11", "v1.34.8", "v1.36.1", "v1.37.0"]
     steps:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -189,7 +189,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.11", "v1.34.8", "v1.37.0"]
+        kubernetes-version: ["v1.32.11", "v1.34.8", "v1.36.1", "v1.37.0"]
     steps:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -230,7 +230,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.32.11", "v1.34.8", "v1.37.0"]
+        kubernetes-version: ["v1.32.11", "v1.34.8", "v1.36.1", "v1.37.0"]
     steps:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -271,7 +271,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14"]  # test only on oldest supported k8s version
+        kubernetes-version: ["v1.32.11"]  # test only on oldest supported k8s version
     steps:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.37.0"]
+        kubernetes-version: ["v1.32.11", "v1.37.0"]
     steps:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -105,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14"]  # test only on oldest supported k8s version
+        kubernetes-version: ["v1.32.11"]  # test only on oldest supported k8s version
     steps:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -176,7 +176,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.37.0"]
+        kubernetes-version: ["v1.32.11", "v1.37.0"]
     steps:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -201,7 +201,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.37.0"]
+        kubernetes-version: ["v1.32.11", "v1.37.0"]
     steps:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -246,7 +246,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.31.14", "v1.37.0"]
+        kubernetes-version: ["v1.32.11", "v1.37.0"]
     steps:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/Documentation/Getting-Started/Prerequisites/prerequisites.md
+++ b/Documentation/Getting-Started/Prerequisites/prerequisites.md
@@ -7,7 +7,7 @@ and Rook is granted the required privileges (see below for more information).
 
 ## Kubernetes Version
 
-Kubernetes versions **v1.31** through **v1.37** are supported.
+Kubernetes versions **v1.32** through **v1.37** are supported.
 
 ## CPU Architecture
 

--- a/Documentation/Getting-Started/maintenance-and-support.md
+++ b/Documentation/Getting-Started/maintenance-and-support.md
@@ -29,6 +29,7 @@ the current release, the authoritative sources are the
 
 | Rook | Kubernetes | Ceph |
 | ---- | ---------- | ---- |
+| 1.21 | v1.32 – v1.37 | Squid v19.2.0+, Tentacle v20.2.1+ |
 | 1.20 | v1.31 – v1.37 | Squid v19.2.0+, Tentacle v20.2.1+ |
 | 1.19 | v1.30 – v1.35 | Squid v19.2.0+, Tentacle v20.2.1+ |
 | 1.18 | v1.29 – v1.34 | Reef v18.2.0+, Squid v19.2.0+, Tentacle v20.2.0+ |

--- a/Documentation/Getting-Started/quickstart.md
+++ b/Documentation/Getting-Started/quickstart.md
@@ -12,7 +12,7 @@ This guide will walk through the basic setup of a Ceph cluster and enable K8s ap
 
 ## Kubernetes Version
 
-Kubernetes versions **v1.31** through **v1.37** are supported.
+Kubernetes versions **v1.32** through **v1.37** are supported.
 
 ## CPU Architecture
 

--- a/Documentation/Upgrade/rook-upgrade.md
+++ b/Documentation/Upgrade/rook-upgrade.md
@@ -41,7 +41,7 @@ those releases.
     ConfigMap must be migrated to the ceph-csi-operator resources. The following sections will guide
     you through this conversion.
 
-* The minimum supported Kubernetes version is v1.31.
+* The minimum supported Kubernetes version is v1.32.
 
 ## Considerations
 


### PR DESCRIPTION
Updating the minimum supported version of K8s to v1.32, to support the most recent six K8s releases (v1.32 - v1.37) per our maintenance policy.

Closes #18331 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

