### PR TITLE
ci: fix a stray $ in the multi-cluster suite's BLOCK export

### DIFF
--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -122,7 +122,7 @@ jobs:
         run: |
           tests/scripts/github-action-helper.sh collect_udev_logs_in_background
           DEVICE_NAME="$(tests/scripts/github-action-helper.sh find_extra_block_dev)"
-          export BLOCK="$/dev/${DEVICE_NAME}"
+          export BLOCK="/dev/${DEVICE_NAME}"
           export TEST_SCRATCH_DEVICE="/dev/${DEVICE_NAME}"
           export DEVICE_FILTER="$DEVICE_NAME"
           go test -v -timeout 1800s -run CephMultiClusterDeploySuite github.com/rook/rook/tests/integration


### PR DESCRIPTION
**Motivation**

`TestCephMultiClusterDeploySuite` on the push path sets `BLOCK` to `$/dev/sdb` rather than `/dev/sdb`. The pull request path spells the same export correctly, so the two copies disagreed and a reader cannot tell which is intended.

**What changed**

Dropped the stray `$`.

**Notable decisions**

Nothing reads `BLOCK` in this suite: the test framework takes its device from `TEST_SCRATCH_DEVICE` and `DEVICE_FILTER`, set on the neighbouring lines, and no script runs before `go test`. This is a consistency fix rather than a behavior fix, and the export is arguably dead in both copies — removing it is a separate question.

AI assistance: Claude Code traced `BLOCK` through the test framework and the CI scripts to establish that nothing consumes it here.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).
