### PR TITLE
core: add support for ceph umbrella v21

### DIFF
--- a/.github/workflows/ceph-suite-integration-test.yml
+++ b/.github/workflows/ceph-suite-integration-test.yml
@@ -8,8 +8,8 @@ on:
         required: true
         type: string
       upgrade_suite_tests:
-        description: "JSON list of upgrade suite subtests such as TestUpgradeCephToSquidDevel, TestUpgradeCephToTentacleDevel"
-        default: '["TestUpgradeCephToSquidDevel", "TestUpgradeCephToTentacleDevel"]'
+        description: "JSON list of upgrade suite subtests such as TestUpgradeCephToSquidDevel, TestUpgradeCephToTentacleDevel, TestUpgradeCephToUmbrellaDevel"
+        default: '["TestUpgradeCephToSquidDevel", "TestUpgradeCephToTentacleDevel", "TestUpgradeCephToUmbrellaDevel"]'
         type: string
       object_suite_tests:
         description: "JSON list of object suite subtests such as TestWithoutTLS, TestWithTLS"

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -9,6 +9,7 @@
 
 ## Features
 
+- Ceph Umbrella (v21) is now a supported version of Ceph.
 - RBD QoS (Quality of Service) support via `VolumeAttributesClass` using the krbd mounter with cgroup v2 `io.max` enforcement. See the [RBD QoS documentation](Documentation/Storage-Configuration/Block-Storage-RBD/rbd-qos.md) for details.
 - Automated OSD replacement. OSD deployment can be annotated to mark it for replacement. Rook will drain and destroy it with preserving its CRUSH position to later reuse it when new device will be available on the same node. All types of OSDs supported for host-based cluster included OSDs sharing metadata device. PVC-based OSDs are not supported. See [OSD replacement design document](./design/ceph/osd-replacement.md) for details.
 - The rook-ceph-cluster Helm chart can create `CephObjectStoreUser` resources via the new `cephObjectStoreUsers` value.

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -16,14 +16,14 @@ metadata:
 spec:
   cephVersion:
     # The container image used to launch the Ceph daemon pods (mon, mgr, osd, mds, rgw).
-    # v19 is Squid, v20 is Tentacle
+    # v19 is Squid, v20 is Tentacle, v21 is Umbrella
     # RECOMMENDATION: In production, use a specific version tag instead of the general v20 flag, which pulls the latest release and could result in different
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
     # If you want to be more precise, you can always use a timestamp tag such as quay.io/ceph/ceph:v20.2.4-20260818
     # This tag might not contain a new Ceph version, just security fixes from the underlying operating system, which will reduce vulnerabilities
     image: quay.io/ceph/ceph:v20.2.4
-    # Whether to allow unsupported versions of Ceph. Currently Squid and Tentacle are supported.
-    # Future versions such as Umbrella (v21) would require this to be set to `true`.
+    # Whether to allow unsupported versions of Ceph. Currently Squid, Tentacle, and Umbrella are supported.
+    # Future versions such as Vampire (v22) would require this to be set to `true`.
     # Do not set to true in production.
     allowUnsupported: false
   security:

--- a/pkg/operator/ceph/cluster/version_test.go
+++ b/pkg/operator/ceph/cluster/version_test.go
@@ -193,8 +193,12 @@ func TestSupportedVersion(t *testing.T) {
 	v = &cephver.CephVersion{Major: 20, Minor: 1, Extra: 0}
 	assert.NoError(t, c.validateCephVersion(v))
 
-	// Umbrella release is not supported
+	// Umbrella is supported
 	v = &cephver.CephVersion{Major: 21, Minor: 1, Extra: 0}
+	assert.NoError(t, c.validateCephVersion(v))
+
+	// Vampire release is not supported
+	v = &cephver.CephVersion{Major: 22, Minor: 1, Extra: 0}
 	assert.Error(t, c.validateCephVersion(v))
 
 	// Unsupported versions are now valid

--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -51,7 +51,7 @@ var (
 	Umbrella = CephVersion{21, 0, 0, 0, ""}
 
 	// supportedVersions are production-ready versions that rook supports
-	supportedVersions = []CephVersion{Squid, Tentacle}
+	supportedVersions = []CephVersion{Squid, Tentacle, Umbrella}
 
 	// unsupportedVersions are possibly Ceph pin-point releases that introduced breaking changes and are not recommended
 	unsupportedVersions []CephVersion

--- a/pkg/operator/ceph/version/version_test.go
+++ b/pkg/operator/ceph/version/version_test.go
@@ -101,14 +101,16 @@ func TestSupported(t *testing.T) {
 	for _, v := range supportedVersions {
 		assert.True(t, v.Supported())
 	}
-	assert.False(t, Umbrella.Supported())
+	assert.False(t, (&CephVersion{22, 0, 0, 0, ""}).Supported())
 }
 
 func TestIsRelease(t *testing.T) {
 	assert.True(t, Squid.isRelease(Squid))
 	assert.True(t, Tentacle.isRelease(Tentacle))
+	assert.True(t, Umbrella.isRelease(Umbrella))
 
 	assert.False(t, Squid.isRelease(Tentacle))
+	assert.False(t, Tentacle.isRelease(Umbrella))
 
 	SquidUpdate := Squid
 	SquidUpdate.Minor = 33
@@ -119,7 +121,10 @@ func TestIsRelease(t *testing.T) {
 func TestVersionAtLeast(t *testing.T) {
 	assert.True(t, Squid.IsAtLeast(Squid))
 	assert.True(t, Tentacle.IsAtLeast(Tentacle))
+	assert.True(t, Umbrella.IsAtLeast(Umbrella))
 	assert.True(t, Tentacle.IsAtLeast(Squid))
+	assert.True(t, Umbrella.IsAtLeast(Tentacle))
+	assert.True(t, Umbrella.IsAtLeast(Squid))
 
 	assert.True(t, (&CephVersion{1, 0, 0, 0, ""}).IsAtLeast(CephVersion{0, 0, 0, 0, ""}))
 	assert.False(t, (&CephVersion{0, 0, 0, 0, ""}).IsAtLeast(CephVersion{1, 0, 0, 0, ""}))
@@ -138,8 +143,13 @@ func TestVersionAtLeast(t *testing.T) {
 func TestVersionAtLeastX(t *testing.T) {
 	assert.True(t, Squid.IsAtLeastSquid())
 	assert.False(t, Squid.IsAtLeastTentacle())
+	assert.False(t, Squid.IsAtLeastUmbrella())
 	assert.True(t, Tentacle.IsAtLeastSquid())
 	assert.True(t, Tentacle.IsAtLeastTentacle())
+	assert.False(t, Tentacle.IsAtLeastUmbrella())
+	assert.True(t, Umbrella.IsAtLeastSquid())
+	assert.True(t, Umbrella.IsAtLeastTentacle())
+	assert.True(t, Umbrella.IsAtLeastUmbrella())
 }
 
 func TestIsIdentical(t *testing.T) {

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -72,7 +72,7 @@ var (
 	SquidVersion                 = cephv1.CephVersionSpec{Image: squidTestImage}
 	SquidDevelVersion            = cephv1.CephVersionSpec{Image: squidDevelTestImage}
 	TentacleVersion              = cephv1.CephVersionSpec{Image: tentacleTestImage}
-	UmbrellaVersion              = cephv1.CephVersionSpec{Image: umbrellaTestImage, AllowUnsupported: true}
+	UmbrellaVersion              = cephv1.CephVersionSpec{Image: umbrellaTestImage}
 	TentacleDevelVersion         = cephv1.CephVersionSpec{Image: tentacleDevelTestImage, AllowUnsupported: true}
 	UmbrellaDevelVersion         = cephv1.CephVersionSpec{Image: umbrellaDevelTestImage, AllowUnsupported: true}
 	MainVersion                  = cephv1.CephVersionSpec{Image: mainTestImage, AllowUnsupported: true}

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -179,7 +179,22 @@ func (s *UpgradeSuite) testUpgrade(useHelm bool, initialCephVersion v1.CephVersi
 	// Verify reading and writing to the test clients
 	newFile = "post-tentacle-upgrade-file"
 	s.verifyFilesAfterUpgrade(newFile, rbdFilesToRead, cephfsFilesToRead)
+	rbdFilesToRead = append(rbdFilesToRead, newFile)
+	cephfsFilesToRead = append(cephfsFilesToRead, newFile)
 	logger.Infof("Verified upgrade from squid to tentacle")
+
+	s.checkObjectUser(objectUserID)
+
+	//
+	// Upgrade from tentacle to umbrella
+	//
+	logger.Infof("*** UPGRADING CEPH FROM TENTACLE TO UMBRELLA ***")
+	s.gatherLogs(s.settings.OperatorNamespace, "_before_umbrella_upgrade")
+	s.upgradeCephVersion(installer.UmbrellaVersion.Image, numOSDs)
+	// Verify reading and writing to the test clients
+	newFile = "post-umbrella-upgrade-file"
+	s.verifyFilesAfterUpgrade(newFile, rbdFilesToRead, cephfsFilesToRead)
+	logger.Infof("Verified upgrade from tentacle to umbrella")
 
 	s.checkObjectUser(objectUserID)
 }
@@ -248,6 +263,40 @@ func (s *UpgradeSuite) TestUpgradeCephToTentacleDevel() {
 	newFile := "post-tentacle-upgrade-file"
 	s.verifyFilesAfterUpgrade(newFile, rbdFilesToRead, cephfsFilesToRead)
 	logger.Infof("verified upgrade from tentacle stable to tentacle devel")
+
+	s.checkObjectUser(objectUserID)
+}
+
+func (s *UpgradeSuite) TestUpgradeCephToUmbrellaDevel() {
+	baseRookImage := installer.LocalBuildTag
+	s.baseSetup(false, baseRookImage, installer.UmbrellaVersion)
+
+	objectUserID := "upgraded-user"
+	preFilename := "pre-upgrade-file"
+	s.settings.CephVersion = installer.UmbrellaVersion
+	numOSDs, rbdFilesToRead, cephfsFilesToRead := s.deployClusterforUpgrade(baseRookImage, objectUserID, preFilename)
+	clusterInfo := client.AdminTestClusterInfo(s.namespace)
+	requireBlockImagesRemoved := false
+	defer func() {
+		blockTestDataCleanUp(s.helper, s.k8sh, &s.Suite, clusterInfo, installer.BlockPoolName, installer.BlockPoolSCName, blockName, rbdPodName, requireBlockImagesRemoved)
+		cleanupFilesystemConsumer(s.helper, s.k8sh, &s.Suite, s.namespace, filePodName)
+		cleanupFilesystem(s.helper, s.k8sh, &s.Suite, s.namespace, installer.FilesystemName)
+		_ = s.helper.ObjectUserClient.Delete(s.namespace, objectUserID)
+		_ = s.helper.BucketClient.DeleteObc(obcName, installer.ObjectStoreSCName, bucketPrefix, maxObject, false)
+		_ = s.helper.BucketClient.DeleteBucketStorageClass(s.namespace, installer.ObjectStoreName, installer.ObjectStoreSCName, "Delete")
+		s.cleanUpObjectStore()
+	}()
+
+	//
+	// Upgrade from umbrella to umbrella devel
+	//
+	logger.Infof("*** UPGRADING CEPH FROM UMBRELLA STABLE TO UMBRELLA DEVEL ***")
+	s.gatherLogs(s.settings.OperatorNamespace, "_before_umbrella_upgrade")
+	s.upgradeCephVersion(installer.UmbrellaDevelVersion.Image, numOSDs)
+	// Verify reading and writing to the test clients
+	newFile := "post-umbrella-upgrade-file"
+	s.verifyFilesAfterUpgrade(newFile, rbdFilesToRead, cephfsFilesToRead)
+	logger.Infof("verified upgrade from umbrella stable to umbrella devel")
 
 	s.checkObjectUser(objectUserID)
 }


### PR DESCRIPTION
Adding support for ceph v21 which will be releasing soon, ceph v21 support will be included from Rook v1.21. Also, adding upgrade test to include umbrella test.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #18347


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

