### PR TITLE
ceph: fix aes256k capability false positive for Ceph 21 pre-release tags

### DIFF
--- a/pkg/daemon/ceph/client/auth.go
+++ b/pkg/daemon/ceph/client/auth.go
@@ -130,8 +130,19 @@ func Aes256kKeysSupported(ver version.CephVersion) bool {
 		return ver.IsAtLeast(version.CephVersion{Major: 19, Minor: 2, Extra: 6})
 	case 20:
 		return ver.IsAtLeast(version.CephVersion{Major: 20, Minor: 2, Extra: 4})
+	case 21:
+		// v21.3.0 is an out-of-sequence Umbrella development tag created before
+		// v21.1.0 and before aes256k support was merged upstream; its numerically
+		// higher minor must not be mistaken for a later, feature-complete release.
+		if ver.Minor == 3 && ver.Extra == 0 {
+			return false
+		}
+		// aes256k support landed after the v21.1.0 development tag, so plain
+		// "major == 21" is a false positive. Umbrella carries the feature
+		// starting with the 21.2.z stable release train.
+		return ver.IsAtLeast(version.CephVersion{Major: 21, Minor: 2, Extra: 0})
 	default:
-		return ver.Major >= 21
+		return ver.Major > 21
 	}
 }
 

--- a/pkg/daemon/ceph/client/auth_test.go
+++ b/pkg/daemon/ceph/client/auth_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/ceph/version"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -762,3 +763,31 @@ const authDumpKeysRawJson = `{
     ]
   }
 }`
+
+func TestAes256kKeysSupported(t *testing.T) {
+	cases := []struct {
+		name     string
+		ver      version.CephVersion
+		expected bool
+	}{
+		{"squid below threshold", version.CephVersion{Major: 19, Minor: 2, Extra: 5}, false},
+		{"squid at threshold", version.CephVersion{Major: 19, Minor: 2, Extra: 6}, true},
+		{"tentacle below threshold", version.CephVersion{Major: 20, Minor: 2, Extra: 3}, false},
+		{"tentacle at threshold", version.CephVersion{Major: 20, Minor: 2, Extra: 4}, true},
+		// regression: v21.1.0 is a pre-release development tag that predates
+		// the aes256k feature merge and must not be reported as supported
+		{"umbrella v21.1.0 dev tag", version.CephVersion{Major: 21, Minor: 1, Extra: 0}, false},
+		{"umbrella below stable threshold", version.CephVersion{Major: 21, Minor: 0, Extra: 1}, false},
+		// regression: v21.3.0 was tagged before v21.1.0 and before the aes256k
+		// feature merge; its numerically higher minor must not read as "later"
+		{"umbrella v21.3.0 out-of-sequence dev tag", version.CephVersion{Major: 21, Minor: 3, Extra: 0}, false},
+		{"umbrella at stable threshold", version.CephVersion{Major: 21, Minor: 2, Extra: 0}, true},
+		{"future major release", version.CephVersion{Major: 22, Minor: 0, Extra: 0}, true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.expected, Aes256kKeysSupported(c.ver))
+		})
+	}
+}

--- a/pkg/operator/ceph/config/keyring/cephx_test.go
+++ b/pkg/operator/ceph/config/keyring/cephx_test.go
@@ -32,7 +32,7 @@ func TestShouldRotateCephxKeys(t *testing.T) {
 	// commit IDs will ensure they are being ignored as part of comparison to keyCephVersion status
 	v20_2_0 := version.CephVersion{Major: 20, Minor: 2, Extra: 0, CommitID: "ababababababa"}
 	v20_2_4 := version.CephVersion{Major: 20, Minor: 2, Extra: 4, CommitID: "ababababababa"}
-	SupportsKeyTypeVer := version.CephVersion{Major: 21}
+	SupportsKeyTypeVer := version.CephVersion{Major: 21, Minor: 2, Extra: 0}
 
 	clusterNs := "rook-system"
 	SetAllowCephxKeyRotationForCluster(clusterNs, true) // default allow rotation


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

**Issue resolved by this Pull Request:**
Resolves #18336

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
  - Not applicable: this is a bug fix restoring intended version-gating behavior, not a config or breaking change.
- [x] Documentation has been updated, if necessary (under the `Documentation` folder).
  - Not needed: existing docs already state Umbrella aes256k support begins at v21.2.0; this PR only makes the code match that.
- [x] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [x] Integration tests have been added, if necessary (in the `tests/integration` folder).
  - Not applicable: this is a pure version-arithmetic predicate, fully covered by unit tests; no cluster-level behavior change to integration-test.

CI note: this PR was validated with targeted package builds/tests locally (see commit message); the base `master` branch's own CI was green at the branch point (HEAD at the time of this PR).

---
AI assistance: this change was drafted with Claude Code.