### PR TITLE
csi: add a setting to skip creating the csi operator resources

### DIFF
--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -57,6 +57,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `csi.attacher.tag` | Attacher image tag | `"v4.12.0"` |
 | `csi.cephcsi.repository` | Ceph CSI image repository | `"quay.io/cephcsi/cephcsi"` |
 | `csi.cephcsi.tag` | Ceph CSI image tag | `"v3.17.1"` |
+| `csi.createCsiOperatorResources` | When true, Rook creates the CephConnection and ClientProfile CRs consumed by the ceph-csi-operator. Set to false for clusters that use no CSI driver, such as object store only clusters, so the ceph-csi-operator and its CRDs are not required. | `true` |
 | `csi.csiAddons.repository` | CSIAddons sidecar image repository | `"quay.io/csiaddons/k8s-sidecar"` |
 | `csi.csiAddons.tag` | CSIAddons sidecar image tag | `"v0.14.0"` |
 | `csi.installCsiOperator` | When true, install the ceph-csi-operator subchart (see Chart.yaml `condition`). | `true` |

--- a/deploy/charts/rook-ceph/templates/configmap.yaml
+++ b/deploy/charts/rook-ceph/templates/configmap.yaml
@@ -25,6 +25,7 @@ data:
   ROOK_CEPH_MON_RUN_AS_ROOT: {{ .Values.monRunAsRoot | quote }}
   ROOK_DELETE_UNUSED_CRUSH_RULES: {{ .Values.deleteUnusedCrushRules | quote }}
   ROOK_ENABLE_DISCOVERY_DAEMON: {{ .Values.enableDiscoveryDaemon | quote }}
+  ROOK_CREATE_CSI_OPERATOR_RESOURCES: {{ .Values.csi.createCsiOperatorResources | quote }}
   {{- with .Values.discoverDaemonUdev }}
   DISCOVER_DAEMON_UDEV_BLACKLIST: {{ . | quote }}
   {{- end }}

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -94,6 +94,11 @@ csi:
   # -- When true, install the ceph-csi-operator subchart (see Chart.yaml `condition`).
   installCsiOperator: true
 
+  # -- When true, Rook creates the CephConnection and ClientProfile CRs consumed by the
+  # ceph-csi-operator. Set to false for clusters that use no CSI driver, such as object store
+  # only clusters, so the ceph-csi-operator and its CRDs are not required.
+  createCsiOperatorResources: true
+
   cephcsi:
     # -- Ceph CSI image repository
     repository: quay.io/cephcsi/cephcsi

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -171,6 +171,11 @@ data:
   # Whether to create all Rook pods to run on the host network, for example in environments where a CNI is not enabled
   ROOK_ENFORCE_HOST_NETWORK: "false"
 
+  # Whether Rook creates the CephConnection and ClientProfile CRs consumed by the ceph-csi-operator.
+  # Set to "false" for clusters that use no CSI driver, such as object store only clusters, so the
+  # ceph-csi-operator and its CRDs (csi-operator.yaml) are not required.
+  ROOK_CREATE_CSI_OPERATOR_RESOURCES: "true"
+
   # RevisionHistoryLimit value for all deployments created by rook.
   # ROOK_REVISION_HISTORY_LIMIT: "3"
 ---

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -88,6 +88,11 @@ data:
   # Whether to create all Rook pods to run on the host network, for example in environments where a CNI is not enabled
   ROOK_ENFORCE_HOST_NETWORK: "false"
 
+  # Whether Rook creates the CephConnection and ClientProfile CRs consumed by the ceph-csi-operator.
+  # Set to "false" for clusters that use no CSI driver, such as object store only clusters, so the
+  # ceph-csi-operator and its CRDs (csi-operator.yaml) are not required.
+  ROOK_CREATE_CSI_OPERATOR_RESOURCES: "true"
+
   # RevisionHistoryLimit value for all deployments created by rook.
   # ROOK_REVISION_HISTORY_LIMIT: "3"
 

--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -167,14 +167,16 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 		}
 	}
 
-	log.NamespacedInfo(cluster.Namespace, logger, "create cephConnection and defaultClientProfile for external mode")
-	err = csi.CreateUpdateCephConnection(c.context.Client, cluster.ClusterInfo, *cluster.Spec)
-	if err != nil {
-		return errors.Wrap(err, "failed to create/update cephConnection")
-	}
-	err = csi.CreateDefaultClientProfile(c.context.Client, cluster.ClusterInfo)
-	if err != nil {
-		return errors.Wrap(err, "failed to create/update default client profile")
+	if opcontroller.CSIOperatorResourcesEnabled() {
+		log.NamespacedInfo(cluster.Namespace, logger, "create cephConnection and defaultClientProfile for external mode")
+		err = csi.CreateUpdateCephConnection(c.context.Client, cluster.ClusterInfo, *cluster.Spec)
+		if err != nil {
+			return errors.Wrap(err, "failed to create/update cephConnection")
+		}
+		err = csi.CreateDefaultClientProfile(c.context.Client, cluster.ClusterInfo)
+		if err != nil {
+			return errors.Wrap(err, "failed to create/update default client profile")
+		}
 	}
 
 	opcontroller.UpdateCondition(c.OpManagerCtx, c.context, cluster.namespacedName, k8sutil.ObservedGenerationNotAvailable, cephv1.ConditionConnected, v1.ConditionTrue, cephv1.ClusterConnectedReason, "Cluster connected successfully")

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -1254,7 +1254,7 @@ func (c *Cluster) saveMonConfig() error {
 		return errors.Wrap(err, "failed to write connection config for new mons")
 	}
 
-	if len(c.ClusterInfo.AllMonitors()) > 0 {
+	if controller.CSIOperatorResourcesEnabled() && len(c.ClusterInfo.AllMonitors()) > 0 {
 		err := csi.CreateUpdateCephConnection(c.context.Client, c.ClusterInfo, c.spec)
 		if err != nil {
 			return errors.Wrap(err, "failed to create/update cephConnection")

--- a/pkg/operator/ceph/cluster/predicate.go
+++ b/pkg/operator/ceph/cluster/predicate.go
@@ -183,8 +183,8 @@ func predicateForClusterConfigMapWatcher[T *corev1.ConfigMap](ctx context.Contex
 			objOld := (*corev1.ConfigMap)(e.ObjectOld)
 
 			if objNew.Name == opcontroller.OperatorSettingConfigMapName {
-				if objOld.Data["ROOK_USE_CSI_OPERATOR"] != objNew.Data["ROOK_USE_CSI_OPERATOR"] {
-					log.NamespacedInfo(objNew.Namespace, logger, "ROOK_USE_CSI_OPERATOR changed from %q to %q", objOld.Data["ROOK_USE_CSI_OPERATOR"], objNew.Data["ROOK_USE_CSI_OPERATOR"])
+				if objOld.Data["ROOK_CREATE_CSI_OPERATOR_RESOURCES"] != objNew.Data["ROOK_CREATE_CSI_OPERATOR_RESOURCES"] {
+					log.NamespacedInfo(objNew.Namespace, logger, "ROOK_CREATE_CSI_OPERATOR_RESOURCES changed from %q to %q", objOld.Data["ROOK_CREATE_CSI_OPERATOR_RESOURCES"], objNew.Data["ROOK_CREATE_CSI_OPERATOR_RESOURCES"])
 					return true
 				}
 			}

--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -61,6 +61,13 @@ const (
 
 	revisionHistoryLimitSettingName string = "ROOK_REVISION_HISTORY_LIMIT"
 
+	// csiOperatorResourcesSettingName controls whether Rook creates the CephConnection and
+	// ClientProfile CRs consumed by the ceph-csi-operator. Clusters that use no CSI driver,
+	// such as object store only clusters, can disable this and skip installing the
+	// ceph-csi-operator and its CRDs entirely.
+	csiOperatorResourcesSettingName  string = "ROOK_CREATE_CSI_OPERATOR_RESOURCES"
+	csiOperatorResourcesDefaultValue string = "true"
+
 	// UninitializedCephConfigError refers to the error message printed by the Ceph CLI when there is no ceph configuration file
 	// This typically is raised when the operator has not finished initializing
 	UninitializedCephConfigError = "error calling conf_read_file"
@@ -98,6 +105,13 @@ var (
 
 func DiscoveryDaemonEnabled() bool {
 	return k8sutil.GetOperatorSetting("ROOK_ENABLE_DISCOVERY_DAEMON", "false") == "true"
+}
+
+// CSIOperatorResourcesEnabled returns true if Rook should create and update the CephConnection
+// and ClientProfile CRs consumed by the ceph-csi-operator. Clusters that use no CSI driver can
+// disable this so the ceph-csi-operator and its CRDs are not required.
+func CSIOperatorResourcesEnabled() bool {
+	return k8sutil.GetOperatorSetting(csiOperatorResourcesSettingName, csiOperatorResourcesDefaultValue) == "true"
 }
 
 // SetCephCommandsTimeout sets the timeout value of Ceph commands which are executed from Rook


### PR DESCRIPTION
Clusters which provide only object storage do not require the CSI, but Rook creates a CephConnection and a ClientProfile CR for every cluster. This commit adds the ROOK_CREATE_CSI_OPERATOR_RESOURCES setting and defaults it to true. When disabled, Rook skips creating both CRs.

Closes #18329 

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [ ] Documentation has been updated, if necessary (under the `Documentation` folder).
- [ ] Unit tests have been added, if necessary (`_test.go` files under the `cmd` and `pkg` folders).
- [ ] Integration tests have been added, if necessary (in the `tests/integration` folder).

