### PR TITLE
core: patch finalizers instead of updating the whole CR

### DIFF
--- a/deploy/charts/rook-ceph/templates/clusterrole.yaml
+++ b/deploy/charts/rook-ceph/templates/clusterrole.yaml
@@ -91,6 +91,7 @@ rules:
       - get
       - list
       - watch
+      - patch
   - apiGroups:
       - ""
       - "discovery.k8s.io"
@@ -166,6 +167,7 @@ rules:
       - watch
       # Ideally the update permission is not required, but Rook needs it to add finalizers to resources.
       - update
+      - patch
   # Rook must have update access to status subresources for its custom resources.
   - apiGroups: ["ceph.rook.io"]
     resources:

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -94,6 +94,7 @@ rules:
       - get
       - list
       - watch
+      - patch
   - apiGroups:
       - ""
       - "discovery.k8s.io"
@@ -169,6 +170,7 @@ rules:
       - watch
       # Ideally the update permission is not required, but Rook needs it to add finalizers to resources.
       - update
+      - patch
   # Rook must have update access to status subresources for its custom resources.
   - apiGroups: ["ceph.rook.io"]
     resources:

--- a/deploy/examples/monitoring/rbac.yaml
+++ b/deploy/examples/monitoring/rbac.yaml
@@ -17,6 +17,7 @@ rules:
       - watch
       - create
       - update
+      - patch
       - delete
 # OLM: END ROLE
 ---
@@ -92,6 +93,7 @@ rules:
       - list
       - create
       - update
+      - patch
 # OLM: END ROLE
 ---
 # OLM: BEGIN ROLE BINDING

--- a/pkg/operator/ceph/controller/finalizer.go
+++ b/pkg/operator/ceph/controller/finalizer.go
@@ -43,39 +43,41 @@ func remove(list []string, s string) []string {
 
 // AddFinalizerIfNotPresent adds a finalizer to an object to avoid instant deletion
 // of the object without finalizing it.
-func AddFinalizerIfNotPresent(ctx context.Context, client client.Client, obj client.Object) (bool, error) {
+func AddFinalizerIfNotPresent(ctx context.Context, cl client.Client, obj client.Object) (bool, error) {
 	objectFinalizer := buildFinalizerName(obj.GetObjectKind().GroupVersionKind().Kind)
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to get meta information of object")
 	}
 
-	if !slices.Contains(accessor.GetFinalizers(), objectFinalizer) {
-		log.NamedInfo(NsName(obj.GetNamespace(), obj.GetName()), logger, "adding finalizer %q", objectFinalizer)
-		accessor.SetFinalizers(append(accessor.GetFinalizers(), objectFinalizer))
-		originalGeneration := obj.GetGeneration()
-
-		// Update CR with finalizer
-		if err := client.Update(ctx, obj); err != nil {
-			return false, errors.Wrapf(err, "failed to add finalizer %q on %q", objectFinalizer, accessor.GetName())
-		}
-		newGeneration := obj.GetGeneration()
-		log.NamedDebug(NsName(obj.GetNamespace(), obj.GetName()), logger, "when adding finalizer, original generation %d, new generation %d", originalGeneration, newGeneration)
-		return originalGeneration != newGeneration, nil
+	if slices.Contains(accessor.GetFinalizers(), objectFinalizer) {
+		return false, nil
 	}
 
-	return false, nil
+	log.NamedInfo(NsName(obj.GetNamespace(), obj.GetName()), logger, "adding finalizer %q", objectFinalizer)
+	originalGeneration := obj.GetGeneration()
+
+	// Patch only the metadata.finalizers field rather than updating the whole object.
+	patch := client.MergeFromWithOptions(obj.DeepCopyObject().(client.Object), client.MergeFromWithOptimisticLock{})
+	accessor.SetFinalizers(append(accessor.GetFinalizers(), objectFinalizer))
+	if err := cl.Patch(ctx, obj, patch); err != nil {
+		return false, errors.Wrapf(err, "failed to add finalizer %q on %q", objectFinalizer, accessor.GetName())
+	}
+
+	newGeneration := obj.GetGeneration()
+	log.NamedDebug(NsName(obj.GetNamespace(), obj.GetName()), logger, "when adding finalizer, original generation %d, new generation %d", originalGeneration, newGeneration)
+	return originalGeneration != newGeneration, nil
 }
 
 // RemoveFinalizer removes a finalizer from an object
-func RemoveFinalizer(ctx context.Context, client client.Client, obj client.Object) error {
+func RemoveFinalizer(ctx context.Context, cl client.Client, obj client.Object) error {
 	finalizerName := buildFinalizerName(obj.GetObjectKind().GroupVersionKind().Kind)
-	return RemoveFinalizerWithName(ctx, client, obj, finalizerName)
+	return RemoveFinalizerWithName(ctx, cl, obj, finalizerName)
 }
 
 // RemoveFinalizerWithName removes finalizer passed as an argument from an object
-func RemoveFinalizerWithName(ctx context.Context, client client.Client, obj client.Object, finalizerName string) error {
-	err := client.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj)
+func RemoveFinalizerWithName(ctx context.Context, cl client.Client, obj client.Object, finalizerName string) error {
+	err := cl.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj)
 	if err != nil {
 		return errors.Wrap(err, "failed to get the latest version of the object")
 	}
@@ -84,12 +86,19 @@ func RemoveFinalizerWithName(ctx context.Context, client client.Client, obj clie
 		return errors.Wrap(err, "failed to get meta information of object")
 	}
 
-	if slices.Contains(accessor.GetFinalizers(), finalizerName) {
-		log.NamedInfo(NsName(obj.GetNamespace(), obj.GetName()), logger, "removing finalizer %q", finalizerName)
-		accessor.SetFinalizers(remove(accessor.GetFinalizers(), finalizerName))
-		if err := client.Update(ctx, obj); err != nil {
-			return errors.Wrapf(err, "failed to remove finalizer %q on %q", finalizerName, accessor.GetName())
-		}
+	if !slices.Contains(accessor.GetFinalizers(), finalizerName) {
+		return nil
+	}
+
+	log.NamedInfo(NsName(obj.GetNamespace(), obj.GetName()), logger, "removing finalizer %q", finalizerName)
+
+	// Patch only the metadata.finalizers field so the operator does not take
+	// ownership of, or normalize, any spec fields (see issue #17439 and the note
+	// in AddFinalizerIfNotPresent).
+	patch := client.MergeFromWithOptions(obj.DeepCopyObject().(client.Object), client.MergeFromWithOptimisticLock{})
+	accessor.SetFinalizers(remove(accessor.GetFinalizers(), finalizerName))
+	if err := cl.Patch(ctx, obj, patch); err != nil {
+		return errors.Wrapf(err, "failed to remove finalizer %q on %q", finalizerName, accessor.GetName())
 	}
 
 	return nil

--- a/pkg/operator/ceph/controller/finalizer_test.go
+++ b/pkg/operator/ceph/controller/finalizer_test.go
@@ -49,6 +49,13 @@ func TestAddFinalizerIfNotPresent(t *testing.T) {
 	generationUpdated, err := AddFinalizerIfNotPresent(context.TODO(), cl, fakeObject)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, fakeObject.Finalizers)
+	// Adding the finalizer is a metadata-only patch, so the generation is not
+	// bumped and the reconcile can continue in the same pass.
+	assert.False(t, generationUpdated)
+
+	// Adding again when the finalizer is already present is a no-op.
+	generationUpdated, err = AddFinalizerIfNotPresent(context.TODO(), cl, fakeObject)
+	assert.NoError(t, err)
 	assert.False(t, generationUpdated)
 }
 


### PR DESCRIPTION
## Description of your changes

`AddFinalizerIfNotPresent` and `RemoveFinalizerWithName` updated the **entire** custom resource with `client.Update` just to add or remove a finalizer. A full-object update makes the operator's field manager (`rook`) take server-side-apply ownership of every `.spec` field currently set, and it re-serializes (normalizes) values such as durations (`60s` → `1m0s`) and resource quantities.

As a result, a subsequent `helm upgrade` fails with apply conflicts on an otherwise no-op upgrade, because Helm's server-side apply finds spec fields owned by `rook` holding different literal values:

```
Apply failed with 4 conflicts: conflicts with "rook" using ceph.rook.io/v1:
- .spec.healthCheck.daemonHealth.osd.interval
- .spec.healthCheck.daemonHealth.status.interval
- .spec.resources.mon.requests.cpu
- .spec.resources.osd.requests.cpu
```

### The fix

Switch both helpers to a **metadata-only merge patch** (`client.MergeFrom`), so only the `metadata.finalizers` list is sent. The operator no longer claims or mutates any spec fields, and repeated `helm upgrade` runs are idempotent without `--force-conflicts`. Because this is the shared finalizer helper for all Ceph CRs, it fixes CephCluster, CephFilesystem, and CephObjectStore together.

`AddFinalizerIfNotPresent` now returns `true` when a finalizer was added (previously it returned whether the generation changed, which only happened as a side effect of the spec being normalized by the full update). Callers already use the return value to requeue after adding the finalizer, so their behavior is unchanged.

Note: status updates were already spec-safe — they go through the `/status` subresource (`client.Status().Update`), which the Ceph CRDs enable, so they never claimed spec ownership. The finalizer path was the one place taking spec ownership.

Fixes: #17439

## Checklist:

- [x] Commit Message Formatting: Commit titles and messages follow guidelines in the [developer guide](https://github.com/rook/rook/blob/master/INSTALL.md#development).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Pending release notes updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.