### PR TITLE
ci: drop the  node 20 requirement for tmate debugging

### DIFF
--- a/.github/workflows/tmate_debug/action.yml
+++ b/.github/workflows/tmate_debug/action.yml
@@ -21,7 +21,7 @@ runs:
 
     - name: set up tmate session
       if: env.ENABLE_TMATE
-      uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101 # v3.23
+      uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113 # v3.24
       with:
         ## whether to limit ssh access and adds the ssh public key for the user who triggered the workflow:
         limit-access-to-actor: false


### PR DESCRIPTION
**Description Of Changes:**
Debugging with action-tmate required node.js 20 in the runners.

This change removes that requirement by upgrading the version of the action-tmate to v3.24 which has updated the node.js runtime from 20 to 24.

See https://github.com/mxschmitt/action-tmate/releases/tag/v3.24

This has been split out of PR #18174 


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

