### PR TITLE
security: drop command output from unmarshal error text

### DIFF
--- a/pkg/daemon/ceph/osd/replace.go
+++ b/pkg/daemon/ceph/osd/replace.go
@@ -51,7 +51,7 @@ func cephVolumeLVMList(context *clusterd.Context, osdID int) ([]cvLVMListEntry, 
 	}
 	var listResult map[string][]cvLVMListEntry
 	if err := json.Unmarshal([]byte(result), &listResult); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal ceph-volume lvm list result for osd.%d. %s", osdID, result)
+		return nil, errors.Wrapf(err, "failed to unmarshal ceph-volume lvm list result for osd.%d (%d bytes)", osdID, len(result))
 	}
 	return listResult[strconv.Itoa(osdID)], nil
 }

--- a/pkg/daemon/ceph/osd/replace_test.go
+++ b/pkg/daemon/ceph/osd/replace_test.go
@@ -691,3 +691,24 @@ func TestIsCryptsetupNotActive(t *testing.T) {
 	assert.False(t, isCryptsetupNotActive(errors.New("exit status 1")))
 	assert.False(t, isCryptsetupNotActive(nil))
 }
+
+func TestCephVolumeLVMListParseFailureDoesNotLeakLockboxSecret(t *testing.T) {
+	// the raw ceph-volume response carries ceph.cephx_lockbox_secret even though
+	// osdTags does not map it, so the payload must not ride along with the error
+	const lockboxSecret = "EXAMPLELOCKBOXSECRET00000000000000000001"
+	badResult := `{"3": [{"type": "block", "path": 12345, "tags": {"ceph.encrypted": "1", "ceph.cephx_lockbox_secret": "` + lockboxSecret + `"}}]}`
+
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		if command == "stdbuf" && args[4] == "lvm" && args[5] == "list" {
+			return badResult, nil
+		}
+		return "", errors.Errorf("unknown command %s %s", command, args)
+	}
+
+	_, err := cephVolumeLVMList(&clusterd.Context{Executor: executor}, 3)
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), lockboxSecret)
+	assert.Contains(t, err.Error(), "cvLVMListEntry.path of type string")
+}

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -1220,7 +1220,10 @@ func GetCephVolumeLVMOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 	var cephVolumeResult map[string][]osdInfo
 	err = json.Unmarshal([]byte(result), &cephVolumeResult)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal ceph-volume %s list results. %s", cvMode, result)
+		// the payload carries ceph.cephx_lockbox_secret for encrypted OSDs, and this
+		// error reaches the OSD status ConfigMap. A syntax error reports only its
+		// message, so report the response size in place of the response.
+		return nil, errors.Wrapf(err, "failed to unmarshal ceph-volume %s list results (%d bytes)", cvMode, len(result))
 	}
 
 	for name, osdInfo := range cephVolumeResult {

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -1836,6 +1836,59 @@ func TestParseCephVolumeLVMResult(t *testing.T) {
 	assert.Equal(t, 2, len(osds))
 }
 
+func TestCephVolumeLVMResultParseFailureDoesNotLeakLockboxSecret(t *testing.T) {
+	// ceph-volume list output carries ceph.cephx_lockbox_secret for encrypted OSDs.
+	// This error becomes OrchestrationStatus.Message, which the OSD provisioning job
+	// writes to a ConfigMap, so the payload must not ride along with it.
+	const lockboxSecret = "EXAMPLELOCKBOXSECRET00000000000000000001"
+	tags := `"tags": {"ceph.osd_fsid": "9ee6a1e7-1c3f-4c1e-9a5b-0c4b1f2d3e4f", "ceph.encrypted": "1", "ceph.cephx_lockbox_secret": "` + lockboxSecret + `"}`
+
+	tests := []struct {
+		name   string
+		result string
+		// the field a type error names; empty when the error is a syntax error,
+		// which reports only its own message
+		namesField string
+	}{
+		{
+			// path is a string in osdInfo, so a number is the shape a ceph-volume
+			// schema change would take
+			name:       "type error",
+			result:     `{"0": [{"name": "osd-block-9ee6a1e7", "path": 12345, ` + tags + `, "type": "block"}]}`,
+			namesField: "osdInfo.path of type string",
+		},
+		{
+			// callCephVolume warns that stderr contamination breaks the unmarshal, so
+			// a malformed response is the likelier failure here
+			name:   "truncated response",
+			result: `{"0": [{"name": "osd-block-9ee6a1e7", ` + tags,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			executor := &exectest.MockExecutor{}
+			executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+				if command == "stdbuf" && args[4] == "lvm" && args[5] == "list" {
+					return tc.result, nil
+				}
+				return "", errors.Errorf("unknown command %s %s", command, args)
+			}
+
+			context := &clusterd.Context{Executor: executor}
+			_, err := GetCephVolumeLVMOSDs(context, &cephclient.ClusterInfo{Namespace: "name"}, "4bfe8b72-5e69-4330-b6c0-4d914db8ab89", "", false, false)
+
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), lockboxSecret)
+			// the response size is the only context a syntax error leaves
+			assert.Contains(t, err.Error(), fmt.Sprintf("(%d bytes)", len(tc.result)))
+			if tc.namesField != "" {
+				assert.Contains(t, err.Error(), tc.namesField)
+			}
+		})
+	}
+}
+
 func TestParseCephVolumeRawResult(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -56,7 +56,11 @@ func decodeUser(data string) (*ObjectUser, int, error) {
 	var user admin.User
 	err := json.Unmarshal([]byte(data), &user)
 	if err != nil {
-		return nil, RGWErrorParse, errors.Wrapf(err, "failed to unmarshal json. %s", data)
+		// the payload is a radosgw-admin user document, which carries the user's S3
+		// keys. A type error names the offending field, but a syntax error reports
+		// only its message, so report the response size in its place.
+		logger.Tracef("failed to unmarshal user json: %s", data) // only trace(insecure) logged because the response carries the user's S3 keys
+		return nil, RGWErrorParse, errors.Wrapf(err, "failed to unmarshal user json (%d bytes)", len(data))
 	}
 
 	rookUser := ObjectUser{UserID: user.ID, DisplayName: &user.DisplayName, Email: &user.Email}

--- a/pkg/operator/ceph/object/user_test.go
+++ b/pkg/operator/ceph/object/user_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/coreos/pkg/capnslog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeUserDoesNotLeakKeys(t *testing.T) {
+	// decodeUser is handed radosgw-admin user output, which carries the user's S3
+	// keys. Its error reaches a Kubernetes event and the CephObjectStore status by
+	// way of the admin-ops and dashboard user provisioning.
+	const (
+		accessKey = "EXAMPLEACCESSKEYID01"
+		secretKey = "EXAMPLEUSERSECRETKEY0000000000000000000001"
+	)
+	keys := `"keys": [{"user": "my-user", "access_key": "` + accessKey + `", "secret_key": "` + secretKey + `"}]`
+
+	tests := []struct {
+		name string
+		json string
+		// the field a type error names; empty when the error is a syntax error,
+		// which reports only its own message
+		namesField string
+	}{
+		{
+			// max_buckets is an int in admin.User, so a string is the shape a schema
+			// change across Ceph versions would take
+			name:       "type error",
+			json:       `{"user_id": "my-user", "max_buckets": "not-an-int", ` + keys + `}`,
+			namesField: "max_buckets",
+		},
+		{
+			name: "truncated response",
+			json: `{"user_id": "my-user", ` + keys,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, code, err := decodeUser(tc.json)
+
+			require.Error(t, err)
+			assert.Equal(t, RGWErrorParse, code)
+			assert.NotContains(t, err.Error(), secretKey)
+			assert.NotContains(t, err.Error(), accessKey)
+			// the response size is the only context a syntax error leaves
+			assert.Contains(t, err.Error(), fmt.Sprintf("(%d bytes)", len(tc.json)))
+			if tc.namesField != "" {
+				assert.Contains(t, err.Error(), tc.namesField)
+			}
+		})
+	}
+}
+
+// captureLogsAtLevel redirects the capnslog sink into a buffer at the given level
+// for the duration of the test, restoring the package default afterwards so later
+// tests still log to stderr and never at TRACE.
+func captureLogsAtLevel(t *testing.T, level capnslog.LogLevel) *bytes.Buffer {
+	t.Helper()
+
+	logBuf := bytes.NewBuffer([]byte{})
+	capnslog.SetFormatter(capnslog.NewLogFormatter(logBuf, "", 0))
+	capnslog.SetGlobalLogLevel(level)
+	t.Cleanup(func() {
+		capnslog.SetFormatter(capnslog.NewDefaultFormatter(os.Stderr))
+		capnslog.SetGlobalLogLevel(capnslog.INFO)
+	})
+
+	return logBuf
+}
+
+func TestDecodeUserLogsRawResponseOnlyUnderTrace(t *testing.T) {
+	// the raw response is the only way to tell a truncated document from a schema
+	// change, but it carries the user's S3 keys, so it is logged only at the TRACE
+	// level that ROOK_LOG_LEVEL=TRACE_INSECURE unlocks.
+	const secretKey = "EXAMPLEUSERSECRETKEY0000000000000000000001"
+	badJSON := `{"user_id": "my-user", "keys": [{"secret_key": "` + secretKey + `"}]`
+
+	for _, tc := range []struct {
+		level  capnslog.LogLevel
+		logged bool
+	}{
+		{level: capnslog.DEBUG, logged: false},
+		{level: capnslog.TRACE, logged: true},
+	} {
+		t.Run(tc.level.String(), func(t *testing.T) {
+			logBuf := captureLogsAtLevel(t, tc.level)
+
+			_, _, err := decodeUser(badJSON)
+
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), secretKey)
+			if tc.logged {
+				assert.Contains(t, logBuf.String(), secretKey)
+			} else {
+				assert.NotContains(t, logBuf.String(), secretKey)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Three unmarshal failures wrapped their raw input into the returned error. That input is a radosgw-admin user document carrying the user's S3 keys in one case, and ceph-volume list output carrying `ceph.cephx_lockbox_secret` in the others.

These errors do not stop at the log: one reaches a Kubernetes event and the CephObjectStore status, another a ConfigMap. They now report the response size in place of the response.

**Notable decisions**

The size is reported rather than nothing, because `json.SyntaxError` gives only its own message and never its offset, and a malformed response is the likelier failure for `ceph-volume list` calls.

**AI assistance:** Claude Code found these during a repo-wide audit, wrote the fixes and the regression tests, and confirmed each test fails when its fix is reverted.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [x] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
