### PR TITLE
ci: bump reviewdog/action-misspell to v1.28.0

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: codespell
-        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # master
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2
         with:
           # LICENSE: skip file because codespell wants to flag complies, which we may want to flag
           # in other places, so ignore the file itself assuming it is correct
@@ -57,4 +57,4 @@ jobs:
         with:
           fetch-depth: 0
       - name: misspell
-        uses: reviewdog/action-misspell@d6429416b12b09b4e2768307d53bef58d172e962 # v1.27.0
+        uses: reviewdog/action-misspell@ba7ac4030fa6812f8c8b2d4e516af8bc99553c32 # v1.28.0


### PR DESCRIPTION
`misspell` fails on every pull request against release-1.19, blocking backports: mergify's automerge conditions for this branch require that check.

The pinned v1.27.0 builds its container from `debian:bullseye-slim`, whose apt repositories have moved to archive, so the image build fails before the action runs. master and release-1.20 already pin v1.28.0.

**Notable decisions**

This targets release-1.19 directly rather than being backported, because master is not affected -- it carries v1.28.0 already. Running pinact over the file also corrected a stale version comment on the codespell pin, whose commit is unchanged.

**AI assistance:** Claude Code diagnosed the failure from the CI logs, verified it reproduces on an unrelated release-1.19 PR, and made the change.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
