### PR TITLE
object: wait for the osd upgrade before reconciling

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -14,3 +14,4 @@
 - The rook-ceph-cluster Helm chart can create `CephObjectStoreUser` resources via the new `cephObjectStoreUsers` value.
 - The toolbox deployments from the Helm chart and the example manifests now reload the keyring and `ceph.conf` automatically after CephX key rotation, mon failover, or a config override change.
 - CephCluster dashboard TLS certificates can now be configured from a same-namespace Kubernetes TLS Secret with `spec.dashboard.sslCertificateRef` when dashboard SSL is enabled. Rook reconciles updates to the referenced Secret and restores the default self-signed certificate when the reference is removed.
+- Object store reconciles now wait for the OSDs to finish upgrading.

--- a/pkg/operator/ceph/controller/version.go
+++ b/pkg/operator/ceph/controller/version.go
@@ -129,7 +129,7 @@ func CurrentAndDesiredCephVersion(ctx context.Context, rookImage, namespace, job
 }
 
 func ErrorCephUpgradingRequeue(runningCephVersion, desiredCephVersion *cephver.CephVersion) error {
-	return errors.Errorf(`waiting for ceph monitors upgrade to finish. `+
+	return errors.Errorf(`waiting for ceph upgrade to finish. `+
 		`current version: %s. `+
 		`expected version: %s. `+
 		`will reconcile again in %s`,

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -430,7 +430,7 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 		r.clusterInfo.CephVersion = desiredCephVersion
 	} else {
 		// Detect desired CephCluster version
-		runningCephVersion, desiredCephVersion, err := currentAndDesiredCephVersion(
+		desiredCephVersion, runningCephVersion, err := currentAndDesiredCephVersion(
 			r.opManagerContext,
 			r.opConfig.Image,
 			cephObjectStore.Namespace,
@@ -452,11 +452,23 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 		// the cluster is being upgraded. So the controller will just wait for the upgrade to finish and
 		// then versions should match. Obviously using the cmd reporter job adds up to the deployment time
 		// Skip waiting for upgrades to finish in case of external cluster.
-		if !cephCluster.Spec.External.Enable && !reflect.DeepEqual(*runningCephVersion, *desiredCephVersion) {
-			// Upgrade is in progress, let's wait for the mons to be done
-			return opcontroller.WaitForRequeueIfCephClusterIsUpgrading,
-				*cephObjectStore,
-				opcontroller.ErrorCephUpgradingRequeue(desiredCephVersion, runningCephVersion)
+		if !cephCluster.Spec.External.Enable {
+			if !reflect.DeepEqual(*runningCephVersion, *desiredCephVersion) {
+				// Upgrade is in progress, let's wait for the mons to be done
+				return opcontroller.WaitForRequeueIfCephClusterIsUpgrading,
+					*cephObjectStore,
+					opcontroller.ErrorCephUpgradingRequeue(runningCephVersion, desiredCephVersion)
+			}
+			// RGW depends on the OSDs, so wait for them to finish upgrading first
+			osdVersion, err := cephclient.LeastUptodateDaemonVersion(r.context, r.clusterInfo, config.OsdType)
+			if err != nil {
+				return reconcile.Result{}, *cephObjectStore, errors.Wrap(err, "failed to retrieve current ceph osd version")
+			}
+			if osdVersion.Major != 0 && !reflect.DeepEqual(osdVersion, *desiredCephVersion) {
+				return opcontroller.WaitForRequeueIfCephClusterIsUpgrading,
+					*cephObjectStore,
+					opcontroller.ErrorCephUpgradingRequeue(&osdVersion, desiredCephVersion)
+			}
 		}
 		r.clusterInfo.CephVersion = *runningCephVersion
 

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
+	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	testopk8s "github.com/rook/rook/pkg/operator/k8sutil/test"
@@ -552,6 +553,22 @@ func TestCephObjectStoreController(t *testing.T) {
 		assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph.svc:80", objectStore.Status.Info["endpoint"], objectStore)
 		assert.True(t, calledCommitConfigChanges)
 		assert.Equal(t, 19, r.clusterInfo.CephVersion.Major)
+	})
+
+	t.Run("requeue - osds still upgrading", func(t *testing.T) {
+		r := setupEnvironmentWithReadyCephCluster()
+		r.context.Executor = &exectest.MockExecutor{
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+				if args[0] == "versions" {
+					return `{"osd": {"ceph version 18.2.4 (0000000000000000) reef (stable)": 3}}`, nil
+				}
+				return "", nil
+			},
+		}
+
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.Equal(t, opcontroller.WaitForRequeueIfCephClusterIsUpgrading, res)
 	})
 }
 


### PR DESCRIPTION
The object controller only waited for the mons to finish upgrading before reconciling, while the osds could still be on the old version.

Wait for the osds to reach the target version as well.

Fixes: https://github.com/rook/rook/issues/18367

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [X] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [X] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

